### PR TITLE
chore: Stop running generated_files_sync on main branch

### DIFF
--- a/.github/workflows/generated_files_sync.yaml
+++ b/.github/workflows/generated_files_sync.yaml
@@ -14,9 +14,6 @@
 # GitHub action job to test core java library features on
 # downstream client libraries before they are released.
 on:
-  push:
-    branches:
-    - main
   pull_request:
 name: generation diff
 env:


### PR DESCRIPTION
Stop running generated_files_sync on main branch. Because it could [fail on main branch](https://github.com/googleapis/google-cloud-java/actions/runs/19371183106/job/55427292336) and it does not need to be run on main branch. 