### PR TITLE
fix: Update renovate config check template to use npx

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/renovate_config_check.yaml
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/workflows/renovate_config_check.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'renovate.json'
+      - '.github/workflows/renovate_config_check.yaml'
 
 jobs:
   renovate_bot_config_validation:
@@ -18,8 +19,6 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Install Renovate and Config Validator
+    - name: Run Renovate Config Validator
       run: |
-        npm install -g npm@latest
-        npm install --global renovate
-        renovate-config-validator
+        npx --package renovate@43.136.0 renovate-config-validator

--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
@@ -29,9 +29,9 @@
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": [
-        "uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v(?<currentValue>.+?)\\n"
+        "uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"
       ],
-      "depNameTemplate": "com.google.cloud:gapic-libraries-bom",
+      "depNameTemplate": "com.google.cloud:google-cloud-shared-dependencies",
       "datasourceTemplate": "maven"
     }
   ],


### PR DESCRIPTION
This PR updates the renovate config check workflow template to use npx instead of global installation, avoiding issues with missing modules. Renovate.json template is also updated to use the google-cloud-shared-dependencies Git tag in the google-cloud-java repository.

Until this template change is propagated to the split repositories, the repositories with hermetic build automation reverts the change.


b/504692883