### PR TITLE
chore(os-login): rm unused config API path

### DIFF
--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1977,7 +1977,6 @@ libraries:
   issue_tracker: https://issuetracker.google.com/savedsearches/559755
   GAPICs:
   - proto_path: google/cloud/oslogin/v1
-  - proto_path: google/cloud/oslogin/v1beta
 - api_shortname: parallelstore
   name_pretty: Parallelstore API
   product_documentation: https://cloud/parallelstore?hl=en

--- a/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
+++ b/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
@@ -120,6 +120,14 @@ python hermetic_build/common/cli/get_changed_libraries.py create \
   --current-generation-config-path="${generation_config}"\
   --force-regenerate-all="${force_regenerate_all}" | tee "${changed_libraries_file}"
 changed_libraries="$(cat "${changed_libraries_file}")"
+# Force run for os-login
+if [[ -z "${changed_libraries}" ]]; then
+  changed_libraries="os-login"
+else
+  if [[ ! "${changed_libraries}" =~ "os-login" ]]; then
+    changed_libraries="os-login,${changed_libraries}"
+  fi
+fi
 echo "Changed libraries are: ${changed_libraries:-"No changed library"}."
 
 # run hermetic code generation docker image.

--- a/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
+++ b/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
@@ -120,14 +120,6 @@ python hermetic_build/common/cli/get_changed_libraries.py create \
   --current-generation-config-path="${generation_config}"\
   --force-regenerate-all="${force_regenerate_all}" | tee "${changed_libraries_file}"
 changed_libraries="$(cat "${changed_libraries_file}")"
-# Force run for os-login
-if [[ -z "${changed_libraries}" ]]; then
-  changed_libraries="os-login"
-else
-  if [[ ! "${changed_libraries}" =~ "os-login" ]]; then
-    changed_libraries="os-login,${changed_libraries}"
-  fi
-fi
 echo "Changed libraries are: ${changed_libraries:-"No changed library"}."
 
 # run hermetic code generation docker image.


### PR DESCRIPTION
Removing unused API path from config for os-login, so that it matches the generated code status.

v1beta of java-os-login was added to the generation_config.yaml as part of initial migration to hermetic build: https://github.com/googleapis/google-cloud-java/commit/14b73467ea8e5037eb713610714a532fbba1a769, but client library code for v1beta is not present in java-os-login/google-cloud-os-login dir. This is due to deep-copy-regex being too strict and does not copy /v1beta from staging dir to final output.

Expect generation workflow to run successfully with not change. (no sample code exists for [os-login](https://github.com/googleapis/google-cloud-java/tree/main/java-os-login))

For https://github.com/googleapis/google-cloud-java/issues/12736
For https://github.com/googleapis/librarian/issues/5370