### PR TITLE
chore: Fix iam policy downgrade

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -1476,7 +1476,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-iam-policy-bom</artifactId>
-        <version>1.64.0</version><!-- {x-version-update:google-iam-policy:current} -->
+        <version>1.87.0</version><!-- {x-version-update:google-iam-policy:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/java-iam/google-iam-policy-bom/pom.xml
+++ b/java-iam/google-iam-policy-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-iam-policy-bom</artifactId>
-  <version>1.64.0</version><!-- {x-version-update:google-iam-policy:current} -->
+  <version>1.87.0</version><!-- {x-version-update:google-iam-policy:current} -->
   <packaging>pom</packaging>
 
   <parent>
@@ -27,7 +27,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-iam-policy</artifactId>
-        <version>1.64.0</version><!-- {x-version-update:google-iam-policy:current} -->
+        <version>1.87.0</version><!-- {x-version-update:google-iam-policy:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java-iam/google-iam-policy/pom.xml
+++ b/java-iam/google-iam-policy/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-iam-policy</artifactId>
-  <version>1.64.0</version><!-- {x-version-update:google-iam-policy:current} -->
+  <version>1.87.0</version><!-- {x-version-update:google-iam-policy:current} -->
   <packaging>jar</packaging>
   <name>Google IAM Policy</name>
   <description>Eventarc lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes.</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-iam-policy-parent</artifactId>
-    <version>1.64.0</version><!-- {x-version-update:google-iam-policy:current} -->
+    <version>1.87.0</version><!-- {x-version-update:google-iam-policy:current} -->
   </parent>
   <properties>
     <site.installationModule>google-iam-policy</site.installationModule>

--- a/java-iam/pom.xml
+++ b/java-iam/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-iam-policy-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.64.0</version><!-- {x-version-update:google-iam-policy:current} -->
+  <version>1.87.0</version><!-- {x-version-update:google-iam-policy:current} -->
   <name>Google IAM Policy Parent</name>
   <description>
     Java idiomatic client for Google Cloud Platform services.

--- a/versions.txt
+++ b/versions.txt
@@ -587,7 +587,7 @@ grpc-google-cloud-tpu-v2:2.91.0:2.91.0
 google-cloud-datalineage:0.82.0:0.82.0
 proto-google-cloud-datalineage-v1:0.82.0:0.82.0
 grpc-google-cloud-datalineage-v1:0.82.0:0.82.0
-google-iam-policy:1.86.0:1.87.0-SNAPSHOT
+google-iam-policy:1.87.0:1.87.0
 proto-google-cloud-build-v2:3.92.0:3.92.0
 grpc-google-cloud-build-v2:3.92.0:3.92.0
 google-cloud-advisorynotifications:0.79.0:0.79.0

--- a/versions.txt
+++ b/versions.txt
@@ -587,7 +587,7 @@ grpc-google-cloud-tpu-v2:2.91.0:2.91.0
 google-cloud-datalineage:0.82.0:0.82.0
 proto-google-cloud-datalineage-v1:0.82.0:0.82.0
 grpc-google-cloud-datalineage-v1:0.82.0:0.82.0
-google-iam-policy:1.64.0:1.64.0
+google-iam-policy:1.86.0:1.87.0-SNAPSHOT
 proto-google-cloud-build-v2:3.92.0:3.92.0
 grpc-google-cloud-build-v2:3.92.0:3.92.0
 google-cloud-advisorynotifications:0.79.0:0.79.0


### PR DESCRIPTION
iam-policy was accidentally downgraded from 1.86.0 to 1.64.0 in [last release](https://github.com/googleapis/google-cloud-java/pull/12764). Manually fixing it. We also need to keep an eye on the release please PR in case it happened again.