### PR TITLE
chore(auth): Address remaining Regional Access Boundary feedback

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -373,8 +373,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    */
   void refreshRegionalAccessBoundaryIfExpired(@Nullable URI uri, @Nullable AccessToken token)
       throws IOException {
-    if (!(this instanceof RegionalAccessBoundaryProvider)
-        || !isDefaultUniverseDomain()) {
+    if (!(this instanceof RegionalAccessBoundaryProvider) || !isDefaultUniverseDomain()) {
       return;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -374,7 +374,6 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   void refreshRegionalAccessBoundaryIfExpired(@Nullable URI uri, @Nullable AccessToken token)
       throws IOException {
     if (!(this instanceof RegionalAccessBoundaryProvider)
-        || !RegionalAccessBoundary.isEnabled()
         || !isDefaultUniverseDomain()) {
       return;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
@@ -67,24 +67,6 @@ final class RegionalAccessBoundary implements Serializable {
   static final String X_ALLOWED_LOCATIONS_HEADER_KEY = "x-allowed-locations";
   private static final long serialVersionUID = -2428522338274020302L;
 
-  private static final ThreadLocal<Boolean> DISABLE_RAB_FOR_TESTS =
-      ThreadLocal.withInitial(() -> false);
-
-  @VisibleForTesting
-  static void disableForTests() {
-    DISABLE_RAB_FOR_TESTS.set(true);
-  }
-
-  @VisibleForTesting
-  static void enableForTests() {
-    DISABLE_RAB_FOR_TESTS.set(false);
-  }
-
-  @VisibleForTesting
-  static void resetForTests() {
-    DISABLE_RAB_FOR_TESTS.remove();
-  }
-
   static final long TTL_MILLIS = 6 * 60 * 60 * 1000L; // 6 hours
   static final long REFRESH_THRESHOLD_MILLIS = 1 * 60 * 60 * 1000L; // 1 hour
 
@@ -191,10 +173,7 @@ final class RegionalAccessBoundary implements Serializable {
    *
    * @return True if the regional access boundary feature is enabled, false otherwise.
    */
-  @InternalApi
-  static boolean isEnabled() {
-    return !DISABLE_RAB_FOR_TESTS.get();
-  }
+
 
   /**
    * Refreshes the regional access boundary by making a network call to the lookup endpoint.

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
@@ -40,10 +40,11 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
 import com.google.api.client.json.GenericJson;
-import com.google.api.client.json.JsonParser;
+import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.Clock;
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.Key;
+import com.google.api.core.InternalApi;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -53,7 +54,6 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * Represents the regional access boundary configuration for a credential. This class holds the
@@ -67,10 +67,24 @@ final class RegionalAccessBoundary implements Serializable {
   static final String X_ALLOWED_LOCATIONS_HEADER_KEY = "x-allowed-locations";
   private static final long serialVersionUID = -2428522338274020302L;
 
-  // Note: this is for internal testing use use only.
-  // TODO: Fix unit test mocks so this can be removed
-  // Refer -> https://github.com/googleapis/google-auth-library-java/issues/1898
-  static final String ENABLE_EXPERIMENT_ENV_VAR = "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT";
+  private static final ThreadLocal<Boolean> DISABLE_RAB_FOR_TESTS =
+      ThreadLocal.withInitial(() -> false);
+
+  @VisibleForTesting
+  static void disableForTests() {
+    DISABLE_RAB_FOR_TESTS.set(true);
+  }
+
+  @VisibleForTesting
+  static void enableForTests() {
+    DISABLE_RAB_FOR_TESTS.set(false);
+  }
+
+  @VisibleForTesting
+  static void resetForTests() {
+    DISABLE_RAB_FOR_TESTS.remove();
+  }
+
   static final long TTL_MILLIS = 6 * 60 * 60 * 1000L; // 6 hours
   static final long REFRESH_THRESHOLD_MILLIS = 1 * 60 * 60 * 1000L; // 1 hour
 
@@ -78,8 +92,6 @@ final class RegionalAccessBoundary implements Serializable {
   private final List<String> locations;
   private final long refreshTime;
   private transient Clock clock;
-
-  private static EnvironmentProvider environmentProvider = SystemEnvironmentProvider.getInstance();
 
   /**
    * Creates a new RegionalAccessBoundary instance.
@@ -172,28 +184,16 @@ final class RegionalAccessBoundary implements Serializable {
     }
   }
 
-  @VisibleForTesting
-  static void setEnvironmentProviderForTest(@Nullable EnvironmentProvider provider) {
-    environmentProvider = provider == null ? SystemEnvironmentProvider.getInstance() : provider;
-  }
-
   /**
-   * Checks if the regional access boundary feature is enabled. The feature is enabled if the
-   * environment variable or system property "GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT" is set
-   * to "true" or "1" (case-insensitive).
+   * Checks if the regional access boundary feature is enabled.
+   *
+   * <p>This method is for internal use only and may be changed or removed in future releases.
    *
    * @return True if the regional access boundary feature is enabled, false otherwise.
    */
+  @InternalApi
   static boolean isEnabled() {
-    String enabled = environmentProvider.getEnv(ENABLE_EXPERIMENT_ENV_VAR);
-    if (enabled == null) {
-      enabled = System.getProperty(ENABLE_EXPERIMENT_ENV_VAR);
-    }
-    if (enabled == null) {
-      return false;
-    }
-    String lowercased = enabled.toLowerCase();
-    return "true".equals(lowercased) || "1".equals(enabled);
+    return !DISABLE_RAB_FOR_TESTS.get();
   }
 
   /**
@@ -249,15 +249,20 @@ final class RegionalAccessBoundary implements Serializable {
     HttpIOExceptionHandler ioExceptionHandler = new HttpBackOffIOExceptionHandler(backoff);
     request.setIOExceptionHandler(ioExceptionHandler);
 
+    request.setParser(new JsonObjectParser(OAuth2Utils.JSON_FACTORY));
+
     RegionalAccessBoundaryResponse json;
+    HttpResponse response = null;
     try {
-      HttpResponse response = request.execute();
-      String responseString = response.parseAsString();
-      JsonParser parser = OAuth2Utils.JSON_FACTORY.createJsonParser(responseString);
-      json = parser.parseAndClose(RegionalAccessBoundaryResponse.class);
+      response = request.execute();
+      json = response.parseAs(RegionalAccessBoundaryResponse.class);
     } catch (IOException e) {
       throw new IOException(
           "RegionalAccessBoundary: Failure while getting regional access boundaries:", e);
+    } finally {
+      if (response != null) {
+        response.disconnect();
+      }
     }
     String encodedLocations = json.getEncodedLocations();
     // The encodedLocations is the value attached to the x-allowed-locations header, and

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
@@ -199,6 +199,8 @@ final class RegionalAccessBoundary implements Serializable {
 
     HttpRequestFactory requestFactory = transportFactory.create().createRequestFactory();
     HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
+    // Disable automatic logging by google-http-java-client to prevent leakage of sensitive tokens.
+    request.setLoggingEnabled(false);
     request.getHeaders().setAuthorization("Bearer " + accessToken.getTokenValue());
 
     // Add retry logic

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
@@ -165,14 +165,6 @@ final class RegionalAccessBoundary implements Serializable {
   }
 
   /**
-   * Checks if the regional access boundary feature is enabled.
-   *
-   * <p>This method is for internal use only and may be changed or removed in future releases.
-   *
-   * @return True if the regional access boundary feature is enabled, false otherwise.
-   */
-
-  /**
    * Refreshes the regional access boundary by making a network call to the lookup endpoint.
    *
    * @param transportFactory The HTTP transport factory to use for the network request.

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundary.java
@@ -44,9 +44,7 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.Clock;
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.Key;
-import com.google.api.core.InternalApi;
 import com.google.auth.http.HttpTransportFactory;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
@@ -173,7 +171,6 @@ final class RegionalAccessBoundary implements Serializable {
    *
    * @return True if the regional access boundary feature is enabled, false otherwise.
    */
-
 
   /**
    * Refreshes the regional access boundary by making a network call to the lookup endpoint.

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -37,7 +37,6 @@ import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -86,14 +86,24 @@ final class RegionalAccessBoundaryManager {
   // on concurrent refresh tasks, while threadCount provides unique names
   // for easier debugging.
   private static final AtomicInteger threadCount = new AtomicInteger(0);
-  private static final ExecutorService EXECUTOR =
-      Executors.newFixedThreadPool(
-          5,
-          r -> {
-            Thread t = new Thread(r, "RAB-refresh-" + threadCount.getAndIncrement());
-            t.setDaemon(true);
-            return t;
-          });
+  private static final ExecutorService EXECUTOR;
+
+  static {
+    java.util.concurrent.ThreadPoolExecutor executor =
+        new java.util.concurrent.ThreadPoolExecutor(
+            5, // corePoolSize: threads to keep alive
+            5, // maximumPoolSize: max threads allowed
+            1, // keepAliveTime: time to wait before terminating idle threads
+            java.util.concurrent.TimeUnit.HOURS, // unit for keepAliveTime
+            new java.util.concurrent.LinkedBlockingQueue<>(), // work queue
+            r -> {
+              Thread t = new Thread(r, "RAB-refresh-" + threadCount.getAndIncrement());
+              t.setDaemon(true);
+              return t;
+            });
+    executor.allowCoreThreadTimeOut(true);
+    EXECUTOR = executor;
+  }
 
   private final transient Clock clock;
   private final int maxRetryElapsedTimeMillis;

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -88,16 +88,22 @@ final class RegionalAccessBoundaryManager {
   // on concurrent refresh tasks, while threadCount provides unique names
   // for easier debugging.
   private static final AtomicInteger threadCount = new AtomicInteger(0);
+  
+  // Bounded executor service ensures hard limits on concurrent refresh tasks and queued tasks
+  // to avoid resource exhaustion.
+  private static final int EXECUTOR_POOL_SIZE = 5;
+  private static final int EXECUTOR_QUEUE_CAPACITY = 100;
+  
   private static final ExecutorService EXECUTOR;
 
   static {
     ThreadPoolExecutor executor =
         new ThreadPoolExecutor(
-            5, // corePoolSize: threads to keep alive
-            5, // maximumPoolSize: max threads allowed
+            EXECUTOR_POOL_SIZE, // corePoolSize: threads to keep alive
+            EXECUTOR_POOL_SIZE, // maximumPoolSize: max threads allowed
             1, // keepAliveTime: time to wait before terminating idle threads
             TimeUnit.HOURS, // unit for keepAliveTime
-            new LinkedBlockingQueue<>(), // work queue
+            new LinkedBlockingQueue<>(EXECUTOR_QUEUE_CAPACITY), // work queue with bound
             r -> {
               Thread t = new Thread(r, "RAB-refresh-" + threadCount.getAndIncrement());
               t.setDaemon(true);

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -142,6 +142,11 @@ final class RegionalAccessBoundaryManager {
     return null;
   }
 
+  @VisibleForTesting
+  void setCachedRAB(RegionalAccessBoundary rab) {
+    this.cachedRAB.set(rab);
+  }
+
   /**
    * Triggers an asynchronous refresh of the RegionalAccessBoundary if it is not already being
    * refreshed and if the cooldown period is not active.

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -36,6 +36,9 @@ import com.google.api.core.InternalApi;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
@@ -77,6 +80,20 @@ final class RegionalAccessBoundaryManager {
 
   private final AtomicReference<CooldownState> cooldownState =
       new AtomicReference<>(new CooldownState(0, INITIAL_COOLDOWN_MILLIS));
+
+  // Unbounded thread creation is discouraged in library code to avoid resource
+  // exhaustion. A shared, bounded executor service ensures a hard limit (5)
+  // on concurrent refresh tasks, while threadCount provides unique names
+  // for easier debugging.
+  private static final AtomicInteger threadCount = new AtomicInteger(0);
+  private static final ExecutorService EXECUTOR =
+      Executors.newFixedThreadPool(
+          5,
+          r -> {
+            Thread t = new Thread(r, "RAB-refresh-" + threadCount.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+          });
 
   private final transient Clock clock;
   private final int maxRetryElapsedTimeMillis;
@@ -161,14 +178,7 @@ final class RegionalAccessBoundaryManager {
           };
 
       try {
-        // We use new Thread() here instead of
-        // CompletableFuture.runAsync() (which uses ForkJoinPool.commonPool()).
-        // This avoids consuming CPU resources since
-        // The common pool has a small, fixed number of threads designed for
-        // CPU-bound tasks.
-        Thread refreshThread = new Thread(refreshTask, "RAB-refresh-thread");
-        refreshThread.setDaemon(true);
-        refreshThread.start();
+        EXECUTOR.submit(refreshTask);
       } catch (Exception | Error e) {
         // If scheduling fails (e.g., RejectedExecutionException, OutOfMemoryError for threads),
         // the task's finally block will never execute. We must release the lock here.

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -31,6 +31,8 @@
 
 package com.google.auth.oauth2;
 
+import static com.google.auth.oauth2.LoggingUtils.log;
+
 import com.google.api.client.util.Clock;
 import com.google.api.core.InternalApi;
 import com.google.auth.http.HttpTransportFactory;
@@ -215,11 +217,13 @@ final class RegionalAccessBoundaryManager {
       } catch (Exception | Error e) {
         // If scheduling fails (e.g., RejectedExecutionException, OutOfMemoryError for threads),
         // the task's finally block will never execute. We must release the lock here.
-        LoggingUtils.log(
+        log(
             LOGGER_PROVIDER,
-            java.util.logging.Level.WARNING,
+            Level.FINE,
             null,
-            "Regional Access Boundary background refresh failed to schedule: " + e.getMessage());
+            "Could not submit background refresh task for Regional Access Boundary. "
+                + "This is non-blocking and the library will attempt to refresh on the next access. Error: "
+                + e.getMessage());
         future.setException(e);
         refreshFuture.set(null);
       }
@@ -247,13 +251,13 @@ final class RegionalAccessBoundaryManager {
     // concurrent failures from logging redundant messages or incorrectly calculating
     // the exponential backoff.
     if (cooldownState.compareAndSet(currentCooldownState, next)) {
-      LoggingUtils.log(
+      log(
           LOGGER_PROVIDER,
           Level.FINE,
           null,
-          "Regional Access Boundary lookup failed; entering cooldown for "
+          "Regional Access Boundary lookup was not successful; will retry after a cooldown of "
               + (next.durationMillis / 60000)
-              + "m. Error: "
+              + "m. This is handled automatically. Details: "
               + e.getMessage());
     }
   }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -37,6 +37,9 @@ import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -88,18 +91,20 @@ final class RegionalAccessBoundaryManager {
   private static final ExecutorService EXECUTOR;
 
   static {
-    java.util.concurrent.ThreadPoolExecutor executor =
-        new java.util.concurrent.ThreadPoolExecutor(
+    ThreadPoolExecutor executor =
+        new ThreadPoolExecutor(
             5, // corePoolSize: threads to keep alive
             5, // maximumPoolSize: max threads allowed
             1, // keepAliveTime: time to wait before terminating idle threads
-            java.util.concurrent.TimeUnit.HOURS, // unit for keepAliveTime
-            new java.util.concurrent.LinkedBlockingQueue<>(), // work queue
+            TimeUnit.HOURS, // unit for keepAliveTime
+            new LinkedBlockingQueue<>(), // work queue
             r -> {
               Thread t = new Thread(r, "RAB-refresh-" + threadCount.getAndIncrement());
               t.setDaemon(true);
               return t;
             });
+    // Allow core threads to time out so the executor can shrink to 0 when idle.
+    // Ensures threads are released when idle to avoid unnecessary resource usage.
     executor.allowCoreThreadTimeOut(true);
     EXECUTOR = executor;
   }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -88,12 +88,12 @@ final class RegionalAccessBoundaryManager {
   // on concurrent refresh tasks, while threadCount provides unique names
   // for easier debugging.
   private static final AtomicInteger threadCount = new AtomicInteger(0);
-  
+
   // Bounded executor service ensures hard limits on concurrent refresh tasks and queued tasks
   // to avoid resource exhaustion.
   private static final int EXECUTOR_POOL_SIZE = 5;
   private static final int EXECUTOR_QUEUE_CAPACITY = 100;
-  
+
   private static final ExecutorService EXECUTOR;
 
   static {

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -64,7 +64,7 @@ final class RegionalAccessBoundaryManager {
    * The default maximum elapsed time in milliseconds for retrying Regional Access Boundary lookup
    * requests.
    */
-  private static final int DEFAULT_MAX_RETRY_ELAPSED_TIME_MILLIS = 60000;
+  static final int DEFAULT_MAX_RETRY_ELAPSED_TIME_MILLIS = 60000;
 
   /**
    * cachedRAB uses AtomicReference to provide thread-safe, lock-free access to the cached data for
@@ -94,7 +94,7 @@ final class RegionalAccessBoundaryManager {
   private static final int EXECUTOR_POOL_SIZE = 5;
   private static final int EXECUTOR_QUEUE_CAPACITY = 100;
 
-  private static final ExecutorService EXECUTOR;
+  private static final ExecutorService DEFAULT_SHARED_EXECUTOR;
 
   static {
     ThreadPoolExecutor executor =
@@ -112,11 +112,12 @@ final class RegionalAccessBoundaryManager {
     // Allow core threads to time out so the executor can shrink to 0 when idle.
     // Ensures threads are released when idle to avoid unnecessary resource usage.
     executor.allowCoreThreadTimeOut(true);
-    EXECUTOR = executor;
+    DEFAULT_SHARED_EXECUTOR = executor;
   }
 
   private final transient Clock clock;
   private final int maxRetryElapsedTimeMillis;
+  private final ExecutorService executor;
 
   /**
    * Creates a new RegionalAccessBoundaryManager with the default retry timeout of 60 seconds.
@@ -124,13 +125,20 @@ final class RegionalAccessBoundaryManager {
    * @param clock The clock to use for cooldown and expiration checks.
    */
   RegionalAccessBoundaryManager(Clock clock) {
-    this(clock, DEFAULT_MAX_RETRY_ELAPSED_TIME_MILLIS);
+    this(clock, DEFAULT_MAX_RETRY_ELAPSED_TIME_MILLIS, DEFAULT_SHARED_EXECUTOR);
   }
 
   @VisibleForTesting
   RegionalAccessBoundaryManager(Clock clock, int maxRetryElapsedTimeMillis) {
+    this(clock, maxRetryElapsedTimeMillis, DEFAULT_SHARED_EXECUTOR);
+  }
+
+  @VisibleForTesting
+  RegionalAccessBoundaryManager(
+      Clock clock, int maxRetryElapsedTimeMillis, ExecutorService executor) {
     this.clock = clock != null ? clock : Clock.SYSTEM;
     this.maxRetryElapsedTimeMillis = maxRetryElapsedTimeMillis;
+    this.executor = executor;
   }
 
   /**
@@ -203,12 +211,15 @@ final class RegionalAccessBoundaryManager {
           };
 
       try {
-        EXECUTOR.submit(refreshTask);
+        this.executor.submit(refreshTask);
       } catch (Exception | Error e) {
         // If scheduling fails (e.g., RejectedExecutionException, OutOfMemoryError for threads),
         // the task's finally block will never execute. We must release the lock here.
-        handleRefreshFailure(
-            new Exception("Regional Access Boundary background refresh failed to schedule", e));
+        LoggingUtils.log(
+            LOGGER_PROVIDER,
+            java.util.logging.Level.WARNING,
+            null,
+            "Regional Access Boundary background refresh failed to schedule: " + e.getMessage());
         future.setException(e);
         refreshFuture.set(null);
       }

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 import static com.google.auth.Credentials.GOOGLE_DEFAULT_UNIVERSE;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -134,9 +135,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -166,9 +165,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationUrl(
                 transportFactory.transport.getServiceAccountImpersonationUrl())
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -201,9 +198,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationOptions(
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -241,9 +236,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -275,9 +268,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationUrl(
                 transportFactory.transport.getServiceAccountImpersonationUrl())
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -301,9 +292,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -348,9 +337,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -424,9 +411,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -472,9 +457,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -514,9 +497,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS region.", exception.getMessage());
@@ -542,9 +523,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS IAM role.", exception.getMessage());
@@ -573,9 +552,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS credentials.", exception.getMessage());
@@ -607,9 +584,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(new AwsCredentialSource(credentialSource))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals(
@@ -638,9 +613,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -683,9 +656,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -736,9 +707,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     assertDoesNotThrow(awsCredential::retrieveSubjectToken);
   }
@@ -761,9 +730,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("test", exception.getMessage());
@@ -781,8 +748,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock));
+        createDummyRab(testAwsCredentials.clock));
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -817,8 +783,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credSource)
             .build();
     testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock));
+        createDummyRab(testAwsCredentials.clock));
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -842,8 +807,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock));
+        createDummyRab(testAwsCredentials.clock));
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -863,9 +827,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     AwsSecurityCredentials credentials =
         awsCredential.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -898,9 +860,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(new AwsCredentialSource(credentialSource))
             .build();
-    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredential.clock));
 
     IOException exception =
         assertThrows(
@@ -929,9 +889,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
-    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock));
+    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredentials.clock));
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -957,9 +915,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
-    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock));
+    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredentials.clock));
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -981,9 +937,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
-    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock));
+    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(awsCredentials.clock));
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -1012,16 +966,12 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setUniverseDomain("universeDomain")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     AwsCredentials newCredentials = (AwsCredentials) credentials.createScoped(newScopes);
-    newCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock));
+    newCredentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(newCredentials.clock));
 
     assertEquals(credentials.getAudience(), newCredentials.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newCredentials.getSubjectTokenType());
@@ -1097,9 +1047,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setUniverseDomain("universeDomain")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -1136,9 +1084,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertEquals("https://test.com", credentials.getRegionalCredentialVerificationUrlOverride());
     assertEquals("audience", credentials.getAudience());
@@ -1176,14 +1122,11 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setUniverseDomain("universeDomain")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     AwsCredentials newBuilderCreds = AwsCredentials.newBuilder(credentials).build();
     newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock));
+        createDummyRab(newBuilderCreds.clock));
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1219,14 +1162,11 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     AwsCredentials newBuilderCreds = AwsCredentials.newBuilder(credentials).build();
     newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock));
+        createDummyRab(newBuilderCreds.clock));
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1264,9 +1204,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertNull(credentials.getRegionalCredentialVerificationUrlOverride());
     assertEquals(
@@ -1347,8 +1285,7 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .build();
     testCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock));
+        createDummyRab(testCredentials.clock));
 
     AwsCredentials deserializedCredentials = serializeAndDeserialize(testCredentials);
     assertEquals(testCredentials, deserializedCredentials);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -134,6 +134,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -163,6 +166,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationUrl(
                 transportFactory.transport.getServiceAccountImpersonationUrl())
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -195,6 +201,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationOptions(
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -232,6 +241,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -263,6 +275,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationUrl(
                 transportFactory.transport.getServiceAccountImpersonationUrl())
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -286,6 +301,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -330,6 +348,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -403,6 +424,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -448,6 +472,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -487,6 +514,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS region.", exception.getMessage());
@@ -512,6 +542,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS IAM role.", exception.getMessage());
@@ -540,6 +573,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS credentials.", exception.getMessage());
@@ -571,6 +607,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(new AwsCredentialSource(credentialSource))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals(
@@ -599,6 +638,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -641,6 +683,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -691,6 +736,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     assertDoesNotThrow(awsCredential::retrieveSubjectToken);
   }
@@ -713,6 +761,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(STS_URL)
             .setSubjectTokenType("subjectTokenType")
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("test", exception.getMessage());
@@ -729,6 +780,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
         AwsCredentials.newBuilder(AWS_CREDENTIAL)
             .setEnvironmentProvider(environmentProvider)
             .build();
+    testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock)
+    );
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -762,6 +816,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .setCredentialSource(credSource)
             .build();
+    testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock)
+    );
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -784,6 +841,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
         AwsCredentials.newBuilder(AWS_CREDENTIAL)
             .setEnvironmentProvider(environmentProvider)
             .build();
+    testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock)
+    );
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -803,6 +863,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     AwsSecurityCredentials credentials =
         awsCredential.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -835,6 +898,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(new AwsCredentialSource(credentialSource))
             .build();
+    awsCredential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
+    );
 
     IOException exception =
         assertThrows(
@@ -863,6 +929,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
+    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock)
+    );
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -888,6 +957,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .setEnvironmentProvider(environmentProvider)
             .build();
+    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock)
+    );
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -909,6 +981,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
+    awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock)
+    );
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -937,10 +1012,16 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setUniverseDomain("universeDomain")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     AwsCredentials newCredentials = (AwsCredentials) credentials.createScoped(newScopes);
+    newCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock)
+    );
 
     assertEquals(credentials.getAudience(), newCredentials.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newCredentials.getSubjectTokenType());
@@ -1016,6 +1097,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setUniverseDomain("universeDomain")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -1052,6 +1136,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertEquals("https://test.com", credentials.getRegionalCredentialVerificationUrlOverride());
     assertEquals("audience", credentials.getAudience());
@@ -1089,8 +1176,14 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setUniverseDomain("universeDomain")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     AwsCredentials newBuilderCreds = AwsCredentials.newBuilder(credentials).build();
+    newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
+    );
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1126,8 +1219,14 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     AwsCredentials newBuilderCreds = AwsCredentials.newBuilder(credentials).build();
+    newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
+    );
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1165,6 +1264,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertNull(credentials.getRegionalCredentialVerificationUrlOverride());
     assertEquals(
@@ -1244,6 +1346,9 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .setScopes(scopes)
             .build();
+    testCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock)
+    );
 
     AwsCredentials deserializedCredentials = serializeAndDeserialize(testCredentials);
     assertEquals(testCredentials, deserializedCredentials);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -65,11 +65,6 @@ class AwsCredentialsTest extends BaseSerializationTest {
   @org.junit.jupiter.api.BeforeEach
   void setUp() {}
 
-  @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
-
   private static final String STS_URL = "https://sts.googleapis.com/v1/token";
   private static final String AWS_CREDENTIALS_URL = "https://169.254.169.254";
   private static final String AWS_CREDENTIALS_URL_WITH_ROLE = "https://169.254.169.254/roleName";
@@ -1369,9 +1364,6 @@ class AwsCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void testRefresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
 
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -135,8 +135,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -167,8 +167,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
                 transportFactory.transport.getServiceAccountImpersonationUrl())
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -202,8 +202,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -242,8 +242,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("subjectTokenType")
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -276,8 +276,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
                 transportFactory.transport.getServiceAccountImpersonationUrl())
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -302,8 +302,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -349,8 +349,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -425,8 +425,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -473,8 +473,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -515,8 +515,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS region.", exception.getMessage());
@@ -543,8 +543,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS IAM role.", exception.getMessage());
@@ -574,8 +574,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("Failed to retrieve AWS credentials.", exception.getMessage());
@@ -608,8 +608,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(new AwsCredentialSource(credentialSource))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals(
@@ -639,8 +639,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("subjectTokenType")
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -684,8 +684,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("subjectTokenType")
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -737,8 +737,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("subjectTokenType")
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     assertDoesNotThrow(awsCredential::retrieveSubjectToken);
   }
@@ -762,8 +762,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("subjectTokenType")
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     IOException exception = assertThrows(IOException.class, awsCredential::retrieveSubjectToken);
     assertEquals("test", exception.getMessage());
@@ -781,8 +781,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock));
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -817,8 +817,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credSource)
             .build();
     testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock));
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -842,8 +842,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     testAwsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), testAwsCredentials.clock));
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -864,8 +864,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     AwsSecurityCredentials credentials =
         awsCredential.getAwsSecurityCredentialsSupplier().getCredentials(emptyContext);
@@ -899,8 +899,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(new AwsCredentialSource(credentialSource))
             .build();
     awsCredential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredential.clock));
 
     IOException exception =
         assertThrows(
@@ -930,8 +930,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock));
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -958,8 +958,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setEnvironmentProvider(environmentProvider)
             .build();
     awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock));
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -982,8 +982,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(buildAwsCredentialSource(transportFactory))
             .build();
     awsCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), awsCredentials.clock));
 
     String region = awsCredentials.getAwsSecurityCredentialsSupplier().getRegion(emptyContext);
 
@@ -1013,15 +1013,15 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     AwsCredentials newCredentials = (AwsCredentials) credentials.createScoped(newScopes);
     newCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock));
 
     assertEquals(credentials.getAudience(), newCredentials.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newCredentials.getSubjectTokenType());
@@ -1098,8 +1098,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -1137,8 +1137,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertEquals("https://test.com", credentials.getRegionalCredentialVerificationUrlOverride());
     assertEquals("audience", credentials.getAudience());
@@ -1177,13 +1177,13 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     AwsCredentials newBuilderCreds = AwsCredentials.newBuilder(credentials).build();
     newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock));
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1220,13 +1220,13 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     AwsCredentials newBuilderCreds = AwsCredentials.newBuilder(credentials).build();
     newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock));
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1265,8 +1265,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertNull(credentials.getRegionalCredentialVerificationUrlOverride());
     assertEquals(
@@ -1347,8 +1347,8 @@ class AwsCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .build();
     testCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock));
 
     AwsCredentials deserializedCredentials = serializeAndDeserialize(testCredentials);
     assertEquals(testCredentials, deserializedCredentials);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -34,6 +34,7 @@ package com.google.auth.oauth2;
 import static com.google.auth.oauth2.ComputeEngineCredentials.METADATA_RESPONSE_EMPTY_CONTENT_ERROR_MESSAGE;
 import static com.google.auth.oauth2.ImpersonatedCredentialsTest.SA_CLIENT_EMAIL;
 import static com.google.auth.oauth2.RegionalAccessBoundary.X_ALLOWED_LOCATIONS_HEADER_KEY;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -393,9 +394,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(SA_CLIENT_EMAIL);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -412,9 +411,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -423,8 +420,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials scopedCredentialCopy =
         (ComputeEngineCredentials) credentials.createScoped(SCOPES);
     scopedCredentialCopy.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentialCopy.clock));
+        createDummyRab(scopedCredentialCopy.clock));
     assertNull(scopedCredentialCopy.getAccessToken());
     Map<String, List<String>> metadataForCopiedCredentials =
         scopedCredentialCopy.getRequestMetadata(CALL_URI);
@@ -439,9 +435,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(CALL_URI));
     String message = exception.getMessage();
@@ -457,9 +451,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(CALL_URI));
     String message = exception.getMessage();
@@ -583,9 +575,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertEquals(defaultAccountEmail, credentials.getAccount());
 
@@ -619,9 +609,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     RuntimeException exception = assertThrows(RuntimeException.class, credentials::getAccount);
     assertEquals("Failed to get service account", exception.getMessage());
@@ -653,9 +641,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     RuntimeException exception = assertThrows(RuntimeException.class, credentials::getAccount);
     assertEquals("Failed to get service account", exception.getMessage());
@@ -673,9 +659,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setSignature(expectedSignature);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertArrayEquals(expectedSignature, credentials.sign(expectedSignature));
   }
@@ -688,9 +672,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transportFactory.transport.setStatusCode(501);
     assertThrows(IOException.class, credentials::getUniverseDomain);
@@ -709,9 +691,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setSignature(expectedSignature);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     SigningException exception =
         assertThrows(SigningException.class, () -> credentials.sign(expectedSignature));
@@ -747,9 +727,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -788,9 +766,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -822,9 +798,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     IOException exception = assertThrows(IOException.class, credentials::refreshAccessToken);
     assertTrue(exception.getCause().getMessage().contains("503"));
@@ -888,9 +862,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals("some-universe.xyz", universeDomain);
@@ -918,9 +890,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, universeDomain);
@@ -948,9 +918,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, universeDomain);
@@ -997,9 +965,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     for (int status = 400; status < 600; status++) {
       // 404 should not throw and tested separately
@@ -1040,9 +1006,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -1059,9 +1023,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1082,9 +1044,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1104,9 +1064,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1133,9 +1091,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1164,9 +1120,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.idTokenWithAudience("Audience", null));
     assertEquals(
@@ -1184,9 +1138,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setEmptyContent(true);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.idTokenWithAudience("Audience", null));
     assertEquals(METADATA_RESPONSE_EMPTY_CONTENT_ERROR_MESSAGE, exception.getMessage());
@@ -1198,9 +1150,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     assertThrows(
         GoogleAuthException.class, () -> credentials.idTokenWithAudience("Audience", null));
   }
@@ -1225,9 +1175,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     String projectId = credentials.getProjectId();
     assertEquals("some-project-id", projectId);
   }
@@ -1238,9 +1186,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     assertNull(credentials.getProjectId());
   }
 
@@ -1250,9 +1196,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     assertNull(credentials.getProjectId());
   }
 
@@ -1262,9 +1206,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
         new MockRequestCountingTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     credentials.setProjectId("explicit.project_id");
 
     assertEquals("explicit.project_id", credentials.getProjectId());

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -393,6 +393,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(SA_CLIENT_EMAIL);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -409,6 +412,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -416,6 +422,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     assertNotNull(credentials.getAccessToken());
     ComputeEngineCredentials scopedCredentialCopy =
         (ComputeEngineCredentials) credentials.createScoped(SCOPES);
+    scopedCredentialCopy.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentialCopy.clock)
+    );
     assertNull(scopedCredentialCopy.getAccessToken());
     Map<String, List<String>> metadataForCopiedCredentials =
         scopedCredentialCopy.getRequestMetadata(CALL_URI);
@@ -430,6 +439,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(CALL_URI));
     String message = exception.getMessage();
@@ -445,6 +457,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(CALL_URI));
     String message = exception.getMessage();
@@ -568,6 +583,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertEquals(defaultAccountEmail, credentials.getAccount());
 
@@ -601,6 +619,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     RuntimeException exception = assertThrows(RuntimeException.class, credentials::getAccount);
     assertEquals("Failed to get service account", exception.getMessage());
@@ -632,6 +653,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     RuntimeException exception = assertThrows(RuntimeException.class, credentials::getAccount);
     assertEquals("Failed to get service account", exception.getMessage());
@@ -649,6 +673,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setSignature(expectedSignature);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertArrayEquals(expectedSignature, credentials.sign(expectedSignature));
   }
@@ -661,6 +688,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transportFactory.transport.setStatusCode(501);
     assertThrows(IOException.class, credentials::getUniverseDomain);
@@ -679,6 +709,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setSignature(expectedSignature);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     SigningException exception =
         assertThrows(SigningException.class, () -> credentials.sign(expectedSignature));
@@ -714,6 +747,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -752,6 +788,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -783,6 +822,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     IOException exception = assertThrows(IOException.class, credentials::refreshAccessToken);
     assertTrue(exception.getCause().getMessage().contains("503"));
@@ -846,6 +888,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals("some-universe.xyz", universeDomain);
@@ -873,6 +918,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, universeDomain);
@@ -900,6 +948,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, universeDomain);
@@ -946,6 +997,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     for (int status = 400; status < 600; status++) {
       // 404 should not throw and tested separately
@@ -986,6 +1040,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -1002,6 +1059,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1022,6 +1082,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1041,6 +1104,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1067,6 +1133,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1095,6 +1164,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     IOException exception =
         assertThrows(IOException.class, () -> credentials.idTokenWithAudience("Audience", null));
     assertEquals(
@@ -1112,6 +1184,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setEmptyContent(true);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     IOException exception =
         assertThrows(IOException.class, () -> credentials.idTokenWithAudience("Audience", null));
     assertEquals(METADATA_RESPONSE_EMPTY_CONTENT_ERROR_MESSAGE, exception.getMessage());
@@ -1123,6 +1198,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     assertThrows(
         GoogleAuthException.class, () -> credentials.idTokenWithAudience("Audience", null));
   }
@@ -1147,6 +1225,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     String projectId = credentials.getProjectId();
     assertEquals("some-project-id", projectId);
   }
@@ -1157,6 +1238,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     assertNull(credentials.getProjectId());
   }
 
@@ -1166,6 +1250,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     assertNull(credentials.getProjectId());
   }
 
@@ -1175,6 +1262,9 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
         new MockRequestCountingTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     credentials.setProjectId("explicit.project_id");
 
     assertEquals("explicit.project_id", credentials.getProjectId());

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -394,8 +394,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -413,8 +413,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -423,8 +423,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials scopedCredentialCopy =
         (ComputeEngineCredentials) credentials.createScoped(SCOPES);
     scopedCredentialCopy.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentialCopy.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentialCopy.clock));
     assertNull(scopedCredentialCopy.getAccessToken());
     Map<String, List<String>> metadataForCopiedCredentials =
         scopedCredentialCopy.getRequestMetadata(CALL_URI);
@@ -440,8 +440,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(CALL_URI));
     String message = exception.getMessage();
@@ -458,8 +458,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(CALL_URI));
     String message = exception.getMessage();
@@ -584,8 +584,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertEquals(defaultAccountEmail, credentials.getAccount());
 
@@ -620,8 +620,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     RuntimeException exception = assertThrows(RuntimeException.class, credentials::getAccount);
     assertEquals("Failed to get service account", exception.getMessage());
@@ -654,8 +654,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     RuntimeException exception = assertThrows(RuntimeException.class, credentials::getAccount);
     assertEquals("Failed to get service account", exception.getMessage());
@@ -674,8 +674,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertArrayEquals(expectedSignature, credentials.sign(expectedSignature));
   }
@@ -689,8 +689,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transportFactory.transport.setStatusCode(501);
     assertThrows(IOException.class, credentials::getUniverseDomain);
@@ -710,8 +710,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     SigningException exception =
         assertThrows(SigningException.class, () -> credentials.sign(expectedSignature));
@@ -748,8 +748,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -789,8 +789,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -823,8 +823,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     IOException exception = assertThrows(IOException.class, credentials::refreshAccessToken);
     assertTrue(exception.getCause().getMessage().contains("503"));
@@ -889,8 +889,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals("some-universe.xyz", universeDomain);
@@ -919,8 +919,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, universeDomain);
@@ -949,8 +949,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String universeDomain = credentials.getUniverseDomain();
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, universeDomain);
@@ -998,8 +998,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     for (int status = 400; status < 600; status++) {
       // 404 should not throw and tested separately
@@ -1041,8 +1041,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     byte[] bytes = {0xD, 0xE, 0xA, 0xD};
 
@@ -1060,8 +1060,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1083,8 +1083,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1105,8 +1105,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1134,8 +1134,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1165,8 +1165,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.idTokenWithAudience("Audience", null));
     assertEquals(
@@ -1185,8 +1185,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.idTokenWithAudience("Audience", null));
     assertEquals(METADATA_RESPONSE_EMPTY_CONTENT_ERROR_MESSAGE, exception.getMessage());
@@ -1199,8 +1199,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     assertThrows(
         GoogleAuthException.class, () -> credentials.idTokenWithAudience("Audience", null));
   }
@@ -1226,8 +1226,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     String projectId = credentials.getProjectId();
     assertEquals("some-project-id", projectId);
   }
@@ -1239,8 +1239,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     assertNull(credentials.getProjectId());
   }
 
@@ -1251,8 +1251,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     assertNull(credentials.getProjectId());
   }
 
@@ -1263,8 +1263,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     credentials.setProjectId("explicit.project_id");
 
     assertEquals("explicit.project_id", credentials.getProjectId());

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -80,11 +80,6 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
   @org.junit.jupiter.api.BeforeEach
   void setUp() {}
 
-  @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
-
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
 
   private static final String TOKEN_URL =
@@ -1188,9 +1183,6 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
   @org.junit.jupiter.api.Test
   void refresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
 
     String defaultAccountEmail = "default@email.com";
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 import static com.google.auth.Credentials.GOOGLE_DEFAULT_UNIVERSE;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -706,9 +707,7 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
   void getRequestMetadata() throws IOException {
     GoogleCredentials credentials =
         ExternalAccountAuthorizedUserCredentials.fromJson(buildJsonCredentials(), transportFactory);
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -720,9 +719,7 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
   void getRequestMetadata_withQuotaProjectId() throws IOException {
     GoogleCredentials credentials =
         ExternalAccountAuthorizedUserCredentials.fromJson(buildJsonCredentials(), transportFactory);
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -741,9 +738,7 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
             .setHttpTransportFactory(transportFactory)
             .setAccessToken(new AccessToken(ACCESS_TOKEN, /* expirationTime= */ null))
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
@@ -130,9 +130,7 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
   }
 
   @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
+  void tearDown() {}
 
   @Test
   void builder_allFields() throws IOException {
@@ -1243,9 +1241,6 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
 
   @org.junit.jupiter.api.Test
   void testRefresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
 
     ExternalAccountAuthorizedUserCredentials credentials =
         ExternalAccountAuthorizedUserCredentials.newBuilder()

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
@@ -707,8 +707,8 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
     GoogleCredentials credentials =
         ExternalAccountAuthorizedUserCredentials.fromJson(buildJsonCredentials(), transportFactory);
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -721,8 +721,8 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
     GoogleCredentials credentials =
         ExternalAccountAuthorizedUserCredentials.fromJson(buildJsonCredentials(), transportFactory);
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -742,8 +742,8 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
             .setAccessToken(new AccessToken(ACCESS_TOKEN, /* expirationTime= */ null))
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentialsTest.java
@@ -706,6 +706,9 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
   void getRequestMetadata() throws IOException {
     GoogleCredentials credentials =
         ExternalAccountAuthorizedUserCredentials.fromJson(buildJsonCredentials(), transportFactory);
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -717,6 +720,9 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
   void getRequestMetadata_withQuotaProjectId() throws IOException {
     GoogleCredentials credentials =
         ExternalAccountAuthorizedUserCredentials.fromJson(buildJsonCredentials(), transportFactory);
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -735,6 +741,9 @@ class ExternalAccountAuthorizedUserCredentialsTest extends BaseSerializationTest
             .setHttpTransportFactory(transportFactory)
             .setAccessToken(new AccessToken(ACCESS_TOKEN, /* expirationTime= */ null))
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -92,11 +92,6 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
     transportFactory = new MockExternalAccountCredentialsTransportFactory();
   }
 
-  @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
-
   @Test
   void fromStream_identityPoolCredentials() throws IOException {
     GenericJson json = buildJsonIdentityPoolCredential();
@@ -1302,9 +1297,7 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void refresh_workload_regionalAccessBoundarySuccess()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     String audience =
         "//iam.googleapis.com/projects/12345/locations/global/workloadIdentityPools/my-pool/providers/my-provider";
 
@@ -1339,9 +1332,7 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void refresh_workforce_regionalAccessBoundarySuccess()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     String audience =
         "//iam.googleapis.com/locations/global/workforcePools/my-pool/providers/my-provider";
 
@@ -1376,9 +1367,7 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void refresh_impersonated_workload_regionalAccessBoundarySuccess()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     String projectNumber = "12345";
     String poolId = "my-pool";
     String providerId = "my-provider";
@@ -1440,9 +1429,7 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void refresh_impersonated_workforce_regionalAccessBoundarySuccess()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     String poolId = "my-pool";
     String providerId = "my-provider";
     String audience =

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -1108,6 +1108,9 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
                 .setCredentialSource(new TestCredentialSource(FILE_CREDENTIAL_SOURCE_MAP))
                 .setQuotaProjectId("quotaProjectId")
                 .build();
+    testCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock)
+    );
 
     Map<String, List<String>> requestMetadata =
         testCredentials.getRequestMetadata(URI.create("http://googleapis.com/foo/bar"));

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -1109,8 +1109,8 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
                 .setQuotaProjectId("quotaProjectId")
                 .build();
     testCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock));
 
     Map<String, List<String>> requestMetadata =
         testCredentials.getRequestMetadata(URI.create("http://googleapis.com/foo/bar"));

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -35,6 +35,7 @@ import static com.google.auth.oauth2.MockExternalAccountCredentialsTransport.SER
 import static com.google.auth.oauth2.OAuth2Utils.IAM_CREDENTIALS_ALLOWED_LOCATIONS_URL_FORMAT_SERVICE_ACCOUNT;
 import static com.google.auth.oauth2.OAuth2Utils.IAM_CREDENTIALS_ALLOWED_LOCATIONS_URL_FORMAT_WORKFORCE_POOL;
 import static com.google.auth.oauth2.OAuth2Utils.IAM_CREDENTIALS_ALLOWED_LOCATIONS_URL_FORMAT_WORKLOAD_POOL;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -1109,8 +1110,7 @@ class ExternalAccountCredentialsTest extends BaseSerializationTest {
                 .setQuotaProjectId("quotaProjectId")
                 .build();
     testCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock));
+        createDummyRab(testCredentials.clock));
 
     Map<String, List<String>> requestMetadata =
         testCredentials.getRequestMetadata(URI.create("http://googleapis.com/foo/bar"));

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -109,9 +109,7 @@ class GoogleCredentialsTest extends BaseSerializationTest {
   void setUp() {}
 
   @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
+  void tearDown() {}
 
   @Test
   void getApplicationDefault_nullTransport_throws() {
@@ -858,9 +856,6 @@ class GoogleCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void serialize_removesStaleRabHeaders() throws Exception {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
 
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     RegionalAccessBoundary rab =
@@ -1046,9 +1041,7 @@ class GoogleCredentialsTest extends BaseSerializationTest {
   @Test
   public void regionalAccessBoundary_shouldFetchAndReturnRegionalAccessBoundaryDataSuccessfully()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     MockTokenServerTransport transport = new MockTokenServerTransport();
     transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     RegionalAccessBoundary regionalAccessBoundary =
@@ -1083,9 +1076,6 @@ class GoogleCredentialsTest extends BaseSerializationTest {
   @Test
   public void regionalAccessBoundary_shouldRetryRegionalAccessBoundaryLookupOnFailure()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
 
     // This transport will be used for the regional access boundary lookup.
     // We will configure it to fail on the first attempt.
@@ -1137,9 +1127,7 @@ class GoogleCredentialsTest extends BaseSerializationTest {
   @Test
   public void regionalAccessBoundary_refreshShouldNotThrowWhenNoValidAccessTokenIsPassed()
       throws IOException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     MockTokenServerTransport transport = new MockTokenServerTransport();
     // Return an expired access token.
     transport.addServiceAccount(SA_CLIENT_EMAIL, "expired-token");
@@ -1162,9 +1150,7 @@ class GoogleCredentialsTest extends BaseSerializationTest {
   @Test
   public void regionalAccessBoundary_cooldownDoublingAndRefresh()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     MockTokenServerTransport transport = new MockTokenServerTransport();
     transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     // Always fail lookup for now.
@@ -1224,9 +1210,7 @@ class GoogleCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void regionalAccessBoundary_shouldFailOpenWhenRefreshCannotBeStarted() throws IOException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     // Use a simple AccessToken-based credential that won't try to refresh.
     GoogleCredentials credentials = GoogleCredentials.create(new AccessToken("some-token", null));
 
@@ -1238,9 +1222,7 @@ class GoogleCredentialsTest extends BaseSerializationTest {
   @Test
   public void regionalAccessBoundary_deduplicationOfConcurrentRefreshes()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     MockTokenServerTransport transport = new MockTokenServerTransport();
     transport.setRegionalAccessBoundary(
         new RegionalAccessBoundary("valid", Collections.singletonList("us-central1"), null));
@@ -1269,9 +1251,7 @@ class GoogleCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void regionalAccessBoundary_shouldSkipRefreshForRegionalEndpoints() throws IOException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     MockTokenServerTransport transport = new MockTokenServerTransport();
     GoogleCredentials credentials = createTestCredentials(transport);
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
@@ -34,6 +34,7 @@ package com.google.auth.oauth2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 /** Test case for {@link IdTokenCredentials}. */
@@ -46,6 +47,9 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -72,6 +76,9 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -99,6 +106,9 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
@@ -31,10 +31,10 @@
 
 package com.google.auth.oauth2;
 
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 /** Test case for {@link IdTokenCredentials}. */
@@ -47,9 +47,7 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -76,9 +74,7 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -106,9 +102,7 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
@@ -48,8 +48,8 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -77,8 +77,8 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -107,8 +107,8 @@ class IdTokenCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -81,9 +81,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
   void setUp() {}
 
   @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
+  void tearDown() {}
 
   @Test
   void createdScoped_clonedCredentialWithAddedScopes() {
@@ -1312,9 +1310,6 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void testRefresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
 
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -94,15 +94,15 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     IdentityPoolCredentials newCredentials = credentials.createScoped(newScopes);
     newCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock));
 
     assertEquals(credentials.getAudience(), newCredentials.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newCredentials.getSubjectTokenType());
@@ -141,8 +141,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credentialSource)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String subjectToken = credentials.retrieveSubjectToken();
 
@@ -185,8 +185,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credentialSource)
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -226,8 +226,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credentialSource)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     IOException e = assertThrows(IOException.class, credentials::retrieveSubjectToken);
     assertEquals(
@@ -247,8 +247,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -275,8 +275,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credentialSource)
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -298,8 +298,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     IOException e = assertThrows(IOException.class, credential::retrieveSubjectToken);
     assertEquals(
@@ -318,8 +318,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenSupplier(testProvider)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String subjectToken = credentials.retrieveSubjectToken();
 
@@ -340,8 +340,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenSupplier(errorProvider)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     IOException e = assertThrows(IOException.class, credentials::retrieveSubjectToken);
     assertEquals("test", e.getMessage());
@@ -367,8 +367,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenSupplier(testSupplier)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     credentials.retrieveSubjectToken();
   }
@@ -391,8 +391,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -420,8 +420,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -460,8 +460,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -496,8 +496,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -535,8 +535,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -567,8 +567,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -600,8 +600,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setWorkforcePoolUserProject("userProject")
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -640,8 +640,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
     credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -826,8 +826,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -863,8 +863,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertEquals(testProvider, credentials.getIdentityPoolSubjectTokenSupplier());
   }
@@ -917,8 +917,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setQuotaProjectId("quotaProjectId")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertTrue(credentials.isWorkforcePoolConfiguration());
   }
@@ -974,8 +974,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -1014,14 +1014,14 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     IdentityPoolCredentials newBuilderCreds =
         IdentityPoolCredentials.newBuilder(credentials).build();
     newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock));
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1061,14 +1061,14 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setWorkforcePoolUserProject("workforcePoolUserProject")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     IdentityPoolCredentials newBuilderCreds =
         IdentityPoolCredentials.newBuilder(credentials).build();
     newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock));
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1098,8 +1098,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("universeDomain")
             .build();
     testCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock));
 
     IdentityPoolCredentials deserializedCredentials = serializeAndDeserialize(testCredentials);
     assertEquals(testCredentials, deserializedCredentials);
@@ -1130,8 +1130,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credentialSource)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     // Verify successful creation and correct internal setup.
     assertNotNull(credentials, "Credentials should be successfully created");
@@ -1175,8 +1175,8 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(credentialSource)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     // Verify successful creation and correct internal setup.
     assertNotNull(credentials, "Credentials should be successfully created");
@@ -1346,18 +1346,19 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
     IdentityPoolCredentialSource identityPoolCredentialSource =
         new IdentityPoolCredentialSource(fileCredentialSourceMap);
 
-    IdentityPoolCredentials credentials = IdentityPoolCredentials.newBuilder()
-        .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-        .setAudience(
-            "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-        .setSubjectTokenType("subjectTokenType")
-        .setTokenUrl(STS_URL)
-        .setTokenInfoUrl("tokenInfoUrl")
-        .setCredentialSource(identityPoolCredentialSource)
-        .build();
+    IdentityPoolCredentials credentials =
+        IdentityPoolCredentials.newBuilder()
+            .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+            .setAudience(
+                "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(identityPoolCredentialSource)
+            .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     return credentials;
   }
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -93,10 +93,16 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setUniverseDomain("universeDomain")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     IdentityPoolCredentials newCredentials = credentials.createScoped(newScopes);
+    newCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock)
+    );
 
     assertEquals(credentials.getAudience(), newCredentials.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newCredentials.getSubjectTokenType());
@@ -134,6 +140,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
         IdentityPoolCredentials.newBuilder(createBaseFileSourcedCredentials())
             .setCredentialSource(credentialSource)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String subjectToken = credentials.retrieveSubjectToken();
 
@@ -175,6 +184,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(credentialSource)
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -213,6 +225,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
         IdentityPoolCredentials.newBuilder(createBaseFileSourcedCredentials())
             .setCredentialSource(credentialSource)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     IOException e = assertThrows(IOException.class, credentials::retrieveSubjectToken);
     assertEquals(
@@ -231,6 +246,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -256,6 +274,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(credentialSource)
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -276,6 +297,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     IOException e = assertThrows(IOException.class, credential::retrieveSubjectToken);
     assertEquals(
@@ -293,6 +317,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(null)
             .setSubjectTokenSupplier(testProvider)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String subjectToken = credentials.retrieveSubjectToken();
 
@@ -312,6 +339,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(null)
             .setSubjectTokenSupplier(errorProvider)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     IOException e = assertThrows(IOException.class, credentials::retrieveSubjectToken);
     assertEquals("test", e.getMessage());
@@ -336,6 +366,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(null)
             .setSubjectTokenSupplier(testSupplier)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     credentials.retrieveSubjectToken();
   }
@@ -357,6 +390,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -383,6 +419,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -420,6 +459,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -453,6 +495,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationOptions(
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -489,6 +534,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(transportFactory.transport.getStsUrl())
             .setHttpTransportFactory(transportFactory)
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -518,6 +566,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(transportFactory.transport.getStsUrl())
             .setHttpTransportFactory(transportFactory)
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -548,6 +599,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .setWorkforcePoolUserProject("userProject")
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -585,6 +639,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationOptions(
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
+    credential.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credential.clock)
+    );
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -768,6 +825,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setUniverseDomain("universeDomain")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -802,6 +862,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertEquals(testProvider, credentials.getIdentityPoolSubjectTokenSupplier());
   }
@@ -853,6 +916,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(createFileCredentialSource())
             .setQuotaProjectId("quotaProjectId")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertTrue(credentials.isWorkforcePoolConfiguration());
   }
@@ -907,6 +973,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -944,9 +1013,15 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setWorkforcePoolUserProject("workforcePoolUserProject")
             .setUniverseDomain("universeDomain")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     IdentityPoolCredentials newBuilderCreds =
         IdentityPoolCredentials.newBuilder(credentials).build();
+    newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
+    );
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -985,9 +1060,15 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setWorkforcePoolUserProject("workforcePoolUserProject")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     IdentityPoolCredentials newBuilderCreds =
         IdentityPoolCredentials.newBuilder(credentials).build();
+    newBuilderCreds.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), newBuilderCreds.clock)
+    );
     assertEquals(credentials.getAudience(), newBuilderCreds.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newBuilderCreds.getSubjectTokenType());
     assertEquals(credentials.getTokenUrl(), newBuilderCreds.getTokenUrl());
@@ -1016,6 +1097,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setUniverseDomain("universeDomain")
             .build();
+    testCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), testCredentials.clock)
+    );
 
     IdentityPoolCredentials deserializedCredentials = serializeAndDeserialize(testCredentials);
     assertEquals(testCredentials, deserializedCredentials);
@@ -1045,6 +1129,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("test-token-type")
             .setCredentialSource(credentialSource)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     // Verify successful creation and correct internal setup.
     assertNotNull(credentials, "Credentials should be successfully created");
@@ -1087,6 +1174,9 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("test-token-type")
             .setCredentialSource(credentialSource)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     // Verify successful creation and correct internal setup.
     assertNotNull(credentials, "Credentials should be successfully created");
@@ -1256,7 +1346,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
     IdentityPoolCredentialSource identityPoolCredentialSource =
         new IdentityPoolCredentialSource(fileCredentialSourceMap);
 
-    return IdentityPoolCredentials.newBuilder()
+    IdentityPoolCredentials credentials = IdentityPoolCredentials.newBuilder()
         .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
         .setAudience(
             "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
@@ -1265,6 +1355,10 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
         .setTokenInfoUrl("tokenInfoUrl")
         .setCredentialSource(identityPoolCredentialSource)
         .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
+    return credentials;
   }
 
   private IdentityPoolCredentialSource createFileCredentialSource() {

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -34,6 +34,7 @@ package com.google.auth.oauth2;
 import static com.google.auth.Credentials.GOOGLE_DEFAULT_UNIVERSE;
 import static com.google.auth.oauth2.MockExternalAccountCredentialsTransport.SERVICE_ACCOUNT_IMPERSONATION_URL;
 import static com.google.auth.oauth2.OAuth2Utils.JSON_FACTORY;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -93,16 +94,12 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setUniverseDomain("universeDomain")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     IdentityPoolCredentials newCredentials = credentials.createScoped(newScopes);
-    newCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), newCredentials.clock));
+    newCredentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(newCredentials.clock));
 
     assertEquals(credentials.getAudience(), newCredentials.getAudience());
     assertEquals(credentials.getSubjectTokenType(), newCredentials.getSubjectTokenType());
@@ -140,9 +137,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
         IdentityPoolCredentials.newBuilder(createBaseFileSourcedCredentials())
             .setCredentialSource(credentialSource)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String subjectToken = credentials.retrieveSubjectToken();
 
@@ -184,9 +179,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(credentialSource)
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -225,9 +218,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
         IdentityPoolCredentials.newBuilder(createBaseFileSourcedCredentials())
             .setCredentialSource(credentialSource)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     IOException e = assertThrows(IOException.class, credentials::retrieveSubjectToken);
     assertEquals(
@@ -246,9 +237,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -274,9 +263,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setCredentialSource(credentialSource)
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -297,9 +284,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     IOException e = assertThrows(IOException.class, credential::retrieveSubjectToken);
     assertEquals(
@@ -317,9 +302,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(null)
             .setSubjectTokenSupplier(testProvider)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String subjectToken = credentials.retrieveSubjectToken();
 
@@ -339,9 +322,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(null)
             .setSubjectTokenSupplier(errorProvider)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     IOException e = assertThrows(IOException.class, credentials::retrieveSubjectToken);
     assertEquals("test", e.getMessage());
@@ -366,9 +347,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(null)
             .setSubjectTokenSupplier(testSupplier)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     credentials.retrieveSubjectToken();
   }
@@ -390,9 +369,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -419,9 +396,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -459,9 +434,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -495,9 +468,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationOptions(
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -534,9 +505,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(transportFactory.transport.getStsUrl())
             .setHttpTransportFactory(transportFactory)
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -566,9 +535,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setTokenUrl(transportFactory.transport.getStsUrl())
             .setHttpTransportFactory(transportFactory)
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -599,9 +566,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
                 buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
             .setWorkforcePoolUserProject("userProject")
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -639,9 +604,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setServiceAccountImpersonationOptions(
                 ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions())
             .build();
-    credential.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credential.clock));
+    credential.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credential.clock));
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -825,9 +788,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setUniverseDomain("universeDomain")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -862,9 +823,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertEquals(testProvider, credentials.getIdentityPoolSubjectTokenSupplier());
   }
@@ -916,9 +875,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setCredentialSource(createFileCredentialSource())
             .setQuotaProjectId("quotaProjectId")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertTrue(credentials.isWorkforcePoolConfiguration());
   }
@@ -973,9 +930,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setClientSecret("clientSecret")
             .setScopes(scopes)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -1013,9 +968,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setWorkforcePoolUserProject("workforcePoolUserProject")
             .setUniverseDomain("universeDomain")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     IdentityPoolCredentials newBuilderCreds =
         IdentityPoolCredentials.newBuilder(credentials).build();
@@ -1060,9 +1013,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setScopes(scopes)
             .setWorkforcePoolUserProject("workforcePoolUserProject")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     IdentityPoolCredentials newBuilderCreds =
         IdentityPoolCredentials.newBuilder(credentials).build();
@@ -1129,9 +1080,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("test-token-type")
             .setCredentialSource(credentialSource)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     // Verify successful creation and correct internal setup.
     assertNotNull(credentials, "Credentials should be successfully created");
@@ -1174,9 +1123,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setSubjectTokenType("test-token-type")
             .setCredentialSource(credentialSource)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     // Verify successful creation and correct internal setup.
     assertNotNull(credentials, "Credentials should be successfully created");
@@ -1356,9 +1303,7 @@ class IdentityPoolCredentialsTest extends BaseSerializationTest {
             .setTokenInfoUrl("tokenInfoUrl")
             .setCredentialSource(identityPoolCredentialSource)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     return credentials;
   }
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -163,11 +163,6 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory = new MockIAMCredentialsServiceTransportFactory();
   }
 
-  @org.junit.After
-  public void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
-
   static GoogleCredentials getSourceCredentials() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     PrivateKey privateKey = OAuth2Utils.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
@@ -1276,9 +1271,7 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
   @Test
   void refresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     // Mock regional access boundary response
     RegionalAccessBoundary regionalAccessBoundary = REGIONAL_ACCESS_BOUNDARY;
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -176,8 +176,8 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     sourceCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), sourceCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), sourceCredentials.clock));
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     transportFactory.transport.setRegionalAccessBoundary(REGIONAL_ACCESS_BOUNDARY);
 
@@ -596,8 +596,8 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             mockTransportFactory,
             QUOTA_PROJECT_ID);
     targetCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock));
 
     Map<String, List<String>> metadata = targetCredentials.getRequestMetadata();
     assertTrue(metadata.containsKey("x-goog-user-project"));
@@ -621,8 +621,8 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             VALID_LIFETIME,
             mockTransportFactory);
     targetCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock));
 
     Map<String, List<String>> metadata = targetCredentials.getRequestMetadata();
     assertFalse(metadata.containsKey("x-goog-user-project"));

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 import static com.google.auth.oauth2.RegionalAccessBoundary.X_ALLOWED_LOCATIONS_HEADER_KEY;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -176,8 +177,7 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     sourceCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), sourceCredentials.clock));
+        createDummyRab(sourceCredentials.clock));
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     transportFactory.transport.setRegionalAccessBoundary(REGIONAL_ACCESS_BOUNDARY);
 
@@ -596,8 +596,7 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             mockTransportFactory,
             QUOTA_PROJECT_ID);
     targetCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock));
+        createDummyRab(targetCredentials.clock));
 
     Map<String, List<String>> metadata = targetCredentials.getRequestMetadata();
     assertTrue(metadata.containsKey("x-goog-user-project"));
@@ -621,8 +620,7 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             VALID_LIFETIME,
             mockTransportFactory);
     targetCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock));
+        createDummyRab(targetCredentials.clock));
 
     Map<String, List<String>> metadata = targetCredentials.getRequestMetadata();
     assertFalse(metadata.containsKey("x-goog-user-project"));

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -175,6 +175,9 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(transportFactory)
             .build();
+    sourceCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), sourceCredentials.clock)
+    );
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     transportFactory.transport.setRegionalAccessBoundary(REGIONAL_ACCESS_BOUNDARY);
 
@@ -592,6 +595,9 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             VALID_LIFETIME,
             mockTransportFactory,
             QUOTA_PROJECT_ID);
+    targetCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock)
+    );
 
     Map<String, List<String>> metadata = targetCredentials.getRequestMetadata();
     assertTrue(metadata.containsKey("x-goog-user-project"));
@@ -614,6 +620,9 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
             IMMUTABLE_SCOPES_LIST,
             VALID_LIFETIME,
             mockTransportFactory);
+    targetCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), targetCredentials.clock)
+    );
 
     Map<String, List<String>> metadata = targetCredentials.getRequestMetadata();
     assertFalse(metadata.containsKey("x-goog-user-project"));

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
@@ -43,6 +43,7 @@ import static com.google.auth.oauth2.ServiceAccountCredentialsTest.CLIENT_EMAIL;
 import static com.google.auth.oauth2.ServiceAccountCredentialsTest.DEFAULT_ID_TOKEN;
 import static com.google.auth.oauth2.ServiceAccountCredentialsTest.SCOPES;
 import static com.google.auth.oauth2.ServiceAccountCredentialsTest.createDefaultBuilder;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static com.google.auth.oauth2.UserCredentialsTest.CLIENT_ID;
 import static com.google.auth.oauth2.UserCredentialsTest.CLIENT_SECRET;
 import static com.google.auth.oauth2.UserCredentialsTest.REFRESH_TOKEN;
@@ -76,7 +77,7 @@ import org.slf4j.event.KeyValuePair;
  * credentials test classes with addition of test logging appender setup and test logic for logging.
  * This duplicates tests setups, but centralizes logging test setup in this class.
  */
-public class LoggingTest {
+class LoggingTest {
 
   private TestAppender setupTestLogger(Class<?> clazz) {
     TestAppender testAppender = new TestAppender();
@@ -167,9 +168,7 @@ public class LoggingTest {
         ServiceAccountCredentialsTest.createDefaultBuilderWithToken(ACCESS_TOKEN)
             .setScopes(SCOPES)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
 
@@ -226,9 +225,7 @@ public class LoggingTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(nonGDU)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -450,9 +447,7 @@ public class LoggingTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -494,9 +489,7 @@ public class LoggingTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -551,9 +544,7 @@ public class LoggingTest {
         ServiceAccountCredentialsTest.createDefaultBuilderWithToken(ACCESS_TOKEN)
             .setScopes(SCOPES)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
@@ -445,7 +445,6 @@ public class LoggingTest {
 
   @Test
   void getRequestMetadata_hasAccessToken() throws IOException {
-    TestAppender testAppender = setupTestLogger(ComputeEngineCredentials.class);
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
@@ -453,11 +452,12 @@ public class LoggingTest {
     credentials.regionalAccessBoundaryManager.setCachedRAB(
         new RegionalAccessBoundary(
             "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    TestAppender testAppender = setupTestLogger(ComputeEngineCredentials.class);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
 
-    assertEquals(3, testAppender.events.size());
+    assertEquals(5, testAppender.events.size());
 
     ILoggingEvent accessTokenRequest = testAppender.events.get(0);
     assertEquals("Sending request to refresh access token", accessTokenRequest.getMessage());

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
@@ -445,6 +445,7 @@ public class LoggingTest {
 
   @Test
   void getRequestMetadata_hasAccessToken() throws IOException {
+    TestAppender testAppender = setupTestLogger(ComputeEngineCredentials.class);
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
@@ -452,7 +453,6 @@ public class LoggingTest {
     credentials.regionalAccessBoundaryManager.setCachedRAB(
         new RegionalAccessBoundary(
             "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
-    TestAppender testAppender = setupTestLogger(ComputeEngineCredentials.class);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
@@ -76,7 +76,7 @@ import org.slf4j.event.KeyValuePair;
  * credentials test classes with addition of test logging appender setup and test logic for logging.
  * This duplicates tests setups, but centralizes logging test setup in this class.
  */
-class LoggingTest {
+public class LoggingTest {
 
   private TestAppender setupTestLogger(Class<?> clazz) {
     TestAppender testAppender = new TestAppender();
@@ -97,10 +97,7 @@ class LoggingTest {
   @org.junit.jupiter.api.BeforeEach
   void setUp() {}
 
-  @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
+
 
   @Test
   void userCredentials_getRequestMetadata_fromRefreshToken_hasAccessToken() throws IOException {
@@ -172,6 +169,9 @@ class LoggingTest {
         ServiceAccountCredentialsTest.createDefaultBuilderWithToken(ACCESS_TOKEN)
             .setScopes(SCOPES)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
 
@@ -228,6 +228,9 @@ class LoggingTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(nonGDU)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -449,6 +452,9 @@ class LoggingTest {
     transportFactory.transport.setServiceAccountEmail("SA_CLIENT_EMAIL");
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -490,6 +496,9 @@ class LoggingTest {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -544,6 +553,9 @@ class LoggingTest {
         ServiceAccountCredentialsTest.createDefaultBuilderWithToken(ACCESS_TOKEN)
             .setScopes(SCOPES)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/LoggingTest.java
@@ -97,8 +97,6 @@ public class LoggingTest {
   @org.junit.jupiter.api.BeforeEach
   void setUp() {}
 
-
-
   @Test
   void userCredentials_getRequestMetadata_fromRefreshToken_hasAccessToken() throws IOException {
     TestAppender testAppender = setupTestLogger(UserCredentials.class);
@@ -170,8 +168,8 @@ public class LoggingTest {
             .setScopes(SCOPES)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
 
@@ -229,8 +227,8 @@ public class LoggingTest {
             .setUniverseDomain(nonGDU)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -453,8 +451,8 @@ public class LoggingTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -497,8 +495,8 @@ public class LoggingTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -554,8 +552,8 @@ public class LoggingTest {
             .setScopes(SCOPES)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
@@ -59,9 +59,7 @@ import org.junit.jupiter.api.Test;
 class PluggableAuthCredentialsTest extends BaseSerializationTest {
 
   @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
+  void tearDown() {}
 
   // The default timeout for waiting for the executable to finish (30 seconds).
   private static final int DEFAULT_EXECUTABLE_TIMEOUT_MS = 30 * 1000;
@@ -610,9 +608,6 @@ class PluggableAuthCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void testRefresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
 
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -222,6 +223,57 @@ public class RegionalAccessBoundaryTest {
         resultRab != null && newerEncoded.equals(resultRab.getEncodedLocations()),
         "Refresh should have completed and updated the cache within 5 seconds");
     assertEquals(newerEncoded, resultRab.getEncodedLocations());
+  }
+
+  @Test
+  public void testExecutorQueueCapacityLimit() throws Exception {
+    final String url = "https://example.com/rab";
+    final AccessToken token = new AccessToken("token", new java.util.Date(System.currentTimeMillis() + 3600000L));
+    RegionalAccessBoundaryProvider provider = () -> url;
+
+    int poolSize = 5;
+    int queueCapacity = 100;
+    int totalCapacity = poolSize + queueCapacity;
+
+    CountDownLatch latch = new CountDownLatch(1);
+    
+    java.io.InputStream blockingStream = new java.io.InputStream() {
+      private final java.io.InputStream delegate = new ByteArrayInputStream("{\"encodedLocations\": \"encoded\", \"locations\": [\"loc\"]}".getBytes());
+      private boolean blocked = false;
+
+      @Override
+      public int read() throws java.io.IOException {
+        if (!blocked) {
+          try {
+            latch.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          blocked = true;
+        }
+        return delegate.read();
+      }
+    };
+
+    MockHttpTransport transport = new MockHttpTransport.Builder()
+        .setLowLevelHttpResponse(new MockLowLevelHttpResponse().setContent(blockingStream).setContentType("application/json"))
+        .build();
+    HttpTransportFactory transportFactory = () -> transport;
+
+    RegionalAccessBoundaryManager[] managers = new RegionalAccessBoundaryManager[totalCapacity];
+    for (int i = 0; i < totalCapacity; i++) {
+      managers[i] = new RegionalAccessBoundaryManager(testClock);
+      managers[i].triggerAsyncRefresh(transportFactory, provider, token);
+    }
+
+    RegionalAccessBoundaryManager extraManager = new RegionalAccessBoundaryManager(testClock);
+    assertFalse(extraManager.isCooldownActive());
+    
+    extraManager.triggerAsyncRefresh(transportFactory, provider, token);
+
+    assertTrue(extraManager.isCooldownActive(), "106th task should have been rejected and entered cooldown");
+
+    latch.countDown();
   }
 
   private static class TestClock implements Clock {

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
@@ -31,9 +31,9 @@
 
 package com.google.auth.oauth2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
@@ -41,17 +41,15 @@ import com.google.api.client.util.Clock;
 import com.google.auth.http.HttpTransportFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class RegionalAccessBoundaryTest {
 
   private static final long TTL = RegionalAccessBoundary.TTL_MILLIS;
@@ -59,12 +57,12 @@ public class RegionalAccessBoundaryTest {
 
   private TestClock testClock;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     testClock = new TestClock();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {}
 
   @Test
@@ -125,6 +123,27 @@ public class RegionalAccessBoundaryTest {
     // The transient clock field should be restored to Clock.SYSTEM upon deserialization,
     // thereby avoiding a NullPointerException when checking expiration.
     assertFalse(deserializedRab.isExpired());
+  }
+
+  @Test
+  public void testRefreshClosesResponse() throws Exception {
+    final String url = "https://example.com/rab";
+    final AccessToken token =
+        new AccessToken("token", new java.util.Date(System.currentTimeMillis() + 3600000L));
+
+    TrackingMockLowLevelHttpResponse mockResponse = new TrackingMockLowLevelHttpResponse();
+    mockResponse.setContentType("application/json");
+    mockResponse.setContent("{\"encodedLocations\": \"encoded\", \"locations\": [\"loc\"]}");
+
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder().setLowLevelHttpResponse(mockResponse).build();
+    HttpTransportFactory transportFactory = () -> transport;
+
+    RegionalAccessBoundary rab =
+        RegionalAccessBoundary.refresh(transportFactory, url, token, testClock, 1000);
+
+    assertEquals("encoded", rab.getEncodedLocations());
+    assertTrue(mockResponse.isDisconnected(), "Response should have been disconnected");
   }
 
   @Test
@@ -200,8 +219,8 @@ public class RegionalAccessBoundaryTest {
     }
 
     assertTrue(
-        "Refresh should have completed and updated the cache within 5 seconds",
-        resultRab != null && newerEncoded.equals(resultRab.getEncodedLocations()));
+        resultRab != null && newerEncoded.equals(resultRab.getEncodedLocations()),
+        "Refresh should have completed and updated the cache within 5 seconds");
     assertEquals(newerEncoded, resultRab.getEncodedLocations());
   }
 
@@ -215,6 +234,20 @@ public class RegionalAccessBoundaryTest {
 
     public void set(long millis) {
       currentTime.set(millis);
+    }
+  }
+
+  private static class TrackingMockLowLevelHttpResponse extends MockLowLevelHttpResponse {
+    private boolean disconnected = false;
+
+    @Override
+    public void disconnect() throws IOException {
+      super.disconnect();
+      disconnected = true;
+    }
+
+    public boolean isDisconnected() {
+      return disconnected;
     }
   }
 }

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
@@ -228,7 +228,8 @@ public class RegionalAccessBoundaryTest {
   @Test
   public void testExecutorQueueCapacityLimit() throws Exception {
     final String url = "https://example.com/rab";
-    final AccessToken token = new AccessToken("token", new java.util.Date(System.currentTimeMillis() + 3600000L));
+    final AccessToken token =
+        new AccessToken("token", new java.util.Date(System.currentTimeMillis() + 3600000L));
     RegionalAccessBoundaryProvider provider = () -> url;
 
     int poolSize = 5;
@@ -236,28 +237,35 @@ public class RegionalAccessBoundaryTest {
     int totalCapacity = poolSize + queueCapacity;
 
     CountDownLatch latch = new CountDownLatch(1);
-    
-    java.io.InputStream blockingStream = new java.io.InputStream() {
-      private final java.io.InputStream delegate = new ByteArrayInputStream("{\"encodedLocations\": \"encoded\", \"locations\": [\"loc\"]}".getBytes());
-      private boolean blocked = false;
 
-      @Override
-      public int read() throws java.io.IOException {
-        if (!blocked) {
-          try {
-            latch.await();
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+    java.io.InputStream blockingStream =
+        new java.io.InputStream() {
+          private final java.io.InputStream delegate =
+              new ByteArrayInputStream(
+                  "{\"encodedLocations\": \"encoded\", \"locations\": [\"loc\"]}".getBytes());
+          private boolean blocked = false;
+
+          @Override
+          public int read() throws java.io.IOException {
+            if (!blocked) {
+              try {
+                latch.await();
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              blocked = true;
+            }
+            return delegate.read();
           }
-          blocked = true;
-        }
-        return delegate.read();
-      }
-    };
+        };
 
-    MockHttpTransport transport = new MockHttpTransport.Builder()
-        .setLowLevelHttpResponse(new MockLowLevelHttpResponse().setContent(blockingStream).setContentType("application/json"))
-        .build();
+    MockHttpTransport transport =
+        new MockHttpTransport.Builder()
+            .setLowLevelHttpResponse(
+                new MockLowLevelHttpResponse()
+                    .setContent(blockingStream)
+                    .setContentType("application/json"))
+            .build();
     HttpTransportFactory transportFactory = () -> transport;
 
     RegionalAccessBoundaryManager[] managers = new RegionalAccessBoundaryManager[totalCapacity];
@@ -268,10 +276,12 @@ public class RegionalAccessBoundaryTest {
 
     RegionalAccessBoundaryManager extraManager = new RegionalAccessBoundaryManager(testClock);
     assertFalse(extraManager.isCooldownActive());
-    
+
     extraManager.triggerAsyncRefresh(transportFactory, provider, token);
 
-    assertTrue(extraManager.isCooldownActive(), "106th task should have been rejected and entered cooldown");
+    assertTrue(
+        extraManager.isCooldownActive(),
+        "106th task should have been rejected and entered cooldown");
 
     latch.countDown();
   }

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/RegionalAccessBoundaryTest.java
@@ -236,6 +236,19 @@ public class RegionalAccessBoundaryTest {
     int queueCapacity = 100;
     int totalCapacity = poolSize + queueCapacity;
 
+    java.util.concurrent.ThreadPoolExecutor testExecutor =
+        new java.util.concurrent.ThreadPoolExecutor(
+            poolSize,
+            poolSize,
+            1,
+            java.util.concurrent.TimeUnit.HOURS,
+            new java.util.concurrent.LinkedBlockingQueue<>(queueCapacity),
+            r -> {
+              Thread t = new Thread(r, "test-RAB-refresh");
+              t.setDaemon(true);
+              return t;
+            });
+
     CountDownLatch latch = new CountDownLatch(1);
 
     java.io.InputStream blockingStream =
@@ -270,20 +283,29 @@ public class RegionalAccessBoundaryTest {
 
     RegionalAccessBoundaryManager[] managers = new RegionalAccessBoundaryManager[totalCapacity];
     for (int i = 0; i < totalCapacity; i++) {
-      managers[i] = new RegionalAccessBoundaryManager(testClock);
+      managers[i] =
+          new RegionalAccessBoundaryManager(
+              testClock,
+              RegionalAccessBoundaryManager.DEFAULT_MAX_RETRY_ELAPSED_TIME_MILLIS,
+              testExecutor);
       managers[i].triggerAsyncRefresh(transportFactory, provider, token);
     }
 
-    RegionalAccessBoundaryManager extraManager = new RegionalAccessBoundaryManager(testClock);
+    RegionalAccessBoundaryManager extraManager =
+        new RegionalAccessBoundaryManager(
+            testClock,
+            RegionalAccessBoundaryManager.DEFAULT_MAX_RETRY_ELAPSED_TIME_MILLIS,
+            testExecutor);
     assertFalse(extraManager.isCooldownActive());
 
     extraManager.triggerAsyncRefresh(transportFactory, provider, token);
 
-    assertTrue(
+    assertFalse(
         extraManager.isCooldownActive(),
-        "106th task should have been rejected and entered cooldown");
+        "106th task should NOT have entered cooldown on scheduling failure");
 
     latch.countDown();
+    testExecutor.shutdownNow();
   }
 
   private static class TestClock implements Clock {

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -160,9 +160,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   void setUp() {}
 
   @org.junit.jupiter.api.AfterEach
-  void tearDown() {
-    RegionalAccessBoundary.setEnvironmentProviderForTest(null);
-  }
+  void tearDown() {}
 
   @Test
   void setLifetime() throws IOException {
@@ -1773,9 +1771,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void refresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     // Mock regional access boundary response
     RegionalAccessBoundary regionalAccessBoundary =
         new RegionalAccessBoundary(
@@ -1813,9 +1809,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void refresh_regionalAccessBoundary_selfSignedJWT()
       throws IOException, InterruptedException {
-    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
-    RegionalAccessBoundary.setEnvironmentProviderForTest(environmentProvider);
-    environmentProvider.setEnv(RegionalAccessBoundary.ENABLE_EXPERIMENT_ENV_VAR, "1");
+
     RegionalAccessBoundary regionalAccessBoundary =
         new RegionalAccessBoundary(
             TestUtils.REGIONAL_ACCESS_BOUNDARY_ENCODED_LOCATION,

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -366,6 +366,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   void createdScoped_withAud_noUniverse_jwtWithScopesDisabled_accessToken() throws IOException {
     GoogleCredentials credentials = createDefaultBuilderWithToken(ACCESS_TOKEN).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     // No aud, no scopes gives an exception.
     IOException exception =
@@ -375,6 +378,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
         "expected to fail with exception");
 
     GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
+    scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
+    );
     assertEquals(false, credentials.isExplicitUniverseDomain());
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, credentials.getUniverseDomain());
     Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(CALL_URI);
@@ -385,17 +391,26 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   void createdScoped_withUniverse_selfSignedJwt() throws IOException {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setUniverseDomain("foo.bar").build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(null));
     assertTrue(
         exception.getMessage().contains("Scopes and uri are not configured for service account"));
 
     GoogleCredentials scopedCredentials = credentials.createScoped("dummy.scope");
+    scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
+    );
     Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.scope");
 
     // Recreate to avoid jwt caching.
     scopedCredentials = credentials.createScoped("dummy.scope2");
+    scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
+    );
     assertEquals(true, scopedCredentials.isExplicitUniverseDomain());
     assertEquals("foo.bar", scopedCredentials.getUniverseDomain());
     metadata = scopedCredentials.getRequestMetadata(CALL_URI);
@@ -405,6 +420,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     scopedCredentials =
         credentials.createScoped(
             Collections.<String>emptyList(), Arrays.asList("dummy.default.scope"));
+    scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
+    );
     metadata = scopedCredentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.default.scope");
 
@@ -412,6 +430,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     scopedCredentials =
         credentials.createScoped(
             Collections.<String>emptyList(), Arrays.asList("dummy.default.scope2"));
+    scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
+    );
     metadata = scopedCredentials.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, "dummy.default.scope2");
   }
@@ -532,6 +553,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GenericJson json = writeServiceAccountJson(PROJECT_ID, null, null);
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -545,6 +569,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GenericJson json = writeServiceAccountJson(PROJECT_ID, null, "foo.bar");
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
@@ -569,6 +596,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     GenericJson json = writeServiceAccountJson(PROJECT_ID, QUOTA_PROJECT, null);
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     credentials = credentials.createScoped(SCOPES);
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -583,6 +613,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   void getRequestMetadata_hasAccessToken() throws IOException {
     GoogleCredentials credentials =
         createDefaultBuilderWithToken(ACCESS_TOKEN).setScopes(SCOPES).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
   }
@@ -593,12 +626,15 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     transportFactory.transport.setTokenServerUri(tokenServerUri);
-    OAuth2Credentials credentials =
+    ServiceAccountCredentials credentials =
         createDefaultBuilder()
             .setScopes(SCOPES)
             .setHttpTransportFactory(transportFactory)
             .setTokenServerUri(tokenServerUri)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -623,6 +659,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
 
@@ -638,6 +677,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     credentials.clock = new FixedClock(0L);
 
     AccessToken accessToken = credentials.refreshAccessToken();
@@ -659,6 +701,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -677,6 +722,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -697,6 +745,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -721,6 +772,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build()
             .createWithCustomRetryStrategy(false);
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -742,6 +796,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
@@ -771,6 +828,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
@@ -802,6 +862,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -827,6 +890,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -864,6 +930,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -896,6 +965,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(nonGDU)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -927,6 +999,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(nonGDU)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "differentAudience";
     IdTokenCredentials tokenCredential =
@@ -948,6 +1023,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setError(new IOException("404 Not Found"));
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
@@ -976,6 +1054,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(universeDomain)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
@@ -1377,6 +1458,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials credentials =
         ServiceAccountCredentials.fromStream(serviceAccountStream, transportFactory);
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     assertNotNull(credentials);
     credentials = credentials.createScoped(SCOPES);
@@ -1419,6 +1503,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transport.setError(new IOException("Invalid grant: Account not found"));
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     String targetAudience = "https://bar";
     IdTokenCredentials tokenCredential =
@@ -1503,6 +1590,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setQuotaProjectId("my-quota-project-id")
             .setHttpTransportFactory(transportFactory)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertTrue(metadata.containsKey("x-goog-user-project"));
@@ -1529,6 +1619,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(transportFactory)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertFalse(metadata.containsKey("x-goog-user-project"));
@@ -1552,6 +1645,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setQuotaProjectId("my-quota-project-id")
             .setHttpTransportFactory(transportFactory)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     final Map<String, List<String>> plainMetadata = credentials.getRequestMetadata();
     final AtomicBoolean success = new AtomicBoolean(false);
@@ -1592,6 +1688,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain("foo.bar")
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     final Map<String, List<String>> plainMetadata = credentials.getRequestMetadata();
     final AtomicBoolean success = new AtomicBoolean(false);
@@ -1628,6 +1727,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
             .setUseJwtAccessWithScope(true)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertNotNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
@@ -1659,6 +1761,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUseJwtAccessWithScope(true)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -1683,6 +1788,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
@@ -1703,6 +1811,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
             .setUseJwtAccessWithScope(true)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.scope");
@@ -1723,6 +1834,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUseJwtAccessWithScope(true)
             .setScopes(SCOPES)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
 
     final AtomicBoolean success = new AtomicBoolean(false);
     credentials.getRequestMetadata(
@@ -1760,6 +1874,9 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setScopes(SCOPES)
             .build();
+    credentials.regionalAccessBoundaryManager.setCachedRAB(
+        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
+    );
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
 
     // Calling createScoped() again will invalidate the existing access token and calling

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -367,8 +367,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   void createdScoped_withAud_noUniverse_jwtWithScopesDisabled_accessToken() throws IOException {
     GoogleCredentials credentials = createDefaultBuilderWithToken(ACCESS_TOKEN).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     // No aud, no scopes gives an exception.
     IOException exception =
@@ -379,8 +379,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
     assertEquals(false, credentials.isExplicitUniverseDomain());
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, credentials.getUniverseDomain());
     Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(CALL_URI);
@@ -392,8 +392,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setUniverseDomain("foo.bar").build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(null));
     assertTrue(
@@ -401,16 +401,16 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials scopedCredentials = credentials.createScoped("dummy.scope");
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
     Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.scope");
 
     // Recreate to avoid jwt caching.
     scopedCredentials = credentials.createScoped("dummy.scope2");
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
     assertEquals(true, scopedCredentials.isExplicitUniverseDomain());
     assertEquals("foo.bar", scopedCredentials.getUniverseDomain());
     metadata = scopedCredentials.getRequestMetadata(CALL_URI);
@@ -421,8 +421,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
         credentials.createScoped(
             Collections.<String>emptyList(), Arrays.asList("dummy.default.scope"));
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
     metadata = scopedCredentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.default.scope");
 
@@ -431,8 +431,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
         credentials.createScoped(
             Collections.<String>emptyList(), Arrays.asList("dummy.default.scope2"));
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
     metadata = scopedCredentials.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, "dummy.default.scope2");
   }
@@ -554,8 +554,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -570,8 +570,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
@@ -597,8 +597,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GenericJson json = writeServiceAccountJson(PROJECT_ID, QUOTA_PROJECT, null);
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     credentials = credentials.createScoped(SCOPES);
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -614,8 +614,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GoogleCredentials credentials =
         createDefaultBuilderWithToken(ACCESS_TOKEN).setScopes(SCOPES).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
   }
@@ -633,8 +633,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setTokenServerUri(tokenServerUri)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -660,8 +660,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
 
@@ -678,8 +678,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     credentials.clock = new FixedClock(0L);
 
     AccessToken accessToken = credentials.refreshAccessToken();
@@ -702,8 +702,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -723,8 +723,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -746,8 +746,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -773,8 +773,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .build()
             .createWithCustomRetryStrategy(false);
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -797,8 +797,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
@@ -829,8 +829,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
@@ -863,8 +863,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -891,8 +891,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -931,8 +931,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -966,8 +966,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain(nonGDU)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -1000,8 +1000,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain(nonGDU)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "differentAudience";
     IdTokenCredentials tokenCredential =
@@ -1024,8 +1024,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
@@ -1055,8 +1055,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain(universeDomain)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
@@ -1459,8 +1459,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GoogleCredentials credentials =
         ServiceAccountCredentials.fromStream(serviceAccountStream, transportFactory);
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     assertNotNull(credentials);
     credentials = credentials.createScoped(SCOPES);
@@ -1504,8 +1504,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     String targetAudience = "https://bar";
     IdTokenCredentials tokenCredential =
@@ -1591,8 +1591,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertTrue(metadata.containsKey("x-goog-user-project"));
@@ -1620,8 +1620,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertFalse(metadata.containsKey("x-goog-user-project"));
@@ -1646,8 +1646,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     final Map<String, List<String>> plainMetadata = credentials.getRequestMetadata();
     final AtomicBoolean success = new AtomicBoolean(false);
@@ -1689,8 +1689,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain("foo.bar")
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     final Map<String, List<String>> plainMetadata = credentials.getRequestMetadata();
     final AtomicBoolean success = new AtomicBoolean(false);
@@ -1728,8 +1728,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUseJwtAccessWithScope(true)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertNotNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
@@ -1762,8 +1762,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUseJwtAccessWithScope(true)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -1789,8 +1789,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
@@ -1812,8 +1812,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUseJwtAccessWithScope(true)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.scope");
@@ -1835,8 +1835,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setScopes(SCOPES)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
 
     final AtomicBoolean success = new AtomicBoolean(false);
     credentials.getRequestMetadata(
@@ -1875,8 +1875,8 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setScopes(SCOPES)
             .build();
     credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary("dummy-locations", Arrays.asList("dummy-loc"), credentials.clock)
-    );
+        new RegionalAccessBoundary(
+            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
 
     // Calling createScoped() again will invalidate the existing access token and calling

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 import static com.google.auth.oauth2.RegionalAccessBoundary.X_ALLOWED_LOCATIONS_HEADER_KEY;
+import static com.google.auth.oauth2.TestUtils.createDummyRab;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -366,9 +367,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   void createdScoped_withAud_noUniverse_jwtWithScopesDisabled_accessToken() throws IOException {
     GoogleCredentials credentials = createDefaultBuilderWithToken(ACCESS_TOKEN).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     // No aud, no scopes gives an exception.
     IOException exception =
@@ -379,8 +378,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
+        createDummyRab(scopedCredentials.clock));
     assertEquals(false, credentials.isExplicitUniverseDomain());
     assertEquals(Credentials.GOOGLE_DEFAULT_UNIVERSE, credentials.getUniverseDomain());
     Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(CALL_URI);
@@ -391,9 +389,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   void createdScoped_withUniverse_selfSignedJwt() throws IOException {
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setUniverseDomain("foo.bar").build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     IOException exception =
         assertThrows(IOException.class, () -> credentials.getRequestMetadata(null));
     assertTrue(
@@ -401,16 +397,14 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials scopedCredentials = credentials.createScoped("dummy.scope");
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
+        createDummyRab(scopedCredentials.clock));
     Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.scope");
 
     // Recreate to avoid jwt caching.
     scopedCredentials = credentials.createScoped("dummy.scope2");
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
+        createDummyRab(scopedCredentials.clock));
     assertEquals(true, scopedCredentials.isExplicitUniverseDomain());
     assertEquals("foo.bar", scopedCredentials.getUniverseDomain());
     metadata = scopedCredentials.getRequestMetadata(CALL_URI);
@@ -421,8 +415,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
         credentials.createScoped(
             Collections.<String>emptyList(), Arrays.asList("dummy.default.scope"));
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
+        createDummyRab(scopedCredentials.clock));
     metadata = scopedCredentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.default.scope");
 
@@ -431,8 +424,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
         credentials.createScoped(
             Collections.<String>emptyList(), Arrays.asList("dummy.default.scope2"));
     scopedCredentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), scopedCredentials.clock));
+        createDummyRab(scopedCredentials.clock));
     metadata = scopedCredentials.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, "dummy.default.scope2");
   }
@@ -553,9 +545,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GenericJson json = writeServiceAccountJson(PROJECT_ID, null, null);
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -569,9 +559,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     GenericJson json = writeServiceAccountJson(PROJECT_ID, null, "foo.bar");
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
@@ -596,9 +584,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     GenericJson json = writeServiceAccountJson(PROJECT_ID, QUOTA_PROJECT, null);
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     credentials = credentials.createScoped(SCOPES);
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -613,9 +599,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
   void getRequestMetadata_hasAccessToken() throws IOException {
     GoogleCredentials credentials =
         createDefaultBuilderWithToken(ACCESS_TOKEN).setScopes(SCOPES).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
   }
@@ -632,9 +616,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setTokenServerUri(tokenServerUri)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -659,9 +641,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
 
@@ -677,9 +657,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     credentials.clock = new FixedClock(0L);
 
     AccessToken accessToken = credentials.refreshAccessToken();
@@ -701,9 +679,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -722,9 +698,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -745,9 +719,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -772,9 +744,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build()
             .createWithCustomRetryStrategy(false);
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -796,9 +766,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
@@ -828,9 +796,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, ACCESS_TOKEN);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
@@ -862,9 +828,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -890,9 +854,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -930,9 +892,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
@@ -965,9 +925,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(nonGDU)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -999,9 +957,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(nonGDU)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "differentAudience";
     IdTokenCredentials tokenCredential =
@@ -1023,9 +979,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setError(new IOException("404 Not Found"));
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
@@ -1054,9 +1008,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain(universeDomain)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
@@ -1458,9 +1410,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials credentials =
         ServiceAccountCredentials.fromStream(serviceAccountStream, transportFactory);
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     assertNotNull(credentials);
     credentials = credentials.createScoped(SCOPES);
@@ -1503,9 +1453,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     transport.setError(new IOException("Invalid grant: Account not found"));
     ServiceAccountCredentials credentials =
         createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     String targetAudience = "https://bar";
     IdTokenCredentials tokenCredential =
@@ -1590,9 +1538,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setQuotaProjectId("my-quota-project-id")
             .setHttpTransportFactory(transportFactory)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertTrue(metadata.containsKey("x-goog-user-project"));
@@ -1619,9 +1565,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(transportFactory)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertFalse(metadata.containsKey("x-goog-user-project"));
@@ -1645,9 +1589,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setQuotaProjectId("my-quota-project-id")
             .setHttpTransportFactory(transportFactory)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     final Map<String, List<String>> plainMetadata = credentials.getRequestMetadata();
     final AtomicBoolean success = new AtomicBoolean(false);
@@ -1688,9 +1630,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUniverseDomain("foo.bar")
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     final Map<String, List<String>> plainMetadata = credentials.getRequestMetadata();
     final AtomicBoolean success = new AtomicBoolean(false);
@@ -1727,9 +1667,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
             .setUseJwtAccessWithScope(true)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertNotNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
@@ -1761,9 +1699,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setUseJwtAccessWithScope(true)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     transport.addServiceAccount(CLIENT_EMAIL, accessToken1);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -1788,9 +1724,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
@@ -1811,9 +1745,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
             .setUseJwtAccessWithScope(true)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
     verifyJwtAccess(metadata, "dummy.scope");
@@ -1834,9 +1766,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUseJwtAccessWithScope(true)
             .setScopes(SCOPES)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
 
     final AtomicBoolean success = new AtomicBoolean(false);
     credentials.getRequestMetadata(
@@ -1874,9 +1804,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .setScopes(SCOPES)
             .build();
-    credentials.regionalAccessBoundaryManager.setCachedRAB(
-        new RegionalAccessBoundary(
-            "dummy-locations", Arrays.asList("dummy-loc"), credentials.clock));
+    credentials.regionalAccessBoundaryManager.setCachedRAB(createDummyRab(credentials.clock));
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN);
 
     // Calling createScoped() again will invalidate the existing access token and calling

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/TestUtils.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/TestUtils.java
@@ -69,4 +69,9 @@ class TestUtils {
     }
     assertEquals(expectedMetricsValue, actualMetricsValue);
   }
+
+  static RegionalAccessBoundary createDummyRab(com.google.api.client.util.Clock clock) {
+    return new RegionalAccessBoundary(
+        "dummy-locations", java.util.Arrays.asList("dummy-loc"), clock);
+  }
 }


### PR DESCRIPTION
1. The RAB refresh uses a direct executor with a fixed thread pool as opposed to instantiating a new thread each time.

2. The RAB env gate -> GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT has been removed. This means RAB refresh triggers by default.

3. Added other fixes/suggestions made in the previous Java [PR](https://github.com/googleapis/google-auth-library-java/pull/1880).