### PR TITLE
ci: fix units filter to correctly exclude split repositories

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,20 +34,11 @@ jobs:
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
-        # we want to run tests if source code is changed or the scripts
-        # used to run the unit tests
         filters: |
           src:
-            - '**/*.java'
-            - '**/pom.xml'
-            - '!java-bigquery/**'
-            - '!java-bigquerystorage/**'
-            - '!java-datastore/**'
-            - '!java-logging-logback/**'
-            - '!java-logging/**'
-            - '!java-spanner/**'
-            - '!java-storage/**'
-            - '!google-auth-library-java/**'
+            - '!(java-bigquery|java-bigquerystorage|java-datastore|java-logging-logback|java-logging|java-spanner|java-storage|google-auth-library-java)/**/*.java'
+            - '!(java-bigquery|java-bigquerystorage|java-datastore|java-logging-logback|java-logging|java-spanner|java-storage|google-auth-library-java)/**/pom.xml'
+            - 'pom.xml'
           ci:
             - '.github/workflows/ci.yaml'
             - '.kokoro/**'


### PR DESCRIPTION
Update the `ci/ units (X)` job to only run when there is a java or pom.xml file change outside of the split repos (or CI file change.