### PR TITLE
chore: update GH Action templates to use gapic-libraries-bom version

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.github/scripts/update_generation_config.sh
@@ -150,10 +150,10 @@ update_config "gapic_generator_version" "${latest_gapic_generator_version}" "${g
 # Update the GitHub Actions reference to the latest.
 # After the google-cloud-java monorepo migration of sdk-platform-java,
 # we cannot rely on the gapic-generator-java version tag. Let's use
-# the shared dependencies BOM version
-latest_shared_dependencies_bom_version=$(get_latest_released_version "com.google.cloud" "google-cloud-shared-dependencies")
+# the gapic-libraries-bom version
+latest_gapic_libraries_bom_version=$(get_latest_released_version "com.google.cloud" "gapic-libraries-bom")
 update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
-  "google-cloud-shared-dependencies/v${latest_shared_dependencies_bom_version}" \
+  "v${latest_gapic_libraries_bom_version}" \
   "${workflow}"
 
 # Update libraries-bom version to the latest

--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/renovate.json
@@ -29,9 +29,9 @@
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": [
-        "uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"
+        "uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v(?<currentValue>.+?)\\n"
       ],
-      "depNameTemplate": "com.google.cloud:google-cloud-shared-dependencies",
+      "depNameTemplate": "com.google.cloud:gapic-libraries-bom",
       "datasourceTemplate": "maven"
     }
   ],


### PR DESCRIPTION
This PR updates the templates in `sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/` to use `gapic-libraries-bom` and the `v{version}` tag format for action versioning.

The Git tag for shared dependencies BOM version is created by an automation (GitHub Actions) automatically. While it would work just fine, chaining automated events will make future troubleshooting difficult. So let's rely on the original tag of the google-cloud-java repository, which matches gapic-libraries-bom version.

b/503444342
