### PR TITLE
fix(gax): Manage span scope in SpanTracer

### DIFF
--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/SpanTracer.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/SpanTracer.java
@@ -37,6 +37,8 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -53,6 +55,7 @@ public class SpanTracer implements ApiTracer {
   private final String attemptSpanName;
   private final ApiTracerContext apiTracerContext;
   private Span attemptSpan;
+  private io.opentelemetry.context.Scope scope;
 
   @Override
   public void injectTraceContext(java.util.Map<String, String> carrier) {
@@ -144,6 +147,7 @@ public class SpanTracer implements ApiTracer {
     spanBuilder.setAllAttributes(ObservabilityUtils.toOtelAttributes(currentAttemptAttributes));
 
     this.attemptSpan = spanBuilder.startSpan();
+    this.scope = attemptSpan.makeCurrent();
   }
 
   @Override
@@ -249,6 +253,7 @@ public class SpanTracer implements ApiTracer {
       return;
     }
 
+    scope.close();
     attemptSpan.end();
     attemptSpan = null;
   }

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/SpanTracerTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/SpanTracerTest.java
@@ -33,9 +33,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ErrorDetails;
@@ -48,6 +46,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +61,7 @@ class SpanTracerTest {
   @Mock private Tracer tracer;
   @Mock private SpanBuilder spanBuilder;
   @Mock private Span span;
+  @Mock private Scope scope;
   private SpanTracer spanTracer;
   private static final String ATTEMPT_SPAN_NAME = "Service/Method/attempt";
 
@@ -71,6 +71,7 @@ class SpanTracerTest {
     when(spanBuilder.setSpanKind(any(SpanKind.class))).thenReturn(spanBuilder);
     when(spanBuilder.setAllAttributes(any(Attributes.class))).thenReturn(spanBuilder);
     when(spanBuilder.startSpan()).thenReturn(span);
+    lenient().when(span.makeCurrent()).thenReturn(scope);
     spanTracer = new SpanTracer(tracer, ApiTracerContext.empty(), ATTEMPT_SPAN_NAME);
   }
 
@@ -624,5 +625,32 @@ class SpanTracerTest {
     assertThat(carrier).containsKey("traceparent");
     assertThat(carrier.get("traceparent")).contains("00000000000000000000000000000001");
     assertThat(carrier.get("traceparent")).contains("0000000000000002");
+  }
+
+  @Test
+  void testAttemptStarted_makesSpanCurrent() {
+    spanTracer.attemptStarted(new Object(), 1);
+    verify(span).makeCurrent();
+  }
+
+  @Test
+  void testAttemptEnded_closesScope_succeeded() {
+    spanTracer.attemptStarted(new Object(), 1);
+    spanTracer.attemptSucceeded();
+    verify(scope).close();
+  }
+
+  @Test
+  void testAttemptEnded_closesScope_failed() {
+    spanTracer.attemptStarted(new Object(), 1);
+    spanTracer.attemptFailedRetriesExhausted(new RuntimeException());
+    verify(scope).close();
+  }
+
+  @Test
+  void testAttemptEnded_closesScope_cancelled() {
+    spanTracer.attemptStarted(new Object(), 1);
+    spanTracer.attemptCancelled();
+    verify(scope).close();
   }
 }


### PR DESCRIPTION
This PR adds a new feature that manages the lifecycle of OpenTelemetry Scope in SpanTracer.

The span is set to current context at the start of a request, and is cleared from current context at the end of a request.