### PR TITLE
chore: Update gapic-generator-java version in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,7 +67,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS")
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS")
 
-_gapic_generator_java_version = "2.68.1-SNAPSHOT"  # {x-version-update:gapic-generator-java:current}
+_gapic_generator_java_version = "2.69.0"  # {x-version-update:gapic-generator-java:current}
 
 maven_install(
     artifacts = [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,9 +8,9 @@
   "packages": {
     ".": {
       "extra-files": [
+        "WORKSPACE",
         ".github/workflows/generated_files_sync.yaml",
         ".github/workflows/hermetic_library_generation.yaml",
-        "sdk-platform-java/WORKSPACE",
         "sdk-platform-java/.cloudbuild/graalvm/cloudbuild.yaml",
         "sdk-platform-java/.cloudbuild/graalvm/cloudbuild-test-a.yaml",
         "sdk-platform-java/.cloudbuild/graalvm/cloudbuild-test-b.yaml",


### PR DESCRIPTION
Release please didn't update the version in WORKSPACE correctly. Manually updating it to the release version.

Add WORKSPACE to release-please-config.json so it can be updated automatically in the future.