### PR TITLE
ci: hermetic build action version to use shared-dependencies verson

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
@@ -48,13 +48,14 @@ function update_config() {
 }
 
 # Update an action to a new version in GitHub action.
+# the second argument must have the git tag (including "v").
 function update_action() {
     local key_word=$1
     local new_value=$2
     local file=$3
     echo "Update ${key_word} to ${new_value} in ${file}"
     # use a different delimiter because the key_word contains "/".
-    sed -i -e "s|${key_word}@v.*$|${key_word}@v${new_value}|" "${file}"
+    sed -i -e "s|${key_word}@[^ ]*$|${key_word}@${new_value}|" "${file}"
 }
 
 # The parameters of this script is:
@@ -143,12 +144,16 @@ rm -rf tmp-googleapis
 update_config "googleapis_commitish" "${latest_commit}" "${generation_config}"
 
 # Update gapic-generator-java version to the latest
-latest_version=$(get_latest_released_version "com.google.api" "gapic-generator-java")
-update_config "gapic_generator_version" "${latest_version}" "${generation_config}"
+latest_gapic_generator_version=$(get_latest_released_version "com.google.api" "gapic-generator-java")
+update_config "gapic_generator_version" "${latest_gapic_generator_version}" "${generation_config}"
 
-# Update composite action version to latest gapic-generator-java version
+# Update the GitHub Actions reference to the latest.
+# After the google-cloud-java monorepo migration of sdk-platform-java,
+# we cannot rely on the gapic-generator-java version tag. Let's use
+# the shared dependencies BOM version
+latest_shared_dependencies_bom_version=$(get_latest_released_version "com.google.cloud" "google-cloud-shared-dependencies")
 update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
-  "${latest_version}" \
+  "google-cloud-shared-dependencies/v${latest_shared_dependencies_bom_version}" \
   "${workflow}"
 
 # Update libraries-bom version to the latest


### PR DESCRIPTION
The hermetic build script relied on the sdk-platform-java release version to set the GitHub Action version. Now it's in the monorepo and cannot rely on the version. Instead, let's use the shared dependencies BOM version in the Git tag.

This change will resolve the latest failure in "chore: Update generation configuration" pull requests https://github.com/googleapis/java-bigtable/pull/2894:

```
Getting action download info
Error: Unable to resolve action `googleapis/google-cloud-java@v2.71.0`, unable to find version `v2.71.0`
```

where 2.71.0 is the version of the latest gapic-generator-java artifact. We don't have this tag in the google-cloud-java repository.
