### PR TITLE
test(spanner): replace fixed hashCode value assertions with contract-compliance tests in OptionsTest

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
@@ -152,11 +152,10 @@ public class OptionsTest {
     assertThat(options.equals(null)).isFalse();
     assertThat(options.equals(this)).isFalse();
     assertNull(options.isolationLevel());
-    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    // Verify hashCode contract: equal objects must have equal hashCodes.
     Options options2 = Options.fromReadOptions();
-    assertThat(options.equals(options2)).isTrue();
+    assertThat(options).isEqualTo(options2);
     assertThat(options.hashCode()).isEqualTo(options2.hashCode());
-    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test
@@ -179,13 +178,12 @@ public class OptionsTest {
     assertThat(options.pageSize()).isEqualTo(pageSize);
     assertThat(options.pageToken()).isEqualTo(pageToken);
     assertThat(options.filter()).isEqualTo(filter);
-    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    // Verify hashCode contract: equal objects must have equal hashCodes.
     Options options2 =
         Options.fromListOptions(
             Options.pageSize(pageSize), Options.pageToken(pageToken), Options.filter(filter));
-    assertThat(options.equals(options2)).isTrue();
+    assertThat(options).isEqualTo(options2);
     assertThat(options.hashCode()).isEqualTo(options2.hashCode());
-    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test
@@ -706,11 +704,10 @@ public class OptionsTest {
     assertEquals("tag: " + tag + " ", options.toString());
     assertTrue(options.hasTag());
     assertThat(options.tag()).isEqualTo(tag);
-    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    // Verify hashCode contract: equal objects must have equal hashCodes.
     Options options2 = Options.fromUpdateOptions(Options.tag(tag));
-    assertThat(options.equals(options2)).isTrue();
+    assertThat(options).isEqualTo(options2);
     assertThat(options.hashCode()).isEqualTo(options2.hashCode());
-    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test
@@ -742,11 +739,10 @@ public class OptionsTest {
     assertEquals("tag: " + tag + " ", options.toString());
     assertTrue(options.hasTag());
     assertThat(options.tag()).isEqualTo(tag);
-    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    // Verify hashCode contract: equal objects must have equal hashCodes.
     Options options2 = Options.fromTransactionOptions(Options.tag(tag));
-    assertThat(options.equals(options2)).isTrue();
+    assertThat(options).isEqualTo(options2);
     assertThat(options.hashCode()).isEqualTo(options2.hashCode());
-    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OptionsTest.java
@@ -152,7 +152,11 @@ public class OptionsTest {
     assertThat(options.equals(null)).isFalse();
     assertThat(options.equals(this)).isFalse();
     assertNull(options.isolationLevel());
-    assertThat(options.hashCode()).isEqualTo(31);
+    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    Options options2 = Options.fromReadOptions();
+    assertThat(options.equals(options2)).isTrue();
+    assertThat(options.hashCode()).isEqualTo(options2.hashCode());
+    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test
@@ -175,7 +179,13 @@ public class OptionsTest {
     assertThat(options.pageSize()).isEqualTo(pageSize);
     assertThat(options.pageToken()).isEqualTo(pageToken);
     assertThat(options.filter()).isEqualTo(filter);
-    assertThat(options.hashCode()).isEqualTo(108027089);
+    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    Options options2 =
+        Options.fromListOptions(
+            Options.pageSize(pageSize), Options.pageToken(pageToken), Options.filter(filter));
+    assertThat(options.equals(options2)).isTrue();
+    assertThat(options.hashCode()).isEqualTo(options2.hashCode());
+    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test
@@ -696,7 +706,11 @@ public class OptionsTest {
     assertEquals("tag: " + tag + " ", options.toString());
     assertTrue(options.hasTag());
     assertThat(options.tag()).isEqualTo(tag);
-    assertThat(options.hashCode()).isEqualTo(-2118248262);
+    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    Options options2 = Options.fromUpdateOptions(Options.tag(tag));
+    assertThat(options.equals(options2)).isTrue();
+    assertThat(options.hashCode()).isEqualTo(options2.hashCode());
+    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test
@@ -728,7 +742,11 @@ public class OptionsTest {
     assertEquals("tag: " + tag + " ", options.toString());
     assertTrue(options.hasTag());
     assertThat(options.tag()).isEqualTo(tag);
-    assertThat(options.hashCode()).isEqualTo(-2118248262);
+    // Verify hashCode contract: equal objects must have equal hashCodes, and hashCode is stable.
+    Options options2 = Options.fromTransactionOptions(Options.tag(tag));
+    assertThat(options.equals(options2)).isTrue();
+    assertThat(options.hashCode()).isEqualTo(options2.hashCode());
+    assertThat(options.hashCode()).isEqualTo(options.hashCode());
   }
 
   @Test


### PR DESCRIPTION
`OptionsTest` contained four assertions that verified `Options#hashCode()` returns specific fixed integer values (31, 108027089, -2118248262). The Java `hashCode()` contract does not guarantee cross-JVM or cross-version stability of hash values, so testing against hardcoded numbers is brittle and misleads readers into thinking fixed values are part of the API contract.

This change replaces each fixed-value assertion in `allOptionsAbsent`, `listOptionsTest`, `updateOptionsTest`, and `transactionOptionsTest` with contract-compliance assertions: two equal `Options` instances produce equal hash codes, and calling `hashCode()` twice on the same instance returns the same value (stability within a session).

Fixes #12268
