### PR TITLE
fix(java-spanner): use the existing dependency versions

### DIFF
--- a/java-spanner/benchmarks/pom.xml
+++ b/java-spanner/benchmarks/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-monitoring</artifactId>
-      <version>3.90.0</version><!-- {x-version-update:google-cloud-monitoring:current} -->
+      <version>3.89.0</version><!-- {x-version-update:google-cloud-monitoring:current} -->
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>

--- a/java-spanner/google-cloud-spanner/pom.xml
+++ b/java-spanner/google-cloud-spanner/pom.xml
@@ -310,7 +310,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-monitoring</artifactId>
-      <version>3.90.0</version><!-- {x-version-update:google-cloud-monitoring:current} -->
+      <version>3.89.0</version><!-- {x-version-update:google-cloud-monitoring:current} -->
       <!-- Version will be managed by guava -->
       <exclusions>
         <exclusion>
@@ -322,7 +322,7 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-monitoring-v3</artifactId>
-      <version>3.90.0</version><!-- {x-version-update:proto-google-cloud-monitoring-v3:current} -->
+      <version>3.89.0</version><!-- {x-version-update:proto-google-cloud-monitoring-v3:current} -->
       <!-- Version will be managed by guava -->
       <exclusions>
         <exclusion>
@@ -334,7 +334,7 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>grpc-google-cloud-monitoring-v3</artifactId>
-      <version>3.90.0</version><!-- {x-version-update:grpc-google-cloud-monitoring-v3:current} -->
+      <version>3.89.0</version><!-- {x-version-update:grpc-google-cloud-monitoring-v3:current} -->
       <scope>test</scope>
       <!-- Version will be managed by guava -->
       <exclusions>
@@ -523,13 +523,13 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-trace</artifactId>
-      <version>2.89.0</version><!-- {x-version-update:google-cloud-trace:current} -->
+      <version>2.88.0</version><!-- {x-version-update:google-cloud-trace:current} -->
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-trace-v1</artifactId>
-      <version>2.89.0</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
+      <version>2.88.0</version><!-- {x-version-update:proto-google-cloud-trace-v1:current} -->
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
For the java-spanner partial release, we cannot use the version in this monorepo.

b/500526314#comment13
