### PR TITLE
test: point to sdk-platform-java/.cloudbuild in generation IT

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>gapic-libraries-bom</artifactId>
   <packaging>pom</packaging>
-  <version>1.85.1</version><!-- {x-version-update:google-cloud-java:current} -->
+  <version>1.85.0</version><!-- {x-version-update:google-cloud-java:current} -->
   <name>Google Cloud Java BOM</name>
   <description>
     BOM for the libraries in google-cloud-java repository. Users should not

--- a/sdk-platform-java/.cloudbuild/library_generation/cloudbuild-library-generation-integration-test.yaml
+++ b/sdk-platform-java/.cloudbuild/library_generation/cloudbuild-library-generation-integration-test.yaml
@@ -110,7 +110,7 @@ steps:
     source .venv/bin/activate
     pip install --require-hashes -r requirements.txt
     python -m unittest integration_tests.py
-  dir: "sdk-plaform-java/.cloudbuild/library_generation/scripts"
+  dir: "sdk-platform-java/.cloudbuild/library_generation/scripts"
   id: verify-generation
   waitFor: ["generate-libraries"]
 options:

--- a/sdk-platform-java/.cloudbuild/library_generation/cloudbuild-library-generation-integration-test.yaml
+++ b/sdk-platform-java/.cloudbuild/library_generation/cloudbuild-library-generation-integration-test.yaml
@@ -23,7 +23,7 @@ steps:
       # Use a fixed protoc version so that the generation result stays the same
       "--build-arg", "PROTOC_VERSION=25.8",
       "-t", "${_TEST_IMAGE}",
-      "-f", ".cloudbuild/library_generation/library_generation_airlock.Dockerfile",
+      "-f", "sdk-platform-java/.cloudbuild/library_generation/library_generation_airlock.Dockerfile",
       "."
   ]
   id: build-image
@@ -110,7 +110,7 @@ steps:
     source .venv/bin/activate
     pip install --require-hashes -r requirements.txt
     python -m unittest integration_tests.py
-  dir: ".cloudbuild/library_generation/scripts"
+  dir: "sdk-plaform-java/.cloudbuild/library_generation/scripts"
   id: verify-generation
   waitFor: ["generate-libraries"]
 options:


### PR DESCRIPTION
Post-migration work.

Related PR: https://github.com/googleapis/google-cloud-java/commit/8e6ba3662d31693e21879f31ed52d9c301a026fd