### PR TITLE
perf(gax-grpc): skip metadata materialization when logging is disabled

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>gapic-libraries-bom</artifactId>
   <packaging>pom</packaging>
-  <version>1.85.1</version><!-- {x-version-update:google-cloud-java:current} -->
+  <version>1.85.0</version><!-- {x-version-update:google-cloud-java:current} -->
   <name>Google Cloud Java BOM</name>
   <description>
     BOM for the libraries in google-cloud-java repository. Users should not

--- a/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcLoggingInterceptor.java
+++ b/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcLoggingInterceptor.java
@@ -31,6 +31,7 @@
 package com.google.api.gax.grpc;
 
 import static com.google.api.gax.logging.LoggingUtils.executeWithTryCatch;
+import static com.google.api.gax.logging.LoggingUtils.isLoggingEnabled;
 import static com.google.api.gax.logging.LoggingUtils.logRequest;
 import static com.google.api.gax.logging.LoggingUtils.logResponse;
 import static com.google.api.gax.logging.LoggingUtils.recordResponseHeaders;
@@ -70,19 +71,23 @@ public class GrpcLoggingInterceptor implements ClientInterceptor {
 
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
-        recordServiceRpcAndRequestHeaders(
-            method.getServiceName(),
-            method.getFullMethodName(),
-            null, // endpoint is for http request only
-            metadataHeadersToMap(headers),
-            logDataBuilder,
-            LOGGER_PROVIDER);
+        if (isLoggingEnabled()) {
+          recordServiceRpcAndRequestHeaders(
+              method.getServiceName(),
+              method.getFullMethodName(),
+              null, // endpoint is for http request only
+              metadataHeadersToMap(headers),
+              logDataBuilder,
+              LOGGER_PROVIDER);
+        }
         SimpleForwardingClientCallListener<RespT> responseLoggingListener =
             new SimpleForwardingClientCallListener<RespT>(responseListener) {
               @Override
               public void onHeaders(Metadata headers) {
-                recordResponseHeaders(
-                    metadataHeadersToMap(headers), logDataBuilder, LOGGER_PROVIDER);
+                if (isLoggingEnabled()) {
+                  recordResponseHeaders(
+                      metadataHeadersToMap(headers), logDataBuilder, LOGGER_PROVIDER);
+                }
                 super.onHeaders(headers);
               }
 

--- a/sdk-platform-java/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcLoggingInterceptorTest.java
+++ b/sdk-platform-java/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcLoggingInterceptorTest.java
@@ -30,6 +30,7 @@
 
 package com.google.api.gax.grpc;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -44,6 +45,8 @@ import io.grpc.ClientInterceptors;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -57,6 +60,11 @@ class GrpcLoggingInterceptorTest {
   @Mock private ClientCall<String, Integer> call;
 
   private static final MethodDescriptor<String, Integer> method = FakeMethodDescriptor.create();
+
+  @AfterEach
+  void tearDown() throws Exception {
+    setLoggingEnabled(false);
+  }
 
   @Test
   void testInterceptor_basic() {
@@ -100,5 +108,37 @@ class GrpcLoggingInterceptorTest {
 
     Status status = Status.OK;
     interceptor.currentListener.onClose(status, new Metadata());
+  }
+
+  @Test
+  void testInterceptor_skipsMetadataMaterializationWhenLoggingDisabled() throws Exception {
+    setLoggingEnabled(false);
+    when(channel.newCall(Mockito.<MethodDescriptor<String, Integer>>any(), any(CallOptions.class)))
+        .thenReturn(call);
+
+    GrpcLoggingInterceptor interceptor = new GrpcLoggingInterceptor();
+    Channel intercepted = ClientInterceptors.intercept(channel, interceptor);
+
+    @SuppressWarnings("unchecked")
+    ClientCall.Listener<Integer> listener = mock(ClientCall.Listener.class);
+
+    Metadata requestHeaders = mock(Metadata.class);
+    when(requestHeaders.keys()).thenThrow(new AssertionError("request headers should not be read"));
+    ClientCall<String, Integer> interceptedCall = intercepted.newCall(method, CallOptions.DEFAULT);
+
+    assertDoesNotThrow(() -> interceptedCall.start(listener, requestHeaders));
+
+    Metadata responseHeaders = mock(Metadata.class);
+    when(responseHeaders.keys())
+        .thenThrow(new AssertionError("response headers should not be read"));
+
+    assertDoesNotThrow(() -> interceptor.currentListener.onHeaders(responseHeaders));
+  }
+
+  private static void setLoggingEnabled(boolean enabled) throws Exception {
+    Class<?> loggingUtils = Class.forName("com.google.api.gax.logging.LoggingUtils");
+    Method method = loggingUtils.getDeclaredMethod("setLoggingEnabled", boolean.class);
+    method.setAccessible(true);
+    method.invoke(null, enabled);
   }
 }

--- a/sdk-platform-java/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcLoggingInterceptorTest.java
+++ b/sdk-platform-java/gax-java/gax-grpc/src/test/java/com/google/api/gax/grpc/GrpcLoggingInterceptorTest.java
@@ -60,10 +60,16 @@ class GrpcLoggingInterceptorTest {
   @Mock private ClientCall<String, Integer> call;
 
   private static final MethodDescriptor<String, Integer> method = FakeMethodDescriptor.create();
+  private boolean originalLoggingEnabled;
+
+  @org.junit.jupiter.api.BeforeEach
+  void setUpLoggingState() throws Exception {
+    originalLoggingEnabled = isLoggingEnabled();
+  }
 
   @AfterEach
   void tearDown() throws Exception {
-    setLoggingEnabled(false);
+    setLoggingEnabled(originalLoggingEnabled);
   }
 
   @Test
@@ -140,5 +146,12 @@ class GrpcLoggingInterceptorTest {
     Method method = loggingUtils.getDeclaredMethod("setLoggingEnabled", boolean.class);
     method.setAccessible(true);
     method.invoke(null, enabled);
+  }
+
+  private static boolean isLoggingEnabled() throws Exception {
+    Class<?> loggingUtils = Class.forName("com.google.api.gax.logging.LoggingUtils");
+    Method method = loggingUtils.getDeclaredMethod("isLoggingEnabled");
+    method.setAccessible(true);
+    return (boolean) method.invoke(null);
   }
 }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/logging/Slf4jUtils.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/logging/Slf4jUtils.java
@@ -47,8 +47,6 @@ import org.slf4j.spi.LoggingEventBuilder;
 class Slf4jUtils {
 
   private static final Logger NO_OP_LOGGER = org.slf4j.helpers.NOPLogger.NOP_LOGGER;
-  private static final boolean loggingEnabled = LoggingUtils.isLoggingEnabled();
-
   private static final boolean isSLF4J2x;
 
   static {
@@ -70,7 +68,7 @@ class Slf4jUtils {
 
   // constructor with LoggerFactoryProvider to make testing easier
   static Logger getLogger(Class<?> clazz, LoggerFactoryProvider factoryProvider) {
-    if (loggingEnabled) {
+    if (LoggingUtils.isLoggingEnabled()) {
       ILoggerFactory loggerFactory = factoryProvider.getLoggerFactory();
       return loggerFactory.getLogger(clazz.getName());
     } else {


### PR DESCRIPTION
## Summary

  GrpcLoggingInterceptor was eagerly converting gRPC metadata into maps even when gax logging was disabled. That meant every RPC still paid metadata iteration/allocation cost before the logging gate.

  This change guards request and response header materialization with `LoggingUtils.isLoggingEnabled()` so the disabled path avoids that work entirely.
  
  
<img width="1717" height="758" alt="Screenshot 2026-04-15 at 7 39 27 PM" src="https://github.com/user-attachments/assets/358bfb61-585d-4688-9c7b-204337454416" />
