### PR TITLE
ci: restore sdk-platform-java jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,13 +209,6 @@ jobs:
       id: date
       run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@v4
-    # Java 8 tests use JDK 11 to compile and JDK 8 to run tests.
-    # Setting up Java 8 first to capture JAVA8_HOME.
-    - uses: actions/setup-java@v4
-      with:
-        java-version: ${{matrix.java}}
-        distribution: temurin
-    - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
     - uses: actions/setup-java@v4
       with:
         java-version: 11
@@ -233,7 +226,11 @@ jobs:
       env:
         BUILD_SUBDIR: ${{matrix.package}}
         JOB_TYPE: install
-
+    - uses: actions/setup-java@v4
+      with:
+        java-version: ${{matrix.java}}
+        distribution: temurin
+    - run: java -version
     - name: Run tests in Java ${{matrix.java}} with the source compiled in Java 11
       run: |
         mvn test \
@@ -243,8 +240,7 @@ jobs:
           -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
           -Dmaven.wagon.http.retryHandler.count=5 \
           --also-make \
-          -T 1C \
-          -Djvm="${JAVA8_HOME}/bin/java"
+          -T 1C
       env:
         BUILD_SUBDIR: ${{matrix.package}}
         JOB_TYPE: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,56 +131,48 @@ jobs:
         filters: |
           google-auth-library-java:
             - 'google-auth-library-java/**'
-            - '.github/workflows/ci.yaml'
           java-bigquery:
             - 'java-bigquery/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
-            - '.github/workflows/ci.yaml'
           java-bigquerystorage:
             - 'java-bigquerystorage/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
-            - '.github/workflows/ci.yaml'
           java-datastore:
             - 'java-datastore/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
-            - '.github/workflows/ci.yaml'
           java-logging-logback:
             - 'java-logging-logback/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
-            - '.github/workflows/ci.yaml'
           java-logging:
             - 'java-logging/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
-            - '.github/workflows/ci.yaml'
           java-spanner:
             - 'java-spanner/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
-            - '.github/workflows/ci.yaml'
           java-storage:
             - 'java-storage/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
-            - '.github/workflows/ci.yaml'
   split-units:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,48 +131,56 @@ jobs:
         filters: |
           google-auth-library-java:
             - 'google-auth-library-java/**'
+            - '.github/workflows/ci.yaml'
           java-bigquery:
             - 'java-bigquery/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
+            - '.github/workflows/ci.yaml'
           java-bigquerystorage:
             - 'java-bigquerystorage/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
+            - '.github/workflows/ci.yaml'
           java-datastore:
             - 'java-datastore/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
+            - '.github/workflows/ci.yaml'
           java-logging-logback:
             - 'java-logging-logback/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
+            - '.github/workflows/ci.yaml'
           java-logging:
             - 'java-logging/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
+            - '.github/workflows/ci.yaml'
           java-spanner:
             - 'java-spanner/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
+            - '.github/workflows/ci.yaml'
           java-storage:
             - 'java-storage/**'
             - 'google-auth-library-java/**/*.java'
             - 'sdk-platform-java/**/*.java'
             - 'sdk-platform-java/java-shared-dependencies/**/pom.xml'
             - 'sdk-platform-java/gapic-generator-java-pom-parent/pom.xml'
+            - '.github/workflows/ci.yaml'
   split-units:
     runs-on: ubuntu-latest
     needs: changes

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -209,6 +209,13 @@ jobs:
       id: date
       run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@v4
+    # Java 8 tests use JDK 11 to compile and JDK 8 to run tests.
+    # Setting up Java 8 first to capture JAVA8_HOME.
+    - uses: actions/setup-java@v4
+      with:
+        java-version: ${{matrix.java}}
+        distribution: temurin
+    - run: echo "JAVA8_HOME=${JAVA_HOME}" >> $GITHUB_ENV
     - uses: actions/setup-java@v4
       with:
         java-version: 11
@@ -226,11 +233,7 @@ jobs:
       env:
         BUILD_SUBDIR: ${{matrix.package}}
         JOB_TYPE: install
-    - uses: actions/setup-java@v4
-      with:
-        java-version: ${{matrix.java}}
-        distribution: temurin
-    - run: java -version
+
     - name: Run tests in Java ${{matrix.java}} with the source compiled in Java 11
       run: |
         mvn test \
@@ -240,7 +243,8 @@ jobs:
           -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS \
           -Dmaven.wagon.http.retryHandler.count=5 \
           --also-make \
-          -T 1C
+          -T 1C \
+          -Djvm="${JAVA8_HOME}/bin/java"
       env:
         BUILD_SUBDIR: ${{matrix.package}}
         JOB_TYPE: test

--- a/.github/workflows/sdk-platform-java-ci.yaml
+++ b/.github/workflows/sdk-platform-java-ci.yaml
@@ -18,6 +18,7 @@ jobs:
           library:
             - 'sdk-platform-java/**'
             - 'google-auth-library-java/**'
+            - '.github/workflows/ci.yaml'
   build:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}

--- a/sdk-platform-java/gax-java/dependencies.properties
+++ b/sdk-platform-java/gax-java/dependencies.properties
@@ -37,8 +37,8 @@ version.io_grpc=1.76.2
 #   2) Replace all characters which are neither alphabetic nor digits with the underscore ('_') character
 maven.com_google_api_grpc_proto_google_common_protos=com.google.api.grpc:proto-google-common-protos:2.63.2
 maven.com_google_api_grpc_grpc_google_common_protos=com.google.api.grpc:grpc-google-common-protos:2.63.2
-maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.42.1
-maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.42.1
+maven.com_google_auth_google_auth_library_oauth2_http=com.google.auth:google-auth-library-oauth2-http:1.46.0
+maven.com_google_auth_google_auth_library_credentials=com.google.auth:google-auth-library-credentials:1.46.0
 maven.io_opentelemetry_opentelemetry_api=io.opentelemetry:opentelemetry-api:1.51.0
 maven.io_opentelemetry_opentelemetry_context=io.opentelemetry:opentelemetry-context:1.51.0
 maven.io_opencensus_opencensus_api=io.opencensus:opencensus-api:0.31.1


### PR DESCRIPTION
This pull request resolves an API compatibility issue in the `sdk-platform-java` standalone Bazel build by updating the dependency pointers for `google-auth-library`.

## Problem
Bazel integration tests for `sdk-platform-java` were failing due to a mismatch between local source code usage and external dependency signatures:

```
external/com_google_api_gax_java/gax/src/main/java/com/google/api/gax/rpc/ClientContext.java:357: error: incompatible types: String cannot be converted to URI
    return ((GdchCredentials) credentials).createWithGdchAudience(audienceString);
                                                                  ^
```

This occurred because `gax-java` locally relies on `createWithGdchAudience(String)`, which was introduced in newer versions of `google-auth-library`, but the inner Bazel `dependencies.properties` file was still downloading `1.42.1`.

## Solution
- Updated `google-auth-library-oauth2-http` and `google-auth-library-credentials` versions from `1.42.1` to `1.46.0` inside `sdk-platform-java/gax-java/dependencies.properties`.
- Added a temporary CI trigger to ensure standalone validation jobs are correctly integrated into the main pipeline feedback cycle.
