### PR TITLE
fix(auth): Address ClientSideCredentialAccessBoundary RefreshTask race condition

### DIFF
--- a/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -248,7 +248,7 @@ public class ClientSideCredentialAccessBoundaryFactory {
         }
         try {
           // Wait for the refresh task to complete.
-          currentRefreshTask.task.get();
+          currentRefreshTask.get();
         } catch (InterruptedException e) {
           // Restore the interrupted status and throw an exception.
           Thread.currentThread().interrupt();
@@ -495,31 +495,17 @@ public class ClientSideCredentialAccessBoundaryFactory {
       this.task = task;
       this.isNew = isNew;
 
-      // Add listener to update factory's credentials when the task completes.
+      // Single listener to guarantee that finishRefreshTask updates the internal state BEFORE
+      // the outer future completes and unblocks waiters.
       task.addListener(
           () -> {
             try {
               finishRefreshTask(task);
+              RefreshTask.this.set(Futures.getDone(task));
             } catch (ExecutionException e) {
-              Throwable cause = e.getCause();
-              RefreshTask.this.setException(cause);
-            }
-          },
-          MoreExecutors.directExecutor());
-
-      // Add callback to set the result or exception based on the outcome.
-      Futures.addCallback(
-          task,
-          new FutureCallback<IntermediateCredentials>() {
-            @Override
-            public void onSuccess(IntermediateCredentials result) {
-              RefreshTask.this.set(result);
-            }
-
-            @Override
-            public void onFailure(@Nullable Throwable t) {
-              RefreshTask.this.setException(
-                  t != null ? t : new IOException("Refresh failed with null Throwable."));
+              RefreshTask.this.setException(e.getCause());
+            } catch (Exception e) {
+              RefreshTask.this.setException(e);
             }
           },
           MoreExecutors.directExecutor());

--- a/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -503,9 +503,10 @@ public class ClientSideCredentialAccessBoundaryFactory {
               finishRefreshTask(task);
               RefreshTask.this.set(Futures.getDone(task));
             } catch (ExecutionException e) {
-              RefreshTask.this.setException(e.getCause());
-            } catch (Exception e) {
-              RefreshTask.this.setException(e);
+              Throwable cause = e.getCause();
+              RefreshTask.this.setException(cause != null ? cause : e);
+            } catch (Throwable t) {
+              RefreshTask.this.setException(t);
             }
           },
           MoreExecutors.directExecutor());

--- a/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -53,7 +53,6 @@ import com.google.auth.oauth2.StsTokenExchangeResponse;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.AbstractFuture;
-import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
@@ -79,7 +78,6 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.Nullable;
 
 /**
  * A factory for generating downscoped access tokens using a client-side approach.

--- a/google-auth-library-java/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
+++ b/google-auth-library-java/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
@@ -988,4 +988,59 @@ class ClientSideCredentialAccessBoundaryFactoryTest {
 
     assertThrows(GeneralSecurityException.class, () -> factory.generateToken(accessBoundary));
   }
+
+  @Test
+  void generateToken_freshInstance_concurrent_noNpe() throws Exception {
+    for (int run = 0; run < 10; run++) { // Run 10 times in a single test instance to save time
+      GoogleCredentials sourceCredentials =
+          getServiceAccountSourceCredentials(mockTokenServerTransportFactory);
+      ClientSideCredentialAccessBoundaryFactory factory =
+          ClientSideCredentialAccessBoundaryFactory.newBuilder()
+              .setSourceCredential(sourceCredentials)
+              .setHttpTransportFactory(mockStsTransportFactory)
+              .build();
+
+      CredentialAccessBoundary.Builder cabBuilder = CredentialAccessBoundary.newBuilder();
+      CredentialAccessBoundary accessBoundary =
+          cabBuilder
+              .addRule(
+                  CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+                      .setAvailableResource("resource")
+                      .setAvailablePermissions(ImmutableList.of("role"))
+                      .build())
+              .build();
+
+      int numThreads = 5;
+      Thread[] threads = new Thread[numThreads];
+      CountDownLatch latch = new CountDownLatch(numThreads);
+      java.util.concurrent.atomic.AtomicInteger npeCount =
+          new java.util.concurrent.atomic.AtomicInteger();
+
+      for (int i = 0; i < numThreads; i++) {
+        threads[i] =
+            new Thread(
+                () -> {
+                  try {
+                    latch.countDown();
+                    latch.await();
+                    factory.generateToken(accessBoundary);
+                  } catch (NullPointerException e) {
+                    npeCount.incrementAndGet();
+                  } catch (Exception e) {
+                    // Ignore other exceptions for the sake of the race reproduction
+                  }
+                });
+        threads[i].start();
+      }
+
+      for (Thread thread : threads) {
+        thread.join();
+      }
+
+      org.junit.jupiter.api.Assertions.assertEquals(
+          0,
+          npeCount.get(),
+          "Expected zero NullPointerExceptions due to the race condition, but some were thrown.");
+    }
+  }
 }

--- a/google-auth-library-java/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
+++ b/google-auth-library-java/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
@@ -1011,30 +1011,30 @@ class ClientSideCredentialAccessBoundaryFactoryTest {
               .build();
 
       int numThreads = 5;
-      Thread[] threads = new Thread[numThreads];
       CountDownLatch latch = new CountDownLatch(numThreads);
       java.util.concurrent.atomic.AtomicInteger npeCount =
           new java.util.concurrent.atomic.AtomicInteger();
+      java.util.concurrent.ExecutorService executor =
+          java.util.concurrent.Executors.newFixedThreadPool(numThreads);
 
-      for (int i = 0; i < numThreads; i++) {
-        threads[i] =
-            new Thread(
-                () -> {
-                  try {
-                    latch.countDown();
-                    latch.await();
-                    factory.generateToken(accessBoundary);
-                  } catch (NullPointerException e) {
-                    npeCount.incrementAndGet();
-                  } catch (Exception e) {
-                    // Ignore other exceptions for the sake of the race reproduction
-                  }
-                });
-        threads[i].start();
-      }
-
-      for (Thread thread : threads) {
-        thread.join();
+      try {
+        for (int i = 0; i < numThreads; i++) {
+          executor.submit(
+              () -> {
+                try {
+                  latch.countDown();
+                  latch.await();
+                  factory.generateToken(accessBoundary);
+                } catch (NullPointerException e) {
+                  npeCount.incrementAndGet();
+                } catch (Exception e) {
+                  // Ignore other exceptions for the sake of the race reproduction
+                }
+              });
+        }
+      } finally {
+        executor.shutdown();
+        executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
       }
 
       org.junit.jupiter.api.Assertions.assertEquals(


### PR DESCRIPTION
This change addresses a race condition in ClientSideCredentialAccessBoundaryFactory that occurred when multiple concurrent calls were made to generateToken.

The fix involves:
- Waiting on the RefreshTask itself rather than its internal task.
- Using a single listener in RefreshTask to ensure finishRefreshTask completes before the outer future unblocks waiting threads.
- Adding a regression test generateToken_freshInstance_concurrent_noNpe.