### PR TITLE
test: skip unit tests for modules that have their own split tests

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -43,8 +43,12 @@ case ${JOB_TYPE} in
       install_modules "${BUILD_SUBDIR}"
       echo "Running in subdir: ${BUILD_SUBDIR}"
       pushd "${BUILD_SUBDIR}"
+      EXTRA_PROFILE_OPT=""
+    else
+      EXTRA_PROFILE_OPT="-PbulkTests"
     fi
     echo "SUREFIRE_JVM_OPT: ${SUREFIRE_JVM_OPT}"
+    echo "EXTRA_PROFILE_OPT: ${EXTRA_PROFILE_OPT}"
     retry_with_backoff 3 10 \
       mvn test \
         -B -ntp \
@@ -56,7 +60,7 @@ case ${JOB_TYPE} in
         -Dflatten.skip=true \
         -Danimal.sniffer.skip=true \
         -Dmaven.wagon.http.retryHandler.count=5 \
-        -T 1C ${SUREFIRE_JVM_OPT}
+        ${SUREFIRE_JVM_OPT} ${EXTRA_PROFILE_OPT}
     RETURN_CODE=$?
 
     if [[ -n "${BUILD_SUBDIR}" ]]

--- a/java-bigquerystorage/pom.xml
+++ b/java-bigquerystorage/pom.xml
@@ -210,6 +210,13 @@
         <module>tutorials</module>
       </modules>
     </profile>
+    <!-- skip tests if bulkTests profile is enabled (when testing the rest of the monorepo) -->
+    <profile>
+      <id>bulkTests</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/java-datastore/pom.xml
+++ b/java-datastore/pom.xml
@@ -232,4 +232,13 @@
     <module>google-cloud-datastore-utils</module>
   </modules>
 
-  </project>
+  <profiles>
+    <!-- skip tests if bulkTests profile is enabled (when testing the rest of the monorepo) -->
+    <profile>
+      <id>bulkTests</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/java-logging/pom.xml
+++ b/java-logging/pom.xml
@@ -93,6 +93,15 @@
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <!-- skip tests if bulkTests profile is enabled (when testing the rest of the monorepo) -->
+    <profile>
+      <id>bulkTests</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
 
   <modules>
     <module>google-cloud-logging</module>


### PR DESCRIPTION
As the new split repos are migrating to the monorepo, we actually want to skip those unit tests when running the unit tests on the entire repo. This is because the unit tests for the migrated repos may be non-trivial and take a lot longer than the rest of the tests.

This is accomplished by adding a new profile called `bulkTests` which we set when running the "full" unit tests suite (no run on the split unit tests). When activated, the modules that migrated into the monorepo have that profile defined that will set the `skipTests` maven property (which skips those tests).