### PR TITLE
fix(gax): make FakePagedApi inner classes public to fix compilation error

### DIFF
--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/rpc/testing/FakePagedApi.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/rpc/testing/FakePagedApi.java
@@ -133,7 +133,7 @@ public class FakePagedApi {
     }
   }
 
-  private static class ListIntegersPage
+  public static class ListIntegersPage
       extends AbstractPage<Integer, List<Integer>, Integer, ListIntegersPage> {
 
     public ListIntegersPage(
@@ -148,7 +148,7 @@ public class FakePagedApi {
     }
   }
 
-  private static class ListIntegersSizedPage
+  public static class ListIntegersSizedPage
       extends AbstractFixedSizeCollection<
           Integer, List<Integer>, Integer, ListIntegersPage, ListIntegersSizedPage> {
 


### PR DESCRIPTION
This PR fixes a compilation error in `PagingTest` where `FakePagedApi.ListIntegersSizedPage` was reported as having private access.

In `FakePagedApi.java`, `ListIntegersSizedPage` and `ListIntegersPage` were declared as `private static class`. However, they were used as type parameters in the public class `ListIntegersPagedResponse`. This exposure of private types via public type parameters caused compilation failures in stricter compiler environments (as seen in the CI failure).

## Changes

- Changed visibility of `ListIntegersPage` and `ListIntegersSizedPage` from `private` to `public` in `FakePagedApi.java`.

## Verification Results

- **Compilation**: Verified that `mvn test-compile -pl sdk-platform-java/gax-java/gax` succeeds.
