### PR TITLE
test: prevent root versions.txt from affecting postprocessor test fixtures

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-dns/pom.xml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-dns/pom.xml
@@ -4,6 +4,6 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-dns</artifactId>
   <packaging>jar</packaging>
-  <version>2.33.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dns:current} -->
+  <version>2.33.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dns-golden:current} -->
   <name>Google Cloud DNS Parent</name>
 </project>

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-service-control/google-cloud-service-control-bom/pom.xml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-service-control/google-cloud-service-control-bom/pom.xml
@@ -3,6 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-service-control-bom</artifactId>
-  <version>1.35.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-service-control:current} -->
+  <version>1.35.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-service-control-golden:current} -->
   <packaging>pom</packaging>
 </project>

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-tasks/google-cloud-tasks-bom/pom.xml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/test_monorepo_postprocessing/java-tasks/google-cloud-tasks-bom/pom.xml
@@ -3,6 +3,6 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-tasks-bom</artifactId>
-  <version>2.35.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-tasks:current} -->
+  <version>2.35.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-tasks-golden:current} -->
   <packaging>pom</packaging>
 </project>


### PR DESCRIPTION
After the monorepo migration, the shared versions.txt at the root caused Release Please to mutate test fixtures named pom.xml, breaking the postprocessor unit test.

- Added -golden suffix to version markers in test resources to isolate them from Release Please scanning.

Fixes #12841