### PR TITLE
ci: stop using Google's Maven mirror in downstream checks

### DIFF
--- a/.github/workflows/sdk-platform-java-downstream.yaml
+++ b/.github/workflows/sdk-platform-java-downstream.yaml
@@ -23,6 +23,7 @@ jobs:
         filters: |
           library:
             - 'sdk-platform-java/**'
+            - .kokoro/downstream-compatibility.sh
   downstream-compatibility:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}

--- a/.kokoro/downstream-compatibility.sh
+++ b/.kokoro/downstream-compatibility.sh
@@ -27,8 +27,6 @@ scriptDir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 cd "${scriptDir}/.." # cd to the root of this repo
 source "$scriptDir/common.sh"
 
-setup_maven_mirror
-
 install_modules "sdk-platform-java"
 cd sdk-platform-java
 
@@ -42,6 +40,9 @@ for repo in ${REPOS_UNDER_TEST//,/ }; do # Split on comma
   git clone "https://github.com/googleapis/$repo.git" --depth=1 --branch "v$last_release"
   update_all_poms_dependency "$repo" google-cloud-shared-dependencies "$SHARED_DEPS_VERSION"
   pushd "$repo"
+  echo "Diff to run the test with modified dependencies:"
+  git --no-pager diff
+  echo "---------------"
   JOB_TYPE="test" ./.kokoro/build.sh
   popd
 done


### PR DESCRIPTION
For https://github.com/googleapis/google-cloud-java/issues/12824. The use of the Maven Central mirror is the causes of the failures:

`Error:      Non-resolvable parent POM for com.google.cloud:google-cloud-bigtable-parent:2.77.1: The following artifacts could not be resolved: com.google.cloud:sdk-platform-java-config:pom:3.59.0 (absent): com.google.cloud:sdk-platform-java-config:pom:3.59.0 was not found in https://maven-central.storage-download.googleapis.com/maven2/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of google-maven-central has elapsed or updates are forced and 'parent.relativePath' points at no local POM @ line 14, column 13 -> [Help 2]`

b/31927595#comment86 for the cause.