### PR TITLE
ci: remove redundant sdk-platform-java from split-units

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,6 @@ jobs:
           java-logging: java-logging/**
           java-spanner: java-spanner/**
           java-storage: java-storage/**
-          sdk-platform-java: sdk-platform-java/**
   split-units:
     runs-on: ubuntu-latest
     needs: changes


### PR DESCRIPTION
sdk-platform-java already has [its own ci](https://github.com/googleapis/google-cloud-java/blob/main/.github/workflows/sdk-platform-java-ci.yaml). There is no need to run units in a separate CI.