### PR TITLE
Revert "chore(deps): update ghcr.io/graalvm/graalvm-ce docker tag to v22.3.3"

### DIFF
--- a/.kokoro/nightly/graalvm-native-17.cfg
+++ b/.kokoro/nightly/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/nightly/graalvm-native.cfg
+++ b/.kokoro/nightly/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/nightly/graalvm-sub-jobs/native-17/common.cfg
+++ b/.kokoro/nightly/graalvm-sub-jobs/native-17/common.cfg
@@ -24,7 +24,7 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/nightly/graalvm-sub-jobs/native/common.cfg
+++ b/.kokoro/nightly/graalvm-sub-jobs/native/common.cfg
@@ -29,7 +29,7 @@ env_vars: {
 
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 # TODO: remove this after we've migrated all tests and scripts

--- a/.kokoro/presubmit/graalvm-native-17-presubmit.cfg
+++ b/.kokoro/presubmit/graalvm-native-17-presubmit.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.3"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-presubmit.cfg
+++ b/.kokoro/presubmit/graalvm-native-presubmit.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.3"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 env_vars: {


### PR DESCRIPTION
Reverts googleapis/google-cloud-java#9962. The docker image is not up yet. We'll make this update for all libraries that are part of the Cloud SDK for Java (sdk-platform-java, monorepo and handwritten) once the rollout of the dependencyManagement migration of graal-sdk is complete. 