### PR TITLE
chore: untangling auth library parent and imported BOM

### DIFF
--- a/google-auth-library-java/bom/java.header
+++ b/google-auth-library-java/bom/java.header
@@ -1,0 +1,30 @@
+^/\*$
+^ \* Copyright \d\d\d\d, Google (Inc\. All rights reserved\.|LLC)$
+^ \*$
+^ \* Redistribution and use in source and binary forms, with or without$
+^ \* modification, are permitted provided that the following conditions are$
+^ \* met:$
+^ \*$
+^ \*    \* Redistributions of source code must retain the above copyright$
+^ \* notice, this list of conditions and the following disclaimer\.$
+^ \*    \* Redistributions in binary form must reproduce the above$
+^ \* copyright notice, this list of conditions and the following disclaimer$
+^ \* in the documentation and/or other materials provided with the$
+^ \* distribution\.$
+^ \*$
+^ \*    \* Neither the name of Google (Inc\.|LLC) nor the names of its$
+^ \* contributors may be used to endorse or promote products derived from$
+^ \* this software without specific prior written permission\.$
+^ \*$
+^ \* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS$
+^ \* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT$
+^ \* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR$
+^ \* A PARTICULAR PURPOSE ARE DISCLAIMED\. IN NO EVENT SHALL THE COPYRIGHT$
+^ \* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,$
+^ \* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES \(INCLUDING, BUT NOT$
+^ \* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,$
+^ \* DATA, OR PROFITS; OR BUSINESS INTERRUPTION\) HOWEVER CAUSED AND ON ANY$
+^ \* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT$
+^ \* \(INCLUDING NEGLIGENCE OR OTHERWISE\) ARISING IN ANY WAY OUT OF THE USE$
+^ \* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE\.$
+^ \*/$

--- a/google-auth-library-java/bom/license-checks.xml
+++ b/google-auth-library-java/bom/license-checks.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="RegexpHeader">
+        <property name="fileExtensions" value="java"/>
+        <property name="headerFile" value="${checkstyle.header.file}"/>
+    </module>
+</module>

--- a/google-auth-library-java/bom/pom.xml
+++ b/google-auth-library-java/bom/pom.xml
@@ -8,9 +8,9 @@
 
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-pom-parent</artifactId>
-    <version>1.83.0</version><!-- {x-version-update:google-cloud-java:current} -->
-    <relativePath>../../google-cloud-pom-parent/pom.xml</relativePath>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <!-- Do not depend on the version in this monorepo. It causes the publication order problem. --> 
+    <version>1.17.0</version>
   </parent>
 
   <name>Google Auth Library for Java BOM</name>

--- a/google-auth-library-java/java.header
+++ b/google-auth-library-java/java.header
@@ -1,0 +1,30 @@
+^/\*$
+^ \* Copyright \d\d\d\d, Google (Inc\. All rights reserved\.|LLC)$
+^ \*$
+^ \* Redistribution and use in source and binary forms, with or without$
+^ \* modification, are permitted provided that the following conditions are$
+^ \* met:$
+^ \*$
+^ \*    \* Redistributions of source code must retain the above copyright$
+^ \* notice, this list of conditions and the following disclaimer\.$
+^ \*    \* Redistributions in binary form must reproduce the above$
+^ \* copyright notice, this list of conditions and the following disclaimer$
+^ \* in the documentation and/or other materials provided with the$
+^ \* distribution\.$
+^ \*$
+^ \*    \* Neither the name of Google (Inc\.|LLC) nor the names of its$
+^ \* contributors may be used to endorse or promote products derived from$
+^ \* this software without specific prior written permission\.$
+^ \*$
+^ \* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS$
+^ \* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT$
+^ \* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR$
+^ \* A PARTICULAR PURPOSE ARE DISCLAIMED\. IN NO EVENT SHALL THE COPYRIGHT$
+^ \* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,$
+^ \* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES \(INCLUDING, BUT NOT$
+^ \* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,$
+^ \* DATA, OR PROFITS; OR BUSINESS INTERRUPTION\) HOWEVER CAUSED AND ON ANY$
+^ \* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT$
+^ \* \(INCLUDING NEGLIGENCE OR OTHERWISE\) ARISING IN ANY WAY OUT OF THE USE$
+^ \* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE\.$
+^ \*/$

--- a/google-auth-library-java/license-checks.xml
+++ b/google-auth-library-java/license-checks.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="RegexpHeader">
+        <property name="fileExtensions" value="java"/>
+        <property name="headerFile" value="${checkstyle.header.file}"/>
+    </module>
+</module>

--- a/google-auth-library-java/oauth2_http/pom.xml
+++ b/google-auth-library-java/oauth2_http/pom.xml
@@ -238,6 +238,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
@@ -256,10 +260,6 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-gson</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/google-auth-library-java/pom.xml
+++ b/google-auth-library-java/pom.xml
@@ -14,12 +14,10 @@
   <url>https://github.com/googleapis/google-cloud-java</url>
 
   <parent>
-    <!-- Because we cannot release com.google.auth and com.google.cloud together,
-      we skip the deployment of this module <maven.deploy.skip>true</maven.deploy.skip> -->
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-jar-parent</artifactId>
-    <version>1.83.0</version><!-- {x-version-update:google-cloud-java:current} -->
-    <relativePath>../google-cloud-jar-parent/pom.xml</relativePath>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <!-- Do not depend on the version in this monorepo. It causes the publication order problem. --> 
+    <version>1.17.0</version>
   </parent>
 
   <distributionManagement>
@@ -82,19 +80,73 @@
     <project.appengine.version>2.0.33</project.appengine.version>
     <project.findbugs.version>3.0.2</project.findbugs.version>
     <deploy.autorelease>false</deploy.autorelease>
-    <project.error-prone.version>2.38.0</project.error-prone.version>
+    <project.error-prone.version>2.42.0</project.error-prone.version>
     <project.protobuf.version>4.33.2</project.protobuf.version>
     <project.cel.version>0.9.0-proto3</project.cel.version>
     <project.tink.version>1.15.0</project.tink.version>
     <project.slf4j.version>2.0.17</project.slf4j.version>
     <project.gson.version>2.12.1</project.gson.version>
     <project.api-common.version>2.53.0</project.api-common.version>
+    <surefire.version>3.5.2</surefire.version>
     <clirr.skip>true</clirr.skip>
-    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <dependencyManagement>
+    <!-- Do not import BOMs in this monorepo. Maven Central publication
+      does not allow uploads of multiple artifacts with different group IDs. -->
     <dependencies>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-bom</artifactId>
+        <version>${project.google.http.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-bom</artifactId>
+        <version>${project.guava.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${project.protobuf.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${project.junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-credentials</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <classifier>testlib</classifier>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>4.11.0</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
@@ -107,11 +159,29 @@
         <version>${project.appengine.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${project.junit.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
+        <groupId>com.google.api</groupId>
+        <artifactId>api-common</artifactId>
+        <version>${project.api-common.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.cel</groupId>
+        <artifactId>cel</artifactId>
+        <version>${project.cel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.crypto.tink</groupId>
+        <artifactId>tink</artifactId>
+        <version>${project.tink.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>${project.findbugs.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${project.error-prone.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/sdk-platform-java/gapic-generator-java-bom/pom.xml
+++ b/sdk-platform-java/gapic-generator-java-bom/pom.xml
@@ -24,10 +24,23 @@
       <!-- Major external dependencies -->
       <dependency>
         <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-bom</artifactId>
-        <version>1.43.0</version><!-- {x-version-update:google-auth-library:current} -->
-        <type>pom</type>
-        <scope>import</scope>
+        <artifactId>google-auth-library-credentials</artifactId>
+        <version>1.44.0</version><!-- {x-version-update:google-auth-library:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>1.44.0</version><!-- {x-version-update:google-auth-library:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-appengine</artifactId>
+        <version>1.44.0</version><!-- {x-version-update:google-auth-library:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-cab-token-generator</artifactId>
+        <version>1.44.0</version><!-- {x-version-update:google-auth-library:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.auth</groupId>


### PR DESCRIPTION
Maven Central does not allow uploading a set of artifacts having different group IDs.

- The shared dependencies BOM (which uses gapic-generator-java-bom) should not import the auth BOM.
- The google-auth-library-java/pom.xml should not use POM file of `com.google.cloud`.
