### PR TITLE
ci: fix dorny/paths-filter to a revision

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       ci: ${{ steps.filter.outputs.ci }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         # we want to run tests if source code is changed or the scripts
@@ -121,7 +121,7 @@ jobs:
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
     steps:
-    - uses: dorny/paths-filter@v4
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         # For each library, run CI in split repos where there are changes in:

--- a/.github/workflows/google-auth-library-java-ci.yaml
+++ b/.github/workflows/google-auth-library-java-ci.yaml
@@ -28,7 +28,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-bigquery-scorecard.yml
+++ b/.github/workflows/java-bigquery-scorecard.yml
@@ -26,7 +26,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-spanner-integration-tests-against-emulator.yaml
+++ b/.github/workflows/java-spanner-integration-tests-against-emulator.yaml
@@ -11,7 +11,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-spanner-jdbc-ci.yaml
+++ b/.github/workflows/java-spanner-jdbc-ci.yaml
@@ -28,7 +28,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-spanner-jdbc-integration-tests-against-emulator.yaml
+++ b/.github/workflows/java-spanner-jdbc-integration-tests-against-emulator.yaml
@@ -13,7 +13,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-spanner-jdbc-quickperf.yaml
+++ b/.github/workflows/java-spanner-jdbc-quickperf.yaml
@@ -25,7 +25,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-spanner-jdbc-sample-tests.yml
+++ b/.github/workflows/java-spanner-jdbc-sample-tests.yml
@@ -25,7 +25,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-spanner-jdbc-spring-data-jdbc-sample.yaml
+++ b/.github/workflows/java-spanner-jdbc-spring-data-jdbc-sample.yaml
@@ -25,7 +25,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-spanner-jdbc-spring-data-mybatis-sample.yaml
+++ b/.github/workflows/java-spanner-jdbc-spring-data-mybatis-sample.yaml
@@ -25,7 +25,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/java-storage-nio-ci.yaml
+++ b/.github/workflows/java-storage-nio-ci.yaml
@@ -28,7 +28,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-analyze_dependency.yaml
+++ b/.github/workflows/sdk-platform-java-analyze_dependency.yaml
@@ -26,7 +26,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-ci.yaml
+++ b/.github/workflows/sdk-platform-java-ci.yaml
@@ -11,7 +11,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-dependency_compatibility_test.yaml
+++ b/.github/workflows/sdk-platform-java-dependency_compatibility_test.yaml
@@ -23,7 +23,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-downstream.yaml
+++ b/.github/workflows/sdk-platform-java-downstream.yaml
@@ -17,7 +17,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
+++ b/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
@@ -17,7 +17,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-java_compatibility_check.yaml
+++ b/.github/workflows/sdk-platform-java-java_compatibility_check.yaml
@@ -25,7 +25,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-shared_dependencies.yaml
+++ b/.github/workflows/sdk-platform-java-shared_dependencies.yaml
@@ -17,7 +17,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-sonar.yaml
+++ b/.github/workflows/sdk-platform-java-sonar.yaml
@@ -14,7 +14,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |

--- a/.github/workflows/sdk-platform-java-verify_library_generation.yaml
+++ b/.github/workflows/sdk-platform-java-verify_library_generation.yaml
@@ -11,7 +11,7 @@ jobs:
       library: ${{ steps.filter.outputs.library }}
     steps:
     - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |


### PR DESCRIPTION
The workflow files start using dorny/paths-filter@v4.0.1 (fbd0ab8f3e69293af611ebaee6363fc25e6d187d).
This will address `An action could not be found at the URI 'https://api.github.com/repos/dorny/paths-filter/tarball/d1c1ffe0248fe513906c8e24db8ea791d46f8590'`
error.

In general, it's a good practice to fix GitHub Actions to a specific Git SHA.

This changes the version from v3 to v4.0.1. https://github.com/dorny/paths-filter/releases/tag/v4.0.0 does not mention any breaking changes.
