### PR TITLE
fix(bqjdbc): lazily instantiate Statement in BigQueryDatabaseMetaData

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
+++ b/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
@@ -1,2 +1,3 @@
 drivers/**
 target-it/**
+*logs/**

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -138,6 +138,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   Long connectionPoolSize;
   Long listenerPoolSize;
   String partnerToken;
+  private static DatabaseMetaData databaseMetaData;
 
   BigQueryConnection(String url) throws IOException {
     this(url, DataSource.fromUrl(url));
@@ -771,7 +772,10 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
   @Override
   public DatabaseMetaData getMetaData() throws SQLException {
-    return new BigQueryDatabaseMetaData(this);
+    if (databaseMetaData == null) {
+      databaseMetaData = new BigQueryDatabaseMetaData(this);
+    }
+    return databaseMetaData;
   }
 
   @Override

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -943,8 +943,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
     Thread fetcherThread = new Thread(procedureFetcher, "getProcedures-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedures");
@@ -1206,8 +1205,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     Thread fetcherThread =
         new Thread(procedureColumnFetcher, "getProcedureColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedureColumns for catalog: " + catalog);
@@ -1868,8 +1866,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
     Thread fetcherThread = new Thread(tableFetcher, "getTables-fetcher-" + effectiveCatalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getTables");
@@ -2009,8 +2006,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     populateQueue(catalogRows, queue, schemaFields);
     signalEndOfData(queue, schemaFields);
 
-    return BigQueryJsonResultSet.of(
-        catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
+    return BigQueryJsonResultSet.of(catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
   }
 
   Schema defineGetCatalogsSchema() {
@@ -2635,7 +2631,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
     String sql = readSqlFromFile(GET_PRIMARY_KEYS_SQL);
-    try(Statement stmt = this.connection.createStatement()) {
+    try {
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
       return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
@@ -2647,7 +2645,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getImportedKeys(String catalog, String schema, String table)
       throws SQLException {
     String sql = readSqlFromFile(GET_IMPORTED_KEYS_SQL);
-    try(Statement stmt = this.connection.createStatement()) {
+    try {
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
       return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
@@ -2659,7 +2659,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getExportedKeys(String catalog, String schema, String table)
       throws SQLException {
     String sql = readSqlFromFile(GET_EXPORTED_KEYS_SQL);
-    try(Statement stmt = this.connection.createStatement()) {
+    try {
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
       return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
@@ -2677,7 +2679,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       String foreignTable)
       throws SQLException {
     String sql = readSqlFromFile(GET_CROSS_REFERENCE_SQL);
-    try(Statement stmt = this.connection.createStatement()) {
+    try {
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql =
           replaceSqlParameters(
               sql,
@@ -3704,8 +3708,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
     Thread fetcherThread = new Thread(schemaFetcher, "getSchemas-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getSchemas");
@@ -3999,8 +4002,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
     Thread fetcherThread = new Thread(functionFetcher, "getFunctions-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctions");
@@ -4254,8 +4256,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     Thread fetcherThread =
         new Thread(functionColumnFetcher, "getFunctionColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctionColumns for catalog: " + catalog);

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -51,6 +51,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.RowIdLifetime;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -138,7 +139,6 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   String URL;
   BigQueryConnection connection;
-  private final BigQueryStatement statement;
   private final BigQuery bigquery;
   private final int metadataFetchThreadCount;
   private static final AtomicReference<String> parsedDriverVersion = new AtomicReference<>(null);
@@ -150,7 +150,6 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   BigQueryDatabaseMetaData(BigQueryConnection connection) throws SQLException {
     this.URL = connection.getConnectionUrl();
     this.connection = connection;
-    this.statement = connection.createStatement().unwrap(BigQueryStatement.class);
     this.bigquery = connection.getBigQuery();
     this.metadataFetchThreadCount = connection.getMetadataFetchThreadCount();
     loadDriverVersionProperties();
@@ -945,7 +944,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     Thread fetcherThread = new Thread(procedureFetcher, "getProcedures-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
         BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, this.statement, new Thread[] {fetcherThread});
+            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedures");
@@ -1208,7 +1207,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
         new Thread(procedureColumnFetcher, "getProcedureColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
         BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, this.statement, new Thread[] {fetcherThread});
+            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedureColumns for catalog: " + catalog);
@@ -1870,7 +1869,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     Thread fetcherThread = new Thread(tableFetcher, "getTables-fetcher-" + effectiveCatalog);
     BigQueryJsonResultSet resultSet =
         BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, this.statement, new Thread[] {fetcherThread});
+            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getTables");
@@ -2011,7 +2010,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     signalEndOfData(queue, schemaFields);
 
     return BigQueryJsonResultSet.of(
-        catalogsSchema, catalogRows.size(), queue, this.statement, new Thread[0]);
+        catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
   }
 
   Schema defineGetCatalogsSchema() {
@@ -2043,7 +2042,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     signalEndOfData(queue, tableTypesSchema.getFields());
 
     return BigQueryJsonResultSet.of(
-        tableTypesSchema, tableTypeRows.size(), queue, this.statement, new Thread[0]);
+        tableTypesSchema, tableTypeRows.size(), queue, null, new Thread[0]);
   }
 
   static Schema defineGetTableTypesSchema() {
@@ -2495,7 +2494,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetColumnPrivilegesSchema() {
@@ -2523,7 +2522,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetTablePrivilegesSchema() {
@@ -2545,7 +2544,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetBestRowIdentifierSchema() {
@@ -2595,7 +2594,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetVersionColumnsSchema() {
@@ -2636,9 +2635,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
     String sql = readSqlFromFile(GET_PRIMARY_KEYS_SQL);
-    try {
+    try(Statement stmt = this.connection.createStatement()) {
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException(e);
     }
@@ -2648,9 +2647,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getImportedKeys(String catalog, String schema, String table)
       throws SQLException {
     String sql = readSqlFromFile(GET_IMPORTED_KEYS_SQL);
-    try {
+    try(Statement stmt = this.connection.createStatement()) {
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException(e);
     }
@@ -2660,9 +2659,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getExportedKeys(String catalog, String schema, String table)
       throws SQLException {
     String sql = readSqlFromFile(GET_EXPORTED_KEYS_SQL);
-    try {
+    try(Statement stmt = this.connection.createStatement()) {
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException(e);
     }
@@ -2678,7 +2677,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       String foreignTable)
       throws SQLException {
     String sql = readSqlFromFile(GET_CROSS_REFERENCE_SQL);
-    try {
+    try(Statement stmt = this.connection.createStatement()) {
       String formattedSql =
           replaceSqlParameters(
               sql,
@@ -2688,7 +2687,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               foreignCatalog,
               foreignSchema,
               foreignTable);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException(e);
     }
@@ -2710,7 +2709,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     populateQueue(typeInfoRows, queue, schemaFields);
     signalEndOfData(queue, schemaFields);
     return BigQueryJsonResultSet.of(
-        typeInfoSchema, typeInfoRows.size(), queue, this.statement, new Thread[0]);
+        typeInfoSchema, typeInfoRows.size(), queue, null, new Thread[0]);
   }
 
   Schema defineGetTypeInfoSchema() {
@@ -3172,7 +3171,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetIndexInfoSchema() {
@@ -3303,7 +3302,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetUDTsSchema() {
@@ -3377,7 +3376,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetSuperTablesSchema() {
@@ -3414,7 +3413,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetSuperTypesSchema() {
@@ -3460,7 +3459,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetAttributesSchema() {
@@ -3706,7 +3705,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     Thread fetcherThread = new Thread(schemaFetcher, "getSchemas-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
         BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, this.statement, new Thread[] {fetcherThread});
+            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getSchemas");
@@ -3825,7 +3824,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       signalEndOfData(queue, resultSchemaFields);
     }
     return BigQueryJsonResultSet.of(
-        resultSchema, collectedResults.size(), queue, this.statement, new Thread[0]);
+        resultSchema, collectedResults.size(), queue, null, new Thread[0]);
   }
 
   Schema defineGetClientInfoPropertiesSchema() {
@@ -4001,7 +4000,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     Thread fetcherThread = new Thread(functionFetcher, "getFunctions-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
         BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, this.statement, new Thread[] {fetcherThread});
+            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctions");
@@ -4256,7 +4255,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
         new Thread(functionColumnFetcher, "getFunctionColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
         BigQueryJsonResultSet.of(
-            resultSchema, -1, queue, this.statement, new Thread[] {fetcherThread});
+            resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctionColumns for catalog: " + catalog);
@@ -4663,7 +4662,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final BlockingQueue<BigQueryFieldValueListWrapper> queue = new LinkedBlockingQueue<>(1);
     signalEndOfData(queue, resultSchemaFields);
 
-    return BigQueryJsonResultSet.of(resultSchema, 0, queue, this.statement, null);
+    return BigQueryJsonResultSet.of(resultSchema, 0, queue, null, null);
   }
 
   Schema defineGetPseudoColumnsSchema() {


### PR DESCRIPTION
[b/501419313](https://b.corp.google.com/501419313)

- Remove pre-emptive BigQueryStatement object creation in BigQueryDatabaseMetData constructor. 
- Make DataBaseMetadata field in BigQueryConnection class static.