### PR TITLE
build: create additional tags on release

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-
-env:
-  BUILD_SUBDIR: sdk-platform-java
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -1,4 +1,4 @@
-name: sdk-platform-java Create additional tags for each release
+name: Create additional tags for each release
 
 on:
   release:
@@ -8,21 +8,7 @@ on:
 env:
   BUILD_SUBDIR: sdk-platform-java
 jobs:
-  filter:
-    runs-on: ubuntu-latest
-    outputs:
-      library: ${{ steps.filter.outputs.library }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          library:
-            - 'sdk-platform-java/**'
   build:
-    needs: filter
-    if: ${{ needs.filter.outputs.library == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       # Permission to create tag

--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
     - name: Set up Git
       run: |
         git config --local user.email "action@github.com"

--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>gapic-libraries-bom</artifactId>
   <packaging>pom</packaging>
-  <version>1.85.1</version><!-- {x-version-update:google-cloud-java:current} -->
+  <version>1.85.0</version><!-- {x-version-update:google-cloud-java:current} -->
   <name>Google Cloud Java BOM</name>
   <description>
     BOM for the libraries in google-cloud-java repository. Users should not


### PR DESCRIPTION
Towards #12724

Renamed the workflow and removed the path filter which doesn't apply to release events.