### PR TITLE
fix(spanner): don't set sticky AFFINITY_KEY for multiplexed sessions

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -2275,30 +2275,12 @@ public class GapicSpannerRpc implements SpannerRpc {
     Long affinity = options == null ? null : Option.CHANNEL_HINT.getLong(options);
     if (affinity != null) {
       if (this.isGrpcGcpExtensionEnabled) {
-        // Set channel affinity in gRPC-GCP.
-        String affinityKey;
-        if (this.isDynamicChannelPoolEnabled) {
-          // When dynamic channel pooling is enabled, we use the raw affinity value as the key.
-          // This allows grpc-gcp to use round-robin for new keys, enabling new channels
-          // (created during scale-up) to receive requests. The affinity key lifetime setting
-          // ensures the affinity map doesn't grow unbounded.
-          affinityKey = String.valueOf(affinity);
-        } else {
-          // When DCP is disabled, compute bounded channel hint to prevent
-          // gRPC-GCP affinity map from getting unbounded.
-          int boundedChannelHint = affinity.intValue() % this.numChannels;
-          affinityKey = String.valueOf(boundedChannelHint);
-        }
-        context =
-            context.withCallOptions(
-                context.getCallOptions().withOption(GcpManagedChannel.AFFINITY_KEY, affinityKey));
-        // Check if the caller wants to unbind the affinity key after this call completes.
-        Boolean unbind = Option.UNBIND_CHANNEL_HINT.get(options);
-        if (Boolean.TRUE.equals(unbind)) {
-          context =
-              context.withCallOptions(
-                  context.getCallOptions().withOption(GcpManagedChannel.UNBIND_AFFINITY_KEY, true));
-        }
+        // Do not set AFFINITY_KEY under grpc-gcp. Multiplexed sessions get no backend-locality
+        // benefit from sticky per-transaction channel affinity, and setting one causes
+        // GcpManagedChannel.pickLeastBusyChannel to permanently bind keys to channel 0 under a
+        // concurrent warmup burst (it reads activeStreamsCount before any caller's start() has
+        // incremented it). With no key, getChannelRef(null) does a fresh per-call least-busy pick
+        // with no sticky binding and no affinity-map growth.
       } else {
         // Set channel affinity in GAX.
         context = context.withChannelAffinity(affinity.intValue());

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/RetryOnDifferentGrpcChannelMockServerTest.java
@@ -23,30 +23,18 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
-import com.google.api.gax.grpc.GrpcInterceptorProvider;
 import com.google.cloud.NoCredentials;
-import com.google.cloud.grpc.GcpManagedChannel;
 import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.connection.AbstractMockServerTest;
-import com.google.common.collect.ImmutableList;
 import com.google.spanner.v1.BatchCreateSessionsRequest;
 import com.google.spanner.v1.BeginTransactionRequest;
 import com.google.spanner.v1.ExecuteSqlRequest;
-import com.google.spanner.v1.SpannerGrpc;
-import io.grpc.CallOptions;
-import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptor;
 import io.grpc.Context;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannelBuilder;
-import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -62,11 +50,6 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServerTest {
-  /** Tracks the logical affinity keys before grpc-gcp routes the request. */
-  private static final Map<String, Set<String>> LOGICAL_AFFINITY_KEYS = new HashMap<>();
-
-  /** Tracks how many calls explicitly request grpc-gcp affinity unbind. */
-  private static final Map<String, Integer> UNBIND_AFFINITY_CALL_COUNTS = new HashMap<>();
 
   @BeforeClass
   public static void setupAndStartServer() throws Exception {
@@ -82,43 +65,8 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
 
   @After
   public void clearRequests() {
-    LOGICAL_AFFINITY_KEYS.clear();
-    UNBIND_AFFINITY_CALL_COUNTS.clear();
     mockSpanner.clearRequests();
     mockSpanner.removeAllExecutionTimes();
-  }
-
-  /**
-   * Creates a client interceptor that captures the logical affinity key before grpc-gcp routes the
-   * request. This allows us to verify that retry logic uses distinct logical channel hints, even
-   * when DCP maps them to fewer physical channels.
-   */
-  static GrpcInterceptorProvider createAffinityKeyInterceptorProvider() {
-    return () ->
-        ImmutableList.of(
-            new ClientInterceptor() {
-              @Override
-              public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-                  MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-                String methodName = method.getFullMethodName();
-                // Capture the AFFINITY_KEY before grpc-gcp processes it.
-                String affinityKey = callOptions.getOption(GcpManagedChannel.AFFINITY_KEY);
-                if (affinityKey != null) {
-                  synchronized (LOGICAL_AFFINITY_KEYS) {
-                    Set<String> keys =
-                        LOGICAL_AFFINITY_KEYS.computeIfAbsent(methodName, k -> new HashSet<>());
-                    keys.add(affinityKey);
-                  }
-                }
-                if (Boolean.TRUE.equals(
-                    callOptions.getOption(GcpManagedChannel.UNBIND_AFFINITY_KEY))) {
-                  synchronized (UNBIND_AFFINITY_CALL_COUNTS) {
-                    UNBIND_AFFINITY_CALL_COUNTS.merge(methodName, 1, Integer::sum);
-                  }
-                }
-                return next.newCall(method, callOptions);
-              }
-            });
   }
 
   SpannerOptions.Builder createSpannerOptionsBuilder() {
@@ -126,8 +74,7 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
         .setProjectId("my-project")
         .setHost(String.format("http://localhost:%d", getPort()))
         .setChannelConfigurator(ManagedChannelBuilder::usePlaintext)
-        .setCredentials(NoCredentials.getInstance())
-        .setInterceptorProvider(createAffinityKeyInterceptorProvider());
+        .setCredentials(NoCredentials.getInstance());
   }
 
   @Test
@@ -163,12 +110,6 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
     List<BeginTransactionRequest> requests =
         mockSpanner.getRequestsOfType(BeginTransactionRequest.class);
     assertNotEquals(requests.get(0).getSession(), requests.get(1).getSession());
-    // Verify that the retry used 2 distinct logical affinity keys (before grpc-gcp routing).
-    assertEquals(
-        2,
-        LOGICAL_AFFINITY_KEYS
-            .getOrDefault("google.spanner.v1.Spanner/BeginTransaction", new HashSet<>())
-            .size());
   }
 
   @Test
@@ -208,13 +149,6 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
       Set<String> sessions =
           requests.stream().map(BeginTransactionRequest::getSession).collect(Collectors.toSet());
       assertEquals(numChannels, sessions.size());
-      // Verify that the retry logic used distinct logical affinity keys (before grpc-gcp routing).
-      // This confirms each retry attempt targeted a different logical channel.
-      assertEquals(
-          numChannels,
-          LOGICAL_AFFINITY_KEYS
-              .getOrDefault("google.spanner.v1.Spanner/BeginTransaction", new HashSet<>())
-              .size());
     }
   }
 
@@ -284,13 +218,6 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
       // of the first transaction. That fails, the session is deny-listed, the transaction is
       // retried on yet another session and succeeds.
       assertEquals(numChannels + 1, sessions.size());
-      // Verify that the retry logic used distinct logical affinity keys (before grpc-gcp routing).
-      // This confirms each retry attempt targeted a different logical channel.
-      assertEquals(
-          numChannels,
-          LOGICAL_AFFINITY_KEYS
-              .getOrDefault("google.spanner.v1.Spanner/BeginTransaction", new HashSet<>())
-              .size());
       assertEquals(numChannels, mockSpanner.countRequestsOfType(BatchCreateSessionsRequest.class));
     }
   }
@@ -316,17 +243,6 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
     List<ExecuteSqlRequest> requests = mockSpanner.getRequestsOfType(ExecuteSqlRequest.class);
     // The requests use the same multiplexed session.
     assertEquals(requests.get(0).getSession(), requests.get(1).getSession());
-    // Verify that the retry used 2 distinct logical affinity keys (before grpc-gcp routing).
-    assertEquals(
-        2,
-        LOGICAL_AFFINITY_KEYS
-            .getOrDefault("google.spanner.v1.Spanner/ExecuteStreamingSql", new HashSet<>())
-            .size());
-    assertEquals(
-        2,
-        UNBIND_AFFINITY_CALL_COUNTS
-            .getOrDefault(SpannerGrpc.getExecuteStreamingSqlMethod().getFullMethodName(), 0)
-            .intValue());
   }
 
   @Test
@@ -354,17 +270,6 @@ public class RetryOnDifferentGrpcChannelMockServerTest extends AbstractMockServe
       // Verify that the retry mechanism is working (made numChannels requests).
       int totalRequests = mockSpanner.countRequestsOfType(ExecuteSqlRequest.class);
       assertEquals(numChannels, totalRequests);
-      // Verify each attempt used a distinct logical affinity key (before grpc-gcp routing).
-      int distinctLogicalKeys =
-          LOGICAL_AFFINITY_KEYS
-              .getOrDefault("google.spanner.v1.Spanner/ExecuteStreamingSql", new HashSet<>())
-              .size();
-      assertEquals(totalRequests, distinctLogicalKeys);
-      assertEquals(
-          totalRequests,
-          UNBIND_AFFINITY_CALL_COUNTS
-              .getOrDefault(SpannerGrpc.getExecuteStreamingSqlMethod().getFullMethodName(), 0)
-              .intValue());
     }
   }
 


### PR DESCRIPTION
### Problem

Since 6.105.0 (#4239 enabled grpc-gcp by default), a `Spanner` client whose first traffic is a high-concurrency burst sees throughput collapse and p50 latency climb. `disableGrpcGcpExtension()` restores the expected scaling.

| concurrency | static `numChannels=32` qps / p50 / p99 | dynamic channel pool qps / p50 / p99 | grpc-gcp OFF qps / p50 / p99 |
|---|---|---|---|
| 50 | 723 / 67.6 / 84.9 | — | 723 / 67.5 / 78.9 |
| 100 | 1198 / 82.1 / 137.8 | — | 1261 / 68.1 / 309.5 |
| 200 | 1491 / 142.9 / 178.5 | — | 2841 / 67.5 / 109.7 |
| **400** | **973 / 402.2 / 538.8** | **5384 / 66 / 341** | **5862 / 64.8 / 80.1** |

(single multiplexed-session client, `SELECT 1`; each cell is a fresh client whose first traffic is at the target concurrency. Dynamic-pool row from a separate probe with `enableDynamicChannelPool()` set on the builder.)

### Root cause

`newCallContext` sets `GcpManagedChannel.AFFINITY_KEY` on every data RPC under grpc-gcp. `GcpManagedChannel.getChannelRef(key)` binds each new key via `pickLeastBusyChannel()` ([1754-1790](https://github.com/GoogleCloudPlatform/grpc-gcp-java/blob/167b569/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java#L1754-L1790)), which reads `activeStreamsCount` and ties to `channelRefs.get(0)`. The count isn't incremented until later in `GcpClientCall.start()` ([:284](https://github.com/GoogleCloudPlatform/grpc-gcp-java/blob/167b569/grpc-gcp/src/main/java/com/google/cloud/grpc/GcpClientCall.java#L284)), so a concurrent first burst all binds to channel 0 and the bindings are sticky. Subsequent RPCs funnel through one HTTP/2 connection and queue at `MAX_CONCURRENT_STREAMS`.

The static-`numChannels` path used `affinity.intValue() % numChannels` (≈63 distinct keys), so the collapse is permanent. The dynamic-pool path mostly self-corrects (p50 matches OFF) because most hints are per-transaction random longs — but `MultiplexedSessionDatabaseClient.getSingleUseChannelHint` allocates the first `numChannels` concurrent hints from a recycled `BitSet` (values `0..N-1`), and those few sticky-bind during the warmup race and keep getting reused, leaving a p99 tail. (Separately: in our testing, setting `enableDynamicChannelPool=true` via JDBC/connection properties did not fully propagate to `GcpManagedChannel`, so DCP is not currently a workaround for connection-API users.)

### Fix

Don't set `AFFINITY_KEY` when grpc-gcp is on. Multiplexed sessions are a single session, so sticky per-transaction channel affinity provides no backend-locality benefit. With no key, `getChannelRef(null)` does a fresh per-call least-busy pick with no sticky binding and no affinity-map growth — matches the OFF curve. (`Math.floorMod` alone doesn't help; the race still ties bounded keys to channel 0.)

`RetryOnDifferentGrpcChannelMockServerTest` previously asserted distinct `AFFINITY_KEY` values via an interceptor; with no key set those assertions are unobservable, so they're removed (the request-count and session assertions still cover the retry loop). Note this means the opt-in `spanner.retry_deadline_exceeded_on_different_channel` feature now relies on grpc-gcp's per-call least-busy pick rather than a forced distinct channel under grpc-gcp (the wedged channel will normally have a higher active-stream count, so least-busy usually picks a different one, but it's no longer guaranteed); the GAX `withChannelAffinity` path (used when grpc-gcp is off) is unchanged.

### Repro

The trigger is the client's *first* traffic burst being high-concurrency (e.g., a connection pool warming many connections at once); a gentle low-C warmup spreads the keys and masks the bug. Standalone single-file reproducer (only dep `google-cloud-spanner`):

<details><summary>SpannerAffinityRepro.java</summary>

```java
// Repro: grpc-gcp channel affinity collapses onto a few channels under
// concurrent warmup with multiplexed sessions, capping per-client throughput.
//
// For each (grpcGcp, concurrency) pair, builds a FRESH Spanner client,
// fires a high-concurrency warmup burst (this is when the race binds keys),
// then measures qps/p50/p99 of SELECT 1 at that concurrency. Expect parity
// at C<=100 and a large divergence (lower qps, higher p50) for grpc-gcp=ON
// at C>=200.
//
// javac -cp 'lib/*' SpannerAffinityRepro.java
// java  -cp '.:lib/*' SpannerAffinityRepro PROJECT INSTANCE DATABASE
import com.google.cloud.spanner.*;
import java.util.*;
import java.util.concurrent.*;
import java.util.concurrent.atomic.AtomicInteger;

public class SpannerAffinityRepro {
  static final int NUM_CHANNELS = 32;
  static final int[] SWEEP = {50, 100, 200, 400};

  record Row(double qps, double p50, double p99) {}

  static Row one(String proj, String inst, String dbId, boolean gcp, int c) throws Exception {
    SpannerOptions.Builder b = SpannerOptions.newBuilder()
        .setProjectId(proj).setNumChannels(NUM_CHANNELS);
    if (!gcp) b.disableGrpcGcpExtension();
    try (Spanner s = b.build().getService()) {
      DatabaseClient db = s.getDatabaseClient(DatabaseId.of(proj, inst, dbId));
      Statement stmt = Statement.of("SELECT 1");
      Runnable q = () -> { try (ResultSet rs = db.singleUse().executeQuery(stmt)) { while (rs.next()) {} } };
      ExecutorService ex = Executors.newVirtualThreadPerTaskExecutor();
      // Warmup AT the target concurrency: this is the burst during which the
      // ~63 affinity keys race through pickLeastBusyChannel and bind.
      runAt(ex, q, c, Math.max(500, c * 4), null);
      int iters = Math.max(2000, c * 30);
      long[] lats = new long[iters];
      long elapsed = runAt(ex, q, c, iters, lats);
      ex.shutdown();
      Arrays.sort(lats);
      double ms = 1e-6;
      return new Row(iters / (elapsed * 1e-9), lats[iters / 2] * ms, lats[(int) (iters * 0.99)] * ms);
    }
  }

  static long runAt(ExecutorService ex, Runnable q, int c, int iters, long[] lats) throws Exception {
    AtomicInteger left = new AtomicInteger(iters), idx = new AtomicInteger();
    CountDownLatch done = new CountDownLatch(c);
    long t0 = System.nanoTime();
    for (int i = 0; i < c; i++) ex.submit(() -> {
      while (true) {
        int s = left.decrementAndGet(); if (s < 0) break;
        long t = System.nanoTime(); q.run();
        if (lats != null) lats[idx.getAndIncrement()] = System.nanoTime() - t;
      }
      done.countDown();
    });
    done.await();
    return System.nanoTime() - t0;
  }

  public static void main(String[] a) throws Exception {
    if (a.length < 3) { System.err.println("usage: PROJECT INSTANCE DATABASE"); System.exit(1); }
    System.out.printf("numChannels=%d, multiplexed sessions (default), fresh client per cell%n", NUM_CHANNELS);
    System.out.printf("%5s | %22s | %22s%n", "", "grpc-gcp ON (default)", "grpc-gcp OFF");
    System.out.printf("%5s | %6s %6s %6s | %6s %6s %6s%n", "C", "qps", "p50ms", "p99ms", "qps", "p50ms", "p99ms");
    for (int c : SWEEP) {
      Row on = one(a[0], a[1], a[2], true, c);
      Row off = one(a[0], a[1], a[2], false, c);
      System.out.printf("%5d | %6.0f %6.1f %6.1f | %6.0f %6.1f %6.1f%n",
          c, on.qps, on.p50, on.p99, off.qps, off.p50, off.p99);
    }
  }
}
```

</details>