### PR TITLE
fix: normalize indentation in owlbot yamls for new libraries

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/postprocess_library.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/postprocess_library.sh
@@ -73,9 +73,7 @@ if [[ "${is_monorepo}" == "true" ]]; then
   # - "/google-.*/src"
 
   library_name=$(basename "${postprocessing_target}")
-  cat "${postprocessing_target}/${owlbot_yaml_file_name}" \
-    | sed "s/- \"\/${library_name}/ - \"/" \
-    > "${postprocessing_target}/.OwlBot.hermetic.yaml"
+  normalize_owlbot_yaml "${postprocessing_target}/${owlbot_yaml_file_name}" "${postprocessing_target}/.OwlBot.hermetic.yaml" "${library_name}"
   owlbot_yaml_relative_path=".OwlBot.hermetic.yaml"
 else
   owlbot_yaml_relative_path=".github/${owlbot_yaml_file_name}"

--- a/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
+++ b/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
@@ -21,7 +21,7 @@ deep-remove-regex:
 
 deep-preserve-regex:
 - "/{{ module_name }}/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
-- "/.*google-.*/src/main/java/com/google/[^/]+/.*/v.*/stub/Version.java"
+- "/.*google-.*/src/main/java/.*/stub/Version.java"
 
 deep-copy-regex:
 - source: "/{{ proto_path }}/(v.*)/.*-java/proto-google-.*/src"

--- a/sdk-platform-java/hermetic_build/library_generation/tests/generate_library_unit_tests.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/generate_library_unit_tests.sh
@@ -213,6 +213,35 @@ get_proto_path_from_preprocessed_sources_multiple_proto_dirs_fails() {
   assertEquals 1 ${res}
 }
 
+normalize_owlbot_yaml_test() {
+  local temp_dir=$(mktemp -d)
+  local input_file="${temp_dir}/input.yaml"
+  local output_file="${temp_dir}/output.yaml"
+  
+  cat <<EOF > "${input_file}"
+deep-remove-regex:
+- "/java-accesscontextmanager/proto-google-.*/src"
+  - "/java-accesscontextmanager/samples/snippets/generated"
+  - "/.*google-.*/src/main/java/.*/stub/Version.java"
+EOF
+
+  normalize_owlbot_yaml "${input_file}" "${output_file}" "java-accesscontextmanager"
+  
+  # Verify content
+  local expected_content
+  expected_content=$(cat <<EOF
+deep-remove-regex:
+- "/proto-google-.*/src"
+- "/samples/snippets/generated"
+- "/.*google-.*/src/main/java/.*/stub/Version.java"
+EOF
+)
+  local actual_content=$(cat "${output_file}")
+  assertEquals "${expected_content}" "${actual_content}"
+  
+  rm -rf "${temp_dir}"
+}
+
 # Execute tests.
 # One line per test.
 test_list=(
@@ -237,6 +266,7 @@ test_list=(
   get_proto_path_from_preprocessed_sources_valid_library_succeeds
   get_proto_path_from_preprocessed_sources_empty_library_fails
   get_proto_path_from_preprocessed_sources_multiple_proto_dirs_fails
+  normalize_owlbot_yaml_test
 )
 
 pushd "${script_dir}"

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-golden.yaml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-golden.yaml
@@ -21,7 +21,7 @@ deep-remove-regex:
 
 deep-preserve-regex:
 - "/java-bare-metal-solution/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
-- "/.*google-.*/src/main/java/com/google/[^/]+/.*/v.*/stub/Version.java"
+- "/.*google-.*/src/main/java/.*/stub/Version.java"
 
 deep-copy-regex:
 - source: "/google/cloud/baremetalsolution/(v.*)/.*-java/proto-google-.*/src"

--- a/sdk-platform-java/hermetic_build/library_generation/utils/utilities.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/utilities.sh
@@ -335,14 +335,14 @@ error_if_not_exists() {
 }
 
 normalize_owlbot_yaml() {
-  local input_file=$1
-  local output_file=$2
-  local library_name=$3
+  local input_file="$1"
+  local output_file="$2"
+  local library_name="$3"
   
   # Step 1: Remove library name prefix and normalize indentation for matching lines.
   # Step 2: Normalize indentation for lines that didn't have the prefix.
-  cat "${input_file}" \
-    | sed -e "s/^[[:space:]]*- \"\/${library_name}/- \"/" \
-          -e "s/^[[:space:]]*- \"/- \"/" \
-    > "${output_file}"
+  # Using | as sed delimiter to avoid escaping forward slashes.
+  sed -e "s|^\s*- \"/${library_name}|- \"|" \
+      -e "s|^\s*- \"|- \"|" \
+      "${input_file}" > "${output_file}"
 }

--- a/sdk-platform-java/hermetic_build/library_generation/utils/utilities.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/utilities.sh
@@ -108,7 +108,7 @@ download_protoc() {
   "protoc-${protoc_version}.zip" \
   "GitHub"
   unzip -o -q "protoc-${protoc_version}.zip"
-  rm "protoc-${protoc_version}.zip" "readme.txt"
+  rm -f "protoc-${protoc_version}.zip" "readme.txt"
 }
 
 download_grpc_plugin() {
@@ -332,4 +332,17 @@ error_if_not_exists() {
     >&2 echo "required tools in this location."
     exit 1
   fi
+}
+
+normalize_owlbot_yaml() {
+  local input_file=$1
+  local output_file=$2
+  local library_name=$3
+  
+  # Step 1: Remove library name prefix and normalize indentation for matching lines.
+  # Step 2: Normalize indentation for lines that didn't have the prefix.
+  cat "${input_file}" \
+    | sed -e "s/^[[:space:]]*- \"\/${library_name}/- \"/" \
+          -e "s/^[[:space:]]*- \"/- \"/" \
+    > "${output_file}"
 }


### PR DESCRIPTION
Fixes the following failure occured in https://github.com/googleapis/google-cloud-java/pull/12756 ([job](https://github.com/googleapis/google-cloud-java/actions/runs/24256669481/job/70829822721?pr=12756)):

```
YAMLException: end of the stream or a document separator is expected (24:1)

 21 | 
 22 | deep-preserve-regex:
 23 |  - "/google-.*/src/test/java/co ...
 24 | - "/.*google-.*/src/main/java/c ...
------^
 25 | 
 26 | deep-copy-regex:
```
 
The approach is to keep the indentation as 0 spaces before the dash.
Added unit tests to confirm this.
Also modified the yaml template to handle special cases such as `io/grafeas` instead of `com/google/cloud/service/...`