### PR TITLE
build: use local clone for release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -3,20 +3,46 @@ releaseType: java-yoshi
 manifest: true
 handleGHRelease: true
 onDemand: true
+local: true
+localCloneDepth: 200
 branches:
     - branch: 1.0.x
       releaseType: java-backport
       bumpMinorPreMajor: true
+      onDemand: true
+      local: true
+      localCloneDepth: 200
     - branch: 1.13.x
       releaseType: java-backport
+      onDemand: true
+      local: true
+      localCloneDepth: 200
     - branch: 1.25.x
       releaseType: java-backport
+      onDemand: true
+      local: true
+      localCloneDepth: 200
     - branch: 1.37.x
       releaseType: java-backport
+      onDemand: true
+      local: true
+      localCloneDepth: 200
     - branch: 1.53.x
       releaseType: java-backport
+      onDemand: true
+      local: true
+      localCloneDepth: 200
     - branch: 1.61.x
       releaseType: java-backport
+      onDemand: true
+      local: true
+      localCloneDepth: 200
     - branch: 1.58.x
       releaseType: java-backport
+      onDemand: true
+      local: true
+      localCloneDepth: 200
     - branch: protobuf-4.x-rc
+      onDemand: true
+      local: true
+      localCloneDepth: 200


### PR DESCRIPTION
This will use a local git clone to speed up the release-please runs and avoid reduce quota issues