### PR TITLE
build: add missing install step to Java 8 CI job

### DIFF
--- a/.github/workflows/sdk-platform-java-ci.yaml
+++ b/.github/workflows/sdk-platform-java-ci.yaml
@@ -180,7 +180,13 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-      - name: Compile with Java 17 and run tests with Java 8
+      - name: Install all modules using Java 17
+        shell: bash
+        run: .kokoro/build.sh
+        env:
+          BUILD_SUBDIR: sdk-platform-java
+          JOB_TYPE: install
+      - name: Run tests with Java 8
         shell: bash
         run: |
           set -x
@@ -192,7 +198,7 @@ jobs:
               -Djvm="${JAVA8_HOME}/bin/java"
         working-directory: sdk-platform-java
       # The `envVarTest` profile runs tests that require an environment variable
-      - name: Compile with Java 17 and run tests with Java 8 (Env Var Tests)
+      - name: Run tests with Java 8 (Env Var Tests)
         shell: bash
         run: |
           set -x


### PR DESCRIPTION
The build-java8-except-gapic-generator-java job was missing a step to install dependencies, which caused it to fail when resolving unpublished artifacts from the monorepo. This commit adds the step to install all modules using Java 17 before running the tests.

Fixes #12842