### PR TITLE
ci: trigger sdk-platform-java CI on google-auth-library-java changes

### DIFF
--- a/.github/workflows/sdk-platform-java-ci.yaml
+++ b/.github/workflows/sdk-platform-java-ci.yaml
@@ -17,6 +17,7 @@ jobs:
         filters: |
           library:
             - 'sdk-platform-java/**'
+            - 'google-auth-library-java/**'
   build:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}


### PR DESCRIPTION
This PR updates the path filter in `sdk-platform-java-ci.yaml` to include `google-auth-library-java/**`. This ensures that any changes to the auth library will also trigger the CI build for the SDK platform.