### PR TITLE
ci: add conditional-required-check for hermetic-build-scripts ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,6 +246,17 @@ jobs:
         JOB_TYPE: test
         JOB_NAME: units-8-runtime-${{matrix.java}}
       working-directory: ${{matrix.package}}
+  required:
+    needs: [ split-units, split-units-8 ]
+    name: conditional-required-check
+    if: ${{ always() }} # Always run even if any "needs" jobs fail
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any previous failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - name: Success otherwise
+        run: echo "Success!"
   windows:
     runs-on: windows-latest
     steps:
@@ -332,30 +343,3 @@ jobs:
       env:
         library_generation_image_tag: 2.68.0
         workspace_name: /workspace
-
-# TODO: Uncomment the needed Github Actions
-#  dependencies:
-#    runs-on: ubuntu-latest
-#    strategy:
-#      matrix:
-#        java: [8, 11, 17]
-#    steps:
-#    - uses: actions/checkout@v3
-#    - uses: actions/setup-java@v3
-#      with:
-#        distribution: zulu
-#        java-version: ${{matrix.java}}
-#    - run: java -version
-#    - run: .kokoro/dependencies.sh
-#  clirr:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v3
-#    - uses: actions/setup-java@v3
-#      with:
-#        distribution: zulu
-#        java-version: 8
-#    - run: java -version
-#    - run: .kokoro/build.sh
-#      env:
-#        JOB_TYPE: clirr

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,7 +247,7 @@ jobs:
         JOB_NAME: units-8-runtime-${{matrix.java}}
       working-directory: ${{matrix.package}}
   required:
-    needs: [ split-units, split-units-8 ]
+    needs: [ changes, split-units, split-units-8 ]
     name: conditional-required-check
     if: ${{ always() }} # Always run even if any "needs" jobs fail
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,13 +247,13 @@ jobs:
         JOB_NAME: units-8-runtime-${{matrix.java}}
       working-directory: ${{matrix.package}}
   required:
-    needs: [ changes, split-units, split-units-8 ]
+    needs: [ changes, split-units ]
     name: conditional-required-check
     if: ${{ always() }} # Always run even if any "needs" jobs fail
     runs-on: ubuntu-22.04
     steps:
       - name: Fail if any previous failure
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ needs.changes.outputs.packages != '[]' && contains(needs.*.result, 'failure') }}
         run: exit 1
       - name: Success otherwise
         run: echo "Success!"

--- a/.github/workflows/google-auth-library-java-ci.yaml
+++ b/.github/workflows/google-auth-library-java-ci.yaml
@@ -34,6 +34,7 @@ jobs:
         filters: |
           library:
             - 'google-auth-library-java/**'
+            - ''.github/workflows/google-auth-library-java-ci.yaml'
   units-logging:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}
@@ -54,3 +55,14 @@ jobs:
         BUILD_SUBDIR: google-auth-library-java
         JOB_TYPE: test
         SUREFIRE_JVM_OPT: "-P '!slf4j2x,slf4j2x-test'"
+  required:
+    needs: [ units-logging ]
+    name: conditional-required-check
+    if: ${{ always() }} # Always run even if any "needs" jobs fail
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any previous failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - name: Success otherwise
+        run: echo "Success!"

--- a/.github/workflows/google-auth-library-java-ci.yaml
+++ b/.github/workflows/google-auth-library-java-ci.yaml
@@ -34,7 +34,7 @@ jobs:
         filters: |
           library:
             - 'google-auth-library-java/**'
-            - ''.github/workflows/google-auth-library-java-ci.yaml'
+            - '.github/workflows/google-auth-library-java-ci.yaml'
   units-logging:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}

--- a/.github/workflows/hermetic-build-scripts-ci.yaml
+++ b/.github/workflows/hermetic-build-scripts-ci.yaml
@@ -97,3 +97,14 @@ jobs:
         # exclude generated golden files
         # exclude owlbot until further refaction
         black --check hermetic_build --exclude "(library_generation/tests/resources/goldens)"
+  required:
+    needs: [ library-generation-unit-tests, library-generation-lint-shell, library-generation-lint-python ]
+    name: conditional-required-check
+    if: ${{ always() }} # Always run even if any "needs" jobs fail
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any previous failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - name: Success otherwise
+        run: echo "Success!"

--- a/.github/workflows/java-spanner-jdbc-ci.yaml
+++ b/.github/workflows/java-spanner-jdbc-ci.yaml
@@ -34,6 +34,7 @@ jobs:
         filters: |
           library:
             - 'java-spanner-jdbc/**'
+            - '.github/workflows/java-spanner-jdbc-ci.yaml'
   units:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}
@@ -141,3 +142,14 @@ jobs:
         JOB_TYPE: lint
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  required:
+    needs: [ units, units-java8, windows, dependencies, javadoc, lint ]
+    name: conditional-required-check
+    if: ${{ always() }} # Always run even if any "needs" jobs fail
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any previous failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - name: Success otherwise
+        run: echo "Success!"

--- a/.github/workflows/java-storage-nio-ci.yaml
+++ b/.github/workflows/java-storage-nio-ci.yaml
@@ -34,6 +34,7 @@ jobs:
         filters: |
           library:
             - 'java-storage-nio/**'
+            - '.github/workflows/java-storage-nio-ci.yaml'
   units:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}
@@ -141,3 +142,14 @@ jobs:
         JOB_TYPE: lint
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  required:
+    needs: [ units, units-java8, windows, dependencies, javadoc, lint ]
+    name: conditional-required-check
+    if: ${{ always() }} # Always run even if any "needs" jobs fail
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any previous failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - name: Success otherwise
+        run: echo "Success!"

--- a/.github/workflows/sdk-platform-java-downstream.yaml
+++ b/.github/workflows/sdk-platform-java-downstream.yaml
@@ -24,6 +24,7 @@ jobs:
           library:
             - 'sdk-platform-java/**'
             - .kokoro/downstream-compatibility.sh
+            - .github/workflows/sdk-platform-java-downstream.yaml
   downstream-compatibility:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}
@@ -71,3 +72,14 @@ jobs:
           sudo apt-get -y install libxml2-utils
       - name: Perform downstream compatibility testing
         run: .kokoro/downstream-compatibility-spring.sh
+  required:
+    needs: [ downstream-compatibility, downstream-compatibility-spring-generator ]
+    name: conditional-required-check
+    if: ${{ always() }} # Always run even if any "needs" jobs fail
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any previous failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - name: Success otherwise
+        run: echo "Success!"

--- a/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
+++ b/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
@@ -3,9 +3,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - .github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
-      - sdk-platform-java/java-shared-dependencies/**
 
 name: sdk-platform-java Downstream Unmanaged Dependency Check
 env:
@@ -22,7 +19,8 @@ jobs:
       with:
         filters: |
           library:
-            - 'sdk-platform-java/**'
+            - 'sdk-platform-java/java-shared-dependencies/**'
+            - '.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml'
   validate:
     needs: filter
     if: ${{ needs.filter.outputs.library == 'true' }}
@@ -96,3 +94,14 @@ jobs:
             exit 1
           fi
           echo "Unmanaged dependency check passed"
+  required:
+    needs: [ validate ]
+    name: conditional-required-check
+    if: ${{ always() }} # Always run even if any "needs" jobs fail
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if any previous failure
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
+      - name: Success otherwise
+        run: echo "Success!"


### PR DESCRIPTION
This adds a new final job to GitHub actions workflows that conditionally skip tests using `jobs.if`. The new `required` job looks to see if any of the jobs within that workflow marked as `needs` have failed. If any have failed, then this test is marked as failed. Otherwise, it is marked as succeeded. We can make this new `conditional-required-check` a required check for merging PRs.

Towards #12702