### PR TITLE
Storage: fix ability to set customized port in HttpStorageRpc

### DIFF
--- a/google-cloud-clients/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
+++ b/google-cloud-clients/google-cloud-storage/src/main/java/com/google/cloud/storage/spi/v1/HttpStorageRpc.java
@@ -718,7 +718,7 @@ public class HttpStorageRpc implements StorageRpc {
       String scheme = url.getScheme();
       String host = url.getHost();
       int port = url.getPort();
-      port = port < 0 ? port : url.toURL().getDefaultPort();
+      port = port > 0 ? port : url.toURL().getDefaultPort();
       String path = "/upload" + url.getRawPath();
       url = new GenericUrl(scheme + "://" + host + ":" + port + path);
       url.set("uploadType", "resumable");


### PR DESCRIPTION
Storage can't set customized port because of this bug.