### PR TITLE
chore: clean up outdated CI table in java-accessapproval

### DIFF
--- a/java-accessapproval/README.md
+++ b/java-accessapproval/README.md
@@ -169,15 +169,6 @@ information.
 
 Apache 2.0 - See [LICENSE][license] for more information.
 
-## CI Status
-
-Java Version | Status
------------- | ------
-Java 8 | [![Kokoro CI][kokoro-badge-image-2]][kokoro-badge-link-2]
-Java 8 OSX | [![Kokoro CI][kokoro-badge-image-3]][kokoro-badge-link-3]
-Java 8 Windows | [![Kokoro CI][kokoro-badge-image-4]][kokoro-badge-link-4]
-Java 11 | [![Kokoro CI][kokoro-badge-image-5]][kokoro-badge-link-5]
-
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/access-approval/docs/


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-java/issues/12453
This was likely copied over from the split repos. The java-accessapproval docs also run on a nightly basis.