### PR TITLE
fix(java-managed-identities): fix copy rules to allow generated v1beta1

### DIFF
--- a/java-managed-identities/.OwlBot-hermetic.yaml
+++ b/java-managed-identities/.OwlBot-hermetic.yaml
@@ -24,11 +24,11 @@ deep-preserve-regex:
 - "/.*google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
 
 deep-copy-regex:
-- source: "/google/cloud/managedidentities/(v\\d)/.*-java/proto-google-.*/src"
+- source: "/google/cloud/managedidentities/(v.*)/.*-java/proto-google-.*/src"
   dest: "/owl-bot-staging/java-managed-identities/$1/proto-google-cloud-managed-identities-$1/src"
-- source: "/google/cloud/managedidentities/(v\\d)/.*-java/grpc-google-.*/src"
+- source: "/google/cloud/managedidentities/(v.*)/.*-java/grpc-google-.*/src"
   dest: "/owl-bot-staging/java-managed-identities/$1/grpc-google-cloud-managed-identities-$1/src"
-- source: "/google/cloud/managedidentities/(v\\d)/.*-java/gapic-google-.*/src"
+- source: "/google/cloud/managedidentities/(v.*)/.*-java/gapic-google-.*/src"
   dest: "/owl-bot-staging/java-managed-identities/$1/google-cloud-managed-identities/src"
 - source: "/google/cloud/managedidentities/(v.*)/.*-java/samples/snippets/generated"
   dest: "/owl-bot-staging/java-managed-identities/$1/samples/snippets/generated"


### PR DESCRIPTION
Fix deep-copy-regex in java-managed-identities/.OwlBot-hermetic.yaml to allow generated code for v1beta1 to be copied to output destination.

v1beta1 of java-managed-identities was added to the generation_config.yaml as part of initial migration to hermetic build: https://github.com/googleapis/google-cloud-java/commit/14b73467ea8e5037eb713610714a532fbba1a769, but client library code for v1beta1 is not present in `java-managed-identities/google-cloud-managed-identities` dir. This is due to `deep-copy-regex` being too strict and does not copy /v1beta1 from staging dir to final output.

Expect generation workflow to add code for v1beta1.

For #12736
For https://github.com/googleapis/librarian/issues/5370