### PR TITLE
chore: Point the README.md to the official Java Docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,10 +240,6 @@ If the service is not listed, [google-api-java-client][google-api-java-client-se
 
 *When building Java applications, preference should be given to the libraries listed in the table.*
 
-## Troubleshooting
-
-To get help, follow the instructions in the [Troubleshooting document](https://github.com/googleapis/google-cloud-java/blob/main/TROUBLESHOOTING.md).
-
 ## Testing
 
 This library provides tools to help write tests for code that uses google-cloud services.


### PR DESCRIPTION
Remove all sections that have been migrated to the offical docs page

See b/428233851 for more information.