### PR TITLE
Fix #4269 update hardcoded "metadata" to "metadata.google.internal"

### DIFF
--- a/google-cloud-clients/google-cloud-core/src/main/java/com/google/cloud/MetadataConfig.java
+++ b/google-cloud-clients/google-cloud-core/src/main/java/com/google/cloud/MetadataConfig.java
@@ -33,7 +33,7 @@ import java.net.URL;
  */
 public class MetadataConfig {
 
-  private static final String METADATA_URL = "http://metadata/computeMetadata/v1/";
+  private static final String METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/";
 
   private MetadataConfig() {}
 


### PR DESCRIPTION
Fixes #4269 update hardcoded "metadata" to "metadata.google.internal"