### PR TITLE
ci: update sdk-platform-java templates and tests for monorepo migration

### DIFF
--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
@@ -412,7 +412,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
         .setArtifactName("com.google.cloud:gapic-showcase")
-        .setRepository("googleapis/sdk-platform-java")
+        .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();
   }

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -444,7 +444,7 @@ public class EchoStubSettings extends StubSettings<EchoStubSettings> {
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
         .setArtifactName("com.google.cloud:gapic-showcase")
-        .setRepository("googleapis/sdk-platform-java")
+        .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();
   }

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
@@ -191,7 +191,7 @@ public class WickedStubSettings extends StubSettings<WickedStubSettings> {
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
         .setArtifactName("com.google.cloud:gapic-showcase")
-        .setRepository("googleapis/sdk-platform-java")
+        .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();
   }

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/PluginArgumentParserTest.java
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/PluginArgumentParserTest.java
@@ -271,7 +271,7 @@ class PluginArgumentParserTest {
 
   @Test
   void parseRepo() {
-    String repo = "googleapis/sdk-platform-java";
+    String repo = "googleapis/google-cloud-java";
     String rawArgument = String.format("repo=%s", repo);
     assertEquals(
         repo,

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/GrpcRestTestProtoLoader.java
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/GrpcRestTestProtoLoader.java
@@ -43,7 +43,7 @@ import java.util.Set;
 
 public class GrpcRestTestProtoLoader extends TestProtoLoader {
   private static final GrpcRestTestProtoLoader INSTANCE = new GrpcRestTestProtoLoader();
-  private static final String ECHO_SERVICE_REPOSITORY = "googleapis/sdk-platform-java";
+  private static final String ECHO_SERVICE_REPOSITORY = "googleapis/google-cloud-java";
   private static final String ECHO_SERVICE_ARTIFACT = "com.google.cloud:gapic-showcase";
 
   protected GrpcRestTestProtoLoader() {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
@@ -73,7 +73,7 @@ public class TestProtoLoader {
           + " service also exposes methods that explicitly implement server delay, and\n"
           + " paginated calls. Set the 'showcase-trailer' metadata key on any method\n"
           + " to have the values echoed in the response trailers.";
-  private static final String ECHO_SERVICE_REPOSITORY = "googleapis/sdk-platform-java";
+  private static final String ECHO_SERVICE_REPOSITORY = "googleapis/google-cloud-java";
   private static final String ECHO_SERVICE_ARTIFACT = "com.google.cloud:gapic-showcase";
   private static final String LOGGING_SERVICE_ARTIFACT = "com.google.cloud:google-cloud-logging";
   private final String testFilesDirectory;

--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
@@ -147,7 +147,7 @@ latest_version=$(get_latest_released_version "com.google.api" "gapic-generator-j
 update_config "gapic_generator_version" "${latest_version}" "${generation_config}"
 
 # Update composite action version to latest gapic-generator-java version
-update_action "googleapis/sdk-platform-java/.github/scripts" \
+update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
   "${latest_version}" \
   "${workflow}"
 

--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
@@ -29,9 +29,9 @@
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": [
-        "uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"
+        "uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v(?<currentValue>.+?)\\n"
       ],
-      "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
+      "depNameTemplate": "com.google.cloud:gapic-libraries-bom",
       "datasourceTemplate": "maven"
     }
   ],

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.repo-metadata-proto-only-golden.json
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.repo-metadata-proto-only-golden.json
@@ -7,7 +7,7 @@
   "release_level": "preview",
   "transport": "grpc",
   "language": "java",
-  "repo": "googleapis/sdk-platform-java",
+  "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bare-metal-solution",
   "distribution_name": "com.google.cloud:google-cloud-bare-metal-solution",
   "library_type": "OTHER",

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-dns/pom.xml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-dns/pom.xml
@@ -4,6 +4,6 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-dns</artifactId>
   <packaging>jar</packaging>
-  <version>2.89.0</version><!-- {x-version-update:google-cloud-dns:current} -->
+  <version>2.33.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dns:current} -->
   <name>Google Cloud DNS Parent</name>
 </project>

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-service-control/google-cloud-service-control-bom/pom.xml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-service-control/google-cloud-service-control-bom/pom.xml
@@ -3,6 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-service-control-bom</artifactId>
-  <version>1.91.0</version><!-- {x-version-update:google-cloud-service-control:current} -->
+  <version>1.35.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-service-control:current} -->
   <packaging>pom</packaging>
 </project>

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-tasks/google-cloud-tasks-bom/pom.xml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-tasks/google-cloud-tasks-bom/pom.xml
@@ -3,6 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-tasks-bom</artifactId>
-  <version>2.91.0</version><!-- {x-version-update:google-cloud-tasks:current} -->
+  <version>2.35.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-tasks:current} -->
   <packaging>pom</packaging>
 </project>

--- a/sdk-platform-java/hermetic_build/library_generation/tests/utilities_unit_tests.py
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/utilities_unit_tests.py
@@ -183,7 +183,7 @@ class UtilitiesTest(unittest.TestCase):
         config = self.__get_a_gen_config(3)
         library = common_protos
         result = util.get_library_repository(config, library)
-        self.assertEqual("googleapis/sdk-platform-java", result)
+        self.assertEqual("googleapis/google-cloud-java", result)
 
     def test_get_library_repository_with_monorepo_returns_google_cloud_java(self):
         config = self.__get_a_gen_config(2)

--- a/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
@@ -26,7 +26,7 @@ from library_generation.utils.file_render import render
 from library_generation.utils.proto_path_utils import remove_version_from
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-SDK_PLATFORM_JAVA = "googleapis/sdk-platform-java"
+SDK_PLATFORM_JAVA = "googleapis/google-cloud-java"
 
 
 def create_argument(arg_key: str, arg_container: object) -> List[str]:

--- a/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
@@ -251,7 +251,10 @@ def generate_postprocessing_prerequisite_files(
         "distribution_name": library.get_maven_coordinate(),
     }
 
-    if library.get_library_name() not in LIBRARIES_WITHOUT_API_ID and library.library_type != "OTHER":
+    if (
+        library.get_library_name() not in LIBRARIES_WITHOUT_API_ID
+        and library.library_type != "OTHER"
+    ):
         repo_metadata["api_id"] = api_id
 
     repo_metadata["library_type"] = library.library_type

--- a/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
@@ -26,7 +26,16 @@ from library_generation.utils.file_render import render
 from library_generation.utils.proto_path_utils import remove_version_from
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-SDK_PLATFORM_JAVA = "googleapis/google-cloud-java"
+
+LIBRARIES_WITHOUT_API_ID = {
+    "google-auth-library",
+    "showcase",
+    "iam",
+    "api-common",
+    "common-protos",
+    "gax",
+    "core",
+}
 
 
 def create_argument(arg_key: str, arg_container: object) -> List[str]:
@@ -179,9 +188,7 @@ def get_library_repository(
 
     :return: string representing the repository
     """
-    if config.contains_common_protos():
-        repo = SDK_PLATFORM_JAVA
-    elif config.is_monorepo():
+    if config.is_monorepo() or config.contains_common_protos():
         repo = "googleapis/google-cloud-java"
     else:
         repo = f"googleapis/{language}-{library.get_library_name()}"
@@ -242,15 +249,13 @@ def generate_postprocessing_prerequisite_files(
         "repo": repo,
         "repo_short": f"{language}-{library_name}",
         "distribution_name": library.get_maven_coordinate(),
-        "api_id": api_id,
-        "library_type": library.library_type,
-        "requires_billing": library.requires_billing,
     }
 
-    # this removal is for java-common-protos and java-iam in
-    # sdk-platform-java
-    if repo == SDK_PLATFORM_JAVA:
-        repo_metadata.pop("api_id")
+    if library.get_library_name() not in LIBRARIES_WITHOUT_API_ID and library.library_type != "OTHER":
+        repo_metadata["api_id"] = api_id
+
+    repo_metadata["library_type"] = library.library_type
+    repo_metadata["requires_billing"] = library.requires_billing
 
     if library.api_reference:
         repo_metadata["api_reference"] = library.api_reference


### PR DESCRIPTION
This PR updates the templates and tests in sdk-platform-java to reflect its new location in the google-cloud-java monorepo. It also switches the unmanaged dependency check to track gapic-libraries-bom. b/503444342