### PR TITLE
fix(hermetic-build): prevent overwrite of Version.java in new libraries'

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
+++ b/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
@@ -21,7 +21,7 @@ deep-remove-regex:
 
 deep-preserve-regex:
 - "/{{ module_name }}/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
-- "/.*google-.*/src/main/java/com/google/cloud/.*/v.*/stub/Version.java"
+- "/.*google-.*/src/main/java/com/google/[^/]+/.*/v.*/stub/Version.java"
 
 deep-copy-regex:
 - source: "/{{ proto_path }}/(v.*)/.*-java/proto-google-.*/src"

--- a/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
+++ b/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
@@ -21,7 +21,7 @@ deep-remove-regex:
 
 deep-preserve-regex:
 - "/{{ module_name }}/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
-- "/{{ module_name }}/google-.*/src/main/java/com/google/cloud/.*/v.*/stub/Version.java"
+- "/.*google-.*/src/main/java/com/google/cloud/.*/v.*/stub/Version.java"
 
 deep-copy-regex:
 - source: "/{{ proto_path }}/(v.*)/.*-java/proto-google-.*/src"

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-golden.yaml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-golden.yaml
@@ -21,7 +21,7 @@ deep-remove-regex:
 
 deep-preserve-regex:
 - "/java-bare-metal-solution/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
-- "/java-bare-metal-solution/google-.*/src/main/java/com/google/cloud/.*/v.*/stub/Version.java"
+- "/.*google-.*/src/main/java/com/google/cloud/.*/v.*/stub/Version.java"
 
 deep-copy-regex:
 - source: "/google/cloud/baremetalsolution/(v.*)/.*-java/proto-google-.*/src"

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-golden.yaml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-golden.yaml
@@ -21,7 +21,7 @@ deep-remove-regex:
 
 deep-preserve-regex:
 - "/java-bare-metal-solution/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
-- "/.*google-.*/src/main/java/com/google/cloud/.*/v.*/stub/Version.java"
+- "/.*google-.*/src/main/java/com/google/[^/]+/.*/v.*/stub/Version.java"
 
 deep-copy-regex:
 - source: "/google/cloud/baremetalsolution/(v.*)/.*-java/proto-google-.*/src"


### PR DESCRIPTION
Applies changes found to work in https://github.com/googleapis/google-cloud-java/pull/12710/changes/59581efc73ee1370a7bd4ad57616ac4ad750130e