### PR TITLE
Spanner: Unflake InstanceAdminGaxTest

### DIFF
--- a/google-cloud-clients/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
+++ b/google-cloud-clients/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InstanceAdminGaxTest.java
@@ -231,8 +231,8 @@ public class InstanceAdminGaxTest {
             .setInitialRetryDelay(Duration.ofMillis(1L))
             .setMaxRetryDelay(Duration.ofMillis(1L))
             .setInitialRpcTimeout(Duration.ofMillis(20L))
-            .setMaxRpcTimeout(Duration.ofMillis(1000L))
-            .setRetryDelayMultiplier(2.0)
+            .setMaxRpcTimeout(Duration.ofMillis(200L))
+            .setRetryDelayMultiplier(1.3)
             .setMaxAttempts(10)
             .setTotalTimeout(Duration.ofMillis(200L))
             .build();


### PR DESCRIPTION
MaxRpcTimeout should not exceed simulated server time. Fixes #6453.