### PR TITLE
fix(gax): reduce visibility of ApiTracerContext methods

### DIFF
--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracerContext.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracerContext.java
@@ -79,7 +79,7 @@ public abstract class ApiTracerContext {
    * @return the server port, or {@code null} if not set
    */
   @Nullable
-  public abstract Integer serverPort();
+  abstract Integer serverPort();
 
   /**
    * Returns the library metadata associated with the RPC.
@@ -135,7 +135,7 @@ public abstract class ApiTracerContext {
    * @return the operation type, or {@code null} if not set
    */
   @Nullable
-  public abstract OperationType operationType();
+  abstract OperationType operationType();
 
   /**
    * Returns the HTTP method used for the RPC, in case the RPC is an HttpJson method.
@@ -159,11 +159,11 @@ public abstract class ApiTracerContext {
 
   /** The service name of a client (e.g. "bigtable", "spanner"). */
   @Nullable
-  public abstract String serviceName();
+  abstract String serviceName();
 
   /** The url domain of the request (e.g. "pubsub.googleapis.com"). */
   @Nullable
-  public abstract String urlDomain();
+  abstract String urlDomain();
 
   @Nullable
   protected abstract Supplier<String> destinationResourceIdSupplier();
@@ -173,7 +173,7 @@ public abstract class ApiTracerContext {
    * //pubsub.googleapis.com/projects/p/locations/l/topics/t).
    */
   @Nullable
-  public String destinationResourceId() {
+  String destinationResourceId() {
     Supplier<String> supplier = destinationResourceIdSupplier();
     if (supplier == null) {
       return null;
@@ -209,7 +209,7 @@ public abstract class ApiTracerContext {
   /**
    * @return a map of attributes to be included in attempt-level spans
    */
-  public Map<String, Object> getAttemptAttributes() {
+  Map<String, Object> getAttemptAttributes() {
     Map<String, Object> attributes = new HashMap<>();
     if (!Strings.isNullOrEmpty(serverAddress())) {
       attributes.put(ObservabilityAttributes.SERVER_ADDRESS_ATTRIBUTE, serverAddress());
@@ -322,7 +322,7 @@ public abstract class ApiTracerContext {
     return builder.build();
   }
 
-  public static ApiTracerContext empty() {
+  static ApiTracerContext empty() {
     return newBuilder().setLibraryMetadata(LibraryMetadata.empty()).build();
   }
 
@@ -330,7 +330,7 @@ public abstract class ApiTracerContext {
     return new AutoValue_ApiTracerContext.Builder();
   }
 
-  public abstract Builder toBuilder();
+  abstract Builder toBuilder();
 
   @AutoValue.Builder
   public abstract static class Builder {

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracerContext.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/ApiTracerContext.java
@@ -342,7 +342,7 @@ public abstract class ApiTracerContext {
 
     public abstract Builder setTransport(@Nullable Transport transport);
 
-    public abstract Builder setOperationType(@Nullable OperationType operationType);
+    abstract Builder setOperationType(@Nullable OperationType operationType);
 
     public abstract Builder setServerPort(@Nullable Integer serverPort);
 
@@ -354,7 +354,7 @@ public abstract class ApiTracerContext {
 
     public abstract Builder setUrlDomain(@Nullable String urlDomain);
 
-    public abstract Builder setDestinationResourceIdSupplier(
+    abstract Builder setDestinationResourceIdSupplier(
         @Nullable Supplier<String> destinationResourceIdSupplier);
 
     public abstract ApiTracerContext build();

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactory.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactory.java
@@ -51,7 +51,10 @@ public class OpenTelemetryMetricsFactory implements ApiTracerFactory {
     this.clientLevelTracerContext = ApiTracerContext.empty();
   }
 
-  private OpenTelemetryMetricsFactory(ApiTracerContext clientLevelTracerContext, OpenTelemetry openTelemetry, GoldenSignalsMetricsRecorder metricsRecorder) {
+  private OpenTelemetryMetricsFactory(
+      ApiTracerContext clientLevelTracerContext,
+      OpenTelemetry openTelemetry,
+      GoldenSignalsMetricsRecorder metricsRecorder) {
     this.clientLevelTracerContext = clientLevelTracerContext;
     this.openTelemetry = openTelemetry;
     this.metricsRecorder = metricsRecorder;
@@ -89,11 +92,11 @@ public class OpenTelemetryMetricsFactory implements ApiTracerFactory {
     if (context == null) {
       return new BaseApiTracerFactory();
     }
-    metricsRecorder =
-        GoldenSignalsMetricsRecorder.create(openTelemetry, context.libraryMetadata());
+    metricsRecorder = GoldenSignalsMetricsRecorder.create(openTelemetry, context.libraryMetadata());
     if (metricsRecorder == null) {
       return new BaseApiTracerFactory();
     }
-    return new OpenTelemetryMetricsFactory(clientLevelTracerContext.merge(context), openTelemetry, metricsRecorder);
+    return new OpenTelemetryMetricsFactory(
+        clientLevelTracerContext.merge(context), openTelemetry, metricsRecorder);
   }
 }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactory.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactory.java
@@ -42,7 +42,7 @@ import io.opentelemetry.api.OpenTelemetry;
 @InternalApi
 public class OpenTelemetryMetricsFactory implements ApiTracerFactory {
 
-  private ApiTracerContext clientLevelTracerContext;
+  private final ApiTracerContext clientLevelTracerContext;
   private final OpenTelemetry openTelemetry;
   private GoldenSignalsMetricsRecorder metricsRecorder;
 

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactory.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactory.java
@@ -51,6 +51,12 @@ public class OpenTelemetryMetricsFactory implements ApiTracerFactory {
     this.clientLevelTracerContext = ApiTracerContext.empty();
   }
 
+  private OpenTelemetryMetricsFactory(ApiTracerContext clientLevelTracerContext, OpenTelemetry openTelemetry, GoldenSignalsMetricsRecorder metricsRecorder) {
+    this.clientLevelTracerContext = clientLevelTracerContext;
+    this.openTelemetry = openTelemetry;
+    this.metricsRecorder = metricsRecorder;
+  }
+
   @Override
   public ApiTracer newTracer(ApiTracer parent, SpanName spanName, OperationType operationType) {
     if (metricsRecorder == null) {
@@ -83,12 +89,11 @@ public class OpenTelemetryMetricsFactory implements ApiTracerFactory {
     if (context == null) {
       return new BaseApiTracerFactory();
     }
-    this.metricsRecorder =
+    metricsRecorder =
         GoldenSignalsMetricsRecorder.create(openTelemetry, context.libraryMetadata());
-    if (this.metricsRecorder == null) {
+    if (metricsRecorder == null) {
       return new BaseApiTracerFactory();
     }
-    this.clientLevelTracerContext = context;
-    return this;
+    return new OpenTelemetryMetricsFactory(clientLevelTracerContext.merge(context), openTelemetry, metricsRecorder);
   }
 }

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactoryTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactoryTest.java
@@ -30,7 +30,6 @@
 package com.google.api.gax.tracing;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.*;
 
 import com.google.api.gax.rpc.LibraryMetadata;
@@ -75,9 +74,10 @@ class OpenTelemetryMetricsFactoryTest {
         ApiTracerContext.newBuilder().setLibraryMetadata(metadata).build();
     ApiTracerContext methodLevelTracerContext =
         ApiTracerContext.newBuilder().setLibraryMetadata(LibraryMetadata.empty()).build();
-    
+
     ApiTracerFactory factoryWithContext = tracerFactory.withContext(clientLevelTracerContext);
-    ApiTracer actual = factoryWithContext.newTracer(mock(ApiTracer.class), methodLevelTracerContext);
+    ApiTracer actual =
+        factoryWithContext.newTracer(mock(ApiTracer.class), methodLevelTracerContext);
 
     assertThat(actual).isInstanceOf(OpenTelemetryMetricsTracer.class);
   }

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactoryTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactoryTest.java
@@ -56,6 +56,7 @@ class OpenTelemetryMetricsFactoryTest {
         factoryWithContext.newTracer(
             mock(ApiTracer.class), mock(SpanName.class), ApiTracerFactory.OperationType.Unary);
     assertThat(actual).isInstanceOf(OpenTelemetryMetricsTracer.class);
+    assertThat(factoryWithContext).isNotEqualTo(tracerFactory);
   }
 
   @Test

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactoryTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/tracing/OpenTelemetryMetricsFactoryTest.java
@@ -52,9 +52,9 @@ class OpenTelemetryMetricsFactoryTest {
     LibraryMetadata metadata =
         LibraryMetadata.newBuilder().setArtifactName("gax-java").setVersion("1.0").build();
     ApiTracerContext context = ApiTracerContext.newBuilder().setLibraryMetadata(metadata).build();
-    tracerFactory.withContext(context);
+    ApiTracerFactory factoryWithContext = tracerFactory.withContext(context);
     ApiTracer actual =
-        tracerFactory.newTracer(
+        factoryWithContext.newTracer(
             mock(ApiTracer.class), mock(SpanName.class), ApiTracerFactory.OperationType.Unary);
     assertThat(actual).isInstanceOf(OpenTelemetryMetricsTracer.class);
   }
@@ -69,17 +69,16 @@ class OpenTelemetryMetricsFactoryTest {
 
   @Test
   void newTracerWithApiTracerContext_shouldMergeApiTracerContext() {
-    ApiTracerContext clientLevelTracerContext = mock(ApiTracerContext.class, RETURNS_DEEP_STUBS);
-    ApiTracerContext methodLevelTracerContext = mock(ApiTracerContext.class);
-    when(clientLevelTracerContext.libraryMetadata().artifactName()).thenReturn("gax-java");
-    when(clientLevelTracerContext.libraryMetadata().isEmpty()).thenReturn(false);
-    when(clientLevelTracerContext.merge(methodLevelTracerContext))
-        .thenReturn(clientLevelTracerContext);
+    LibraryMetadata metadata =
+        LibraryMetadata.newBuilder().setArtifactName("gax-java").setVersion("1.0").build();
+    ApiTracerContext clientLevelTracerContext =
+        ApiTracerContext.newBuilder().setLibraryMetadata(metadata).build();
+    ApiTracerContext methodLevelTracerContext =
+        ApiTracerContext.newBuilder().setLibraryMetadata(LibraryMetadata.empty()).build();
+    
+    ApiTracerFactory factoryWithContext = tracerFactory.withContext(clientLevelTracerContext);
+    ApiTracer actual = factoryWithContext.newTracer(mock(ApiTracer.class), methodLevelTracerContext);
 
-    tracerFactory.withContext(clientLevelTracerContext);
-    ApiTracer actual = tracerFactory.newTracer(mock(ApiTracer.class), methodLevelTracerContext);
-
-    verify(clientLevelTracerContext).merge(methodLevelTracerContext);
     assertThat(actual).isInstanceOf(OpenTelemetryMetricsTracer.class);
   }
 
@@ -140,8 +139,8 @@ class OpenTelemetryMetricsFactoryTest {
         LibraryMetadata.newBuilder().setArtifactName("gax-java").setVersion("1.0").build();
     ApiTracerContext context = ApiTracerContext.newBuilder().setLibraryMetadata(metadata).build();
 
-    tracerFactory.withContext(context);
+    ApiTracerFactory factoryWithContext = tracerFactory.withContext(context);
 
-    assertThat(tracerFactory.needsContext()).isFalse();
+    assertThat(factoryWithContext.needsContext()).isFalse();
   }
 }


### PR DESCRIPTION
This PR
- Reduced visibility of several methods in ApiTracerContext to package-private to limit API surface area. 
- Returns a new instance of `OpenTelemetryMetricsFactory` in `withContext` method to maintain immutability.