### PR TITLE
feat(spanner): add connection property for enabling/disabling grpc-gcp

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -35,6 +35,7 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_DI
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_DYNAMIC_CHANNEL_POOL;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_END_TO_END_TRACING;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_EXTENDED_TRACING;
+import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_GRPC_GCP;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENCODED_CREDENTIALS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENDPOINT;
 import static com.google.cloud.spanner.connection.ConnectionProperties.GRPC_INTERCEPTOR_PROVIDER;
@@ -160,6 +161,7 @@ public class ConnectionOptions {
   static final Integer DEFAULT_MAX_SESSIONS = null;
   static final Integer DEFAULT_NUM_CHANNELS = null;
   static final Boolean DEFAULT_ENABLE_DYNAMIC_CHANNEL_POOL = null;
+  static final Boolean DEFAULT_ENABLE_GRPC_GCP = null;
   static final Integer DEFAULT_DCP_MIN_CHANNELS = null;
   static final Integer DEFAULT_DCP_MAX_CHANNELS = null;
   static final Integer DEFAULT_DCP_INITIAL_CHANNELS = null;
@@ -262,6 +264,9 @@ public class ConnectionOptions {
 
   /** Name of the 'enableDynamicChannelPool' connection property. */
   public static final String ENABLE_DYNAMIC_CHANNEL_POOL_PROPERTY_NAME = "enableDynamicChannelPool";
+
+  /** Name of the 'enableGrpcGcp' connection property. */
+  public static final String ENABLE_GRPC_GCP_PROPERTY_NAME = "enableGrpcGcp";
 
   /** Name of the 'dcpMinChannels' connection property. */
   public static final String DCP_MIN_CHANNELS_PROPERTY_NAME = "dcpMinChannels";
@@ -1014,6 +1019,11 @@ public class ConnectionOptions {
   /** Whether dynamic channel pooling is enabled for this connection. */
   public Boolean isEnableDynamicChannelPool() {
     return getInitialConnectionPropertyValue(ENABLE_DYNAMIC_CHANNEL_POOL);
+  }
+
+  /** Whether grpc-gcp is enabled for this connection. */
+  public Boolean isEnableGrpcGcp() {
+    return getInitialConnectionPropertyValue(ENABLE_GRPC_GCP);
   }
 
   /** The minimum number of channels in the dynamic channel pool. */

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -469,7 +469,10 @@ public class ConnectionProperties {
       create(
           ENABLE_GRPC_GCP_PROPERTY_NAME,
           "Enable or disable grpc-gcp channel pool (true/false). "
-              + "Setting this to false will disable grpc-gcp and use the Gax gRPC channel pool.",
+              + "Setting this to false will disable grpc-gcp and use the Gax gRPC channel pool. "
+              + "Disabling grpc-gcp also automatically disables dynamic channel pooling, regardless "
+              + "of the value of enableDynamicChannelPool, as Spanner only supports dynamic channel "
+              + "pooling in combination with grpc-gcp.",
           DEFAULT_ENABLE_GRPC_GCP,
           BOOLEANS,
           BooleanConverter.INSTANCE,

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -55,6 +55,7 @@ import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENAB
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENABLE_DYNAMIC_CHANNEL_POOL;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENABLE_END_TO_END_TRACING;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENABLE_EXTENDED_TRACING;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENABLE_GRPC_GCP;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_ENDPOINT;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_IS_EXPERIMENTAL_HOST;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_KEEP_TRANSACTION_ALIVE;
@@ -85,6 +86,7 @@ import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_API_T
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_DYNAMIC_CHANNEL_POOL_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_END_TO_END_TRACING_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_EXTENDED_TRACING_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_GRPC_GCP_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_GRPC_INTERCEPTOR_PROVIDER_SYSTEM_PROPERTY;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENCODED_CREDENTIALS_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENDPOINT_PROPERTY_NAME;
@@ -460,6 +462,15 @@ public class ConnectionProperties {
               + "The default is currently false (disabled), but this may change to true in a "
               + "future version. Set this property explicitly to ensure consistent behavior.",
           DEFAULT_ENABLE_DYNAMIC_CHANNEL_POOL,
+          BOOLEANS,
+          BooleanConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Boolean> ENABLE_GRPC_GCP =
+      create(
+          ENABLE_GRPC_GCP_PROPERTY_NAME,
+          "Enable or disable grpc-gcp channel pool (true/false). "
+              + "Setting this to false will disable grpc-gcp and use the Gax gRPC channel pool.",
+          DEFAULT_ENABLE_GRPC_GCP,
           BOOLEANS,
           BooleanConverter.INSTANCE,
           Context.STARTUP);

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -155,6 +155,7 @@ public class SpannerPool {
     private final SessionPoolOptions sessionPoolOptions;
     private final Integer numChannels;
     private final Boolean enableDynamicChannelPool;
+    private final Boolean enableGrpcGcp;
     private final Integer dcpMinChannels;
     private final Integer dcpMaxChannels;
     private final Integer dcpInitialChannels;
@@ -197,6 +198,7 @@ public class SpannerPool {
               : options.getSessionPoolOptions();
       this.numChannels = options.getNumChannels();
       this.enableDynamicChannelPool = options.isEnableDynamicChannelPool();
+      this.enableGrpcGcp = options.isEnableGrpcGcp();
       this.dcpMinChannels = options.getDcpMinChannels();
       this.dcpMaxChannels = options.getDcpMaxChannels();
       this.dcpInitialChannels = options.getDcpInitialChannels();
@@ -228,6 +230,7 @@ public class SpannerPool {
           && Objects.equals(this.sessionPoolOptions, other.sessionPoolOptions)
           && Objects.equals(this.numChannels, other.numChannels)
           && Objects.equals(this.enableDynamicChannelPool, other.enableDynamicChannelPool)
+          && Objects.equals(this.enableGrpcGcp, other.enableGrpcGcp)
           && Objects.equals(this.dcpMinChannels, other.dcpMinChannels)
           && Objects.equals(this.dcpMaxChannels, other.dcpMaxChannels)
           && Objects.equals(this.dcpInitialChannels, other.dcpInitialChannels)
@@ -258,6 +261,7 @@ public class SpannerPool {
           this.sessionPoolOptions,
           this.numChannels,
           this.enableDynamicChannelPool,
+          this.enableGrpcGcp,
           this.dcpMinChannels,
           this.dcpMaxChannels,
           this.dcpInitialChannels,
@@ -421,9 +425,18 @@ public class SpannerPool {
     if (key.numChannels != null) {
       builder.setNumChannels(key.numChannels);
     }
+    if (key.enableGrpcGcp != null) {
+      if (Boolean.TRUE.equals(key.enableGrpcGcp)) {
+        builder.enableGrpcGcpExtension();
+      } else {
+        builder.disableGrpcGcpExtension();
+      }
+    }
     // Configure Dynamic Channel Pooling (DCP) based on explicit user setting.
     // Note: Setting numChannels disables DCP even if enableDynamicChannelPool is true.
-    if (key.enableDynamicChannelPool != null && key.numChannels == null) {
+    if (key.enableDynamicChannelPool != null
+        && key.numChannels == null
+        && !Boolean.FALSE.equals(key.enableGrpcGcp)) {
       if (Boolean.TRUE.equals(key.enableDynamicChannelPool)) {
         builder.enableDynamicChannelPool();
         // Build custom GcpChannelPoolOptions if any DCP-specific options are set.

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcGcpMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcGcpMockServerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.Statement;
+import com.google.cloud.spanner.connection.StatementResult.ResultType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GrpcGcpMockServerTest extends AbstractMockServerTest {
+
+  @Before
+  public void setup() {
+    SpannerPool.closeSpannerPool();
+  }
+
+  @After
+  public void teardown() {
+    SpannerPool.closeSpannerPool();
+  }
+
+  private void verifyConnectionWorks(Connection connection) {
+    StatementResult result = connection.execute(Statement.of("SELECT 1"));
+    assertEquals(ResultType.RESULT_SET, result.getResultType());
+    try (ResultSet rs = result.getResultSet()) {
+      assertTrue(rs.next());
+      assertEquals(1L, rs.getLong(0));
+      assertFalse(rs.next());
+    }
+  }
+
+  @Test
+  public void testDisableGrpcGcp() {
+    try (Connection connection = createConnection(";enableGrpcGcp=false")) {
+      Spanner spanner = ((ConnectionImpl) connection).getSpanner();
+      assertFalse(spanner.getOptions().isGrpcGcpExtensionEnabled());
+      verifyConnectionWorks(connection);
+    }
+  }
+
+  @Test
+  public void testEnableGrpcGcp() {
+    try (Connection connection = createConnection(";enableGrpcGcp=true")) {
+      Spanner spanner = ((ConnectionImpl) connection).getSpanner();
+      assertTrue(spanner.getOptions().isGrpcGcpExtensionEnabled());
+      verifyConnectionWorks(connection);
+    }
+  }
+
+  @Test
+  public void testDefaultGrpcGcp() {
+    try (Connection connection = createConnection()) {
+      Spanner spanner = ((ConnectionImpl) connection).getSpanner();
+      // Default should be true in SpannerOptions
+      assertTrue(spanner.getOptions().isGrpcGcpExtensionEnabled());
+      verifyConnectionWorks(connection);
+    }
+  }
+}

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -771,4 +771,47 @@ public class SpannerPoolTest {
                 .setCredentials(NoCredentials.getInstance())
                 .build()));
   }
+
+  @Test
+  public void testGrpcGcpSettings() {
+    SpannerPoolKey keyWithoutGrpcGcp =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+    SpannerPoolKey keyWithGrpcGcpEnabled =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableGrpcGcp=true")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+    SpannerPoolKey keyWithGrpcGcpDisabled =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableGrpcGcp=false")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+
+    // grpcGcp settings should affect the SpannerPoolKey
+    assertNotEquals(keyWithoutGrpcGcp, keyWithGrpcGcpEnabled);
+    assertNotEquals(keyWithoutGrpcGcp, keyWithGrpcGcpDisabled);
+    assertNotEquals(keyWithGrpcGcpEnabled, keyWithGrpcGcpDisabled);
+
+    // Same configuration should create equal keys
+    assertEquals(
+        keyWithGrpcGcpEnabled,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableGrpcGcp=true")
+                .setCredentials(NoCredentials.getInstance())
+                .build()));
+    assertEquals(
+        keyWithGrpcGcpDisabled,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri("cloudspanner:/projects/p/instances/i/databases/d?enableGrpcGcp=false")
+                .setCredentials(NoCredentials.getInstance())
+                .build()));
+  }
 }


### PR DESCRIPTION
Adds a connection property for enabling/disabling the grpc-gcp channel pool. This channel pool is the default, but can be disabled by setting this property to false. The connection will use Gax for channel pooling if grpc-gcp is disabled.