### PR TITLE
build(sdk-platform-java): Add formatter plugin to the root pom of sdk-platform-java.

### DIFF
--- a/sdk-platform-java/pom.xml
+++ b/sdk-platform-java/pom.xml
@@ -30,6 +30,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>com.spotify.fmt</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>3.1.3</version>


### PR DESCRIPTION
Running mvn fmt:format would result in errors in the root pom, because the [formatter plugin](https://github.com/googleapis/sdk-platform-java/blob/febe86f1ea4f0b5e6d8454024ed499adb7dc9328/pom.xml#L31-L34) was not migrated. Add formatter plugin to the root pom of sdk-platform-java to resolve the issue.