### PR TITLE
chore: downgrade gapic-libraries-bom to 1.85.0

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>gapic-libraries-bom</artifactId>
   <packaging>pom</packaging>
-  <version>1.85.1</version><!-- {x-version-update:google-cloud-java:current} -->
+  <version>1.85.0</version><!-- {x-version-update:google-cloud-java:current} -->
   <name>Google Cloud Java BOM</name>
   <description>
     BOM for the libraries in google-cloud-java repository. Users should not
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>google-cloud-pom-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.85.1</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.85.0</version><!-- {x-version-update:google-cloud-java:current} -->
     <relativePath>../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 

--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>google-cloud-pom-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.85.0</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.85.1</version><!-- {x-version-update:google-cloud-java:current} -->
     <relativePath>../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,7 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-java:1.85.1:1.85.1
+google-cloud-java:1.85.0:1.85.0
 google-cloud-accessapproval:2.92.0:2.92.0
 grpc-google-cloud-accessapproval-v1:2.92.0:2.92.0
 proto-google-cloud-accessapproval-v1:2.92.0:2.92.0

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,7 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-java:1.85.0:1.85.0
+google-cloud-java:1.85.1:1.85.1
 google-cloud-accessapproval:2.92.0:2.92.0
 grpc-google-cloud-accessapproval-v1:2.92.0:2.92.0
 proto-google-cloud-accessapproval-v1:2.92.0:2.92.0


### PR DESCRIPTION
gapic-libraries-bom was [released with 1.85.1](https://github.com/googleapis/google-cloud-java/pull/12805) due to partial release of vector search. However, versions.txt was not updated accordingly and caused unrelated PRs to downgrade it. 

Manually downgrade it to 1.85.0 to avoid affecting other PRs.

For selective releasing in the future, we should either not release gapic-libraries-bom or change versions.txt and release `google-cloud-pom-parent` as well.