### PR TITLE
ci: replace java-logging with java-pubsub in downstream check

### DIFF
--- a/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
+++ b/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
@@ -33,7 +33,7 @@ jobs:
         repo:
           - java-bigtable
           - java-firestore
-          - java-logging
+          - java-pubsub
     steps:
       - name: Checkout sdk-platform-java
         uses: actions/checkout@v3


### PR DESCRIPTION
java-logging has been migrated to google-cloud-java but java-pubsub is still in a separate repo. Updating the CI to reflect it.