### PR TITLE
build: add cab-token-generator to always install deps

### DIFF
--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -408,6 +408,7 @@ function install_modules() {
     always_install_deps_list=(
       'google-auth-library-java/appengine'
       'google-auth-library-java/bom'
+      'google-auth-library-java/cab-token-generator'
       'google-auth-library-java/credentials'
       'google-auth-library-java/oauth2_http'
       'sdk-platform-java/java-shared-dependencies'


### PR DESCRIPTION
Adds 'google-auth-library-java/cab-token-generator' to the `always_install_deps_list` in `.kokoro/common.sh`.

After the monorepo migration, release PRs failed the `gapic-generator-java-bom` check because they couldn't resolve the new auth library version from Maven Central before it was published.

This fix ensures the artifact is installed to the local Maven repository during the CI's install phase, satisfying the canary validation without requiring a full repository build.

Fixes #12843