### PR TITLE
ci: skip bulk tests for isolated handwritten library changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,14 @@ jobs:
           src:
             - '**/*.java'
             - '**/pom.xml'
+            - '!java-bigquery/**'
+            - '!java-bigquerystorage/**'
+            - '!java-datastore/**'
+            - '!java-logging-logback/**'
+            - '!java-logging/**'
+            - '!java-spanner/**'
+            - '!java-storage/**'
+            - '!google-auth-library-java/**'
           ci:
             - '.github/workflows/ci.yaml'
             - '.kokoro/**'
@@ -121,6 +129,8 @@ jobs:
         # 2. Java code changes in upstream modules: Auth Library and Sdk-Platform-Java
         # 3. Upstream dependency version changes: Shared-Deps and Gapic-Generator-Pom-Parent
         filters: |
+          google-auth-library-java:
+            - 'google-auth-library-java/**'
           java-bigquery:
             - 'java-bigquery/**'
             - 'google-auth-library-java/**/*.java'


### PR DESCRIPTION
For now, try to skip the GAPIC unit tests if there are handwritten changes only in the handwritten repos.

In the future, we may want to see if we even want to run all the GAPIC unit tests (can we just use showcase tests?)