### PR TITLE
chore(auth): Revert temporary configurable timeout values

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -36,7 +36,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Data;
-import com.google.api.core.InternalApi;
 import com.google.auth.RequestMetadataCallback;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.base.MoreObjects;
@@ -98,9 +97,6 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
 
   private EnvironmentProvider environmentProvider;
   private PropertyProvider propertyProvider;
-
-  private int connectTimeout;
-  private int readTimeout;
 
   /**
    * Constructor with minimum identifying information and custom HTTP transport. Does not support
@@ -281,8 +277,6 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
             : builder.metricsHandler;
 
     this.name = GoogleCredentialsInfo.EXTERNAL_ACCOUNT_CREDENTIALS.getCredentialName();
-    this.connectTimeout = builder.connectTimeout;
-    this.readTimeout = builder.readTimeout;
   }
 
   ImpersonatedCredentials buildImpersonatedCredentials() {
@@ -317,8 +311,6 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
         .setScopes(new ArrayList<>(scopes))
         .setLifetime(this.serviceAccountImpersonationOptions.lifetime)
         .setIamEndpointOverride(serviceAccountImpersonationUrl)
-        .setConnectTimeout(connectTimeout)
-        .setReadTimeout(readTimeout)
         .build();
   }
 
@@ -547,9 +539,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
 
     StsRequestHandler.Builder requestHandler =
         StsRequestHandler.newBuilder(
-                tokenUrl, stsTokenExchangeRequest, transportFactory.create().createRequestFactory())
-            .setConnectTimeout(connectTimeout)
-            .setReadTimeout(readTimeout);
+            tokenUrl, stsTokenExchangeRequest, transportFactory.create().createRequestFactory());
 
     // If this credential was initialized with a Workforce configuration then the
     // workforcePoolUserProject must be passed to the Security Token Service via the internal
@@ -792,9 +782,6 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     @Nullable protected String workforcePoolUserProject;
     @Nullable protected ServiceAccountImpersonationOptions serviceAccountImpersonationOptions;
 
-    protected int connectTimeout = 20000; // Default to 20000ms = 20s
-    protected int readTimeout = 20000; // Default to 20000ms = 20s
-
     /* The field is not being used and value not set. Superseded by the same field in the
     {@link GoogleCredentials.Builder}.
     */
@@ -821,8 +808,6 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
       this.workforcePoolUserProject = credentials.workforcePoolUserProject;
       this.serviceAccountImpersonationOptions = credentials.serviceAccountImpersonationOptions;
       this.metricsHandler = credentials.metricsHandler;
-      this.connectTimeout = credentials.connectTimeout;
-      this.readTimeout = credentials.readTimeout;
     }
 
     /**
@@ -1012,20 +997,6 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     @Override
     public Builder setUniverseDomain(String universeDomain) {
       super.setUniverseDomain(universeDomain);
-      return this;
-    }
-
-    /** Warning: Not for public use and can be removed at any time. */
-    @InternalApi
-    public Builder setConnectTimeout(int connectTimeout) {
-      this.connectTimeout = connectTimeout;
-      return this;
-    }
-
-    /** Warning: Not for public use and can be removed at any time. */
-    @InternalApi
-    public Builder setReadTimeout(int readTimeout) {
-      this.readTimeout = readTimeout;
       return this;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -44,7 +44,6 @@ import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.GenericData;
-import com.google.api.core.InternalApi;
 import com.google.api.core.ObsoleteApi;
 import com.google.auth.CredentialTypeForMetrics;
 import com.google.auth.ServiceAccountSigner;
@@ -117,9 +116,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
   private transient HttpTransportFactory transportFactory;
 
   private transient Calendar calendar;
-
-  private int connectTimeout;
-  private int readTimeout;
 
   /**
    * @param sourceCredentials the source credential used to acquire the impersonated credentials. It
@@ -567,8 +563,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
                   + "does not match %s universe domain set for impersonated credentials.",
               this.sourceCredentials.getUniverseDomain(), builder.getUniverseDomain()));
     }
-    this.connectTimeout = builder.connectTimeout;
-    this.readTimeout = builder.readTimeout;
   }
 
   /**
@@ -597,12 +591,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
         || (isDefaultUniverseDomain()
             && ((ServiceAccountCredentials) this.sourceCredentials)
                 .shouldUseAssertionFlowForGdu())) {
-      if (this.sourceCredentials instanceof IdentityPoolCredentials) {
-        this.sourceCredentials =
-            ((IdentityPoolCredentials) this.sourceCredentials)
-                .toBuilder().setConnectTimeout(connectTimeout).setReadTimeout(readTimeout).build();
-      }
-
       try {
         this.sourceCredentials.refreshIfExpired();
       } catch (IOException e) {
@@ -635,8 +623,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
     // Disable automatic logging by google-http-java-client to prevent leakage of sensitive tokens.
     // Client Library Debug Logging via LoggingUtils is used instead.
     request.setLoggingEnabled(false);
-    request.setConnectTimeout(connectTimeout);
-    request.setReadTimeout(readTimeout);
     adapter.initialize(request);
     request.setParser(parser);
     MetricsUtils.setMetricsHeader(
@@ -783,9 +769,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
     private String iamEndpointOverride;
     private Calendar calendar = Calendar.getInstance();
 
-    private int connectTimeout = 20000; // Default to 20000ms = 20s
-    private int readTimeout = 20000; // Default to 20000ms = 20s
-
     protected Builder() {}
 
     /**
@@ -809,8 +792,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
       this.lifetime = credentials.lifetime;
       this.transportFactory = credentials.transportFactory;
       this.iamEndpointOverride = credentials.iamEndpointOverride;
-      this.connectTimeout = credentials.connectTimeout;
-      this.readTimeout = credentials.readTimeout;
     }
 
     @CanIgnoreReturnValue
@@ -909,20 +890,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
     @ObsoleteApi("This method is obsolete and will be removed in a future release.")
     public Builder setCalendar(Calendar calendar) {
       this.calendar = calendar;
-      return this;
-    }
-
-    /** Warning: Not for public use and can be removed at any time. */
-    @InternalApi
-    public Builder setConnectTimeout(int connectTimeout) {
-      this.connectTimeout = connectTimeout;
-      return this;
-    }
-
-    /** Warning: Not for public use and can be removed at any time. */
-    @InternalApi
-    public Builder setReadTimeout(int readTimeout) {
-      this.readTimeout = readTimeout;
       return this;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
@@ -42,7 +42,6 @@ import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.util.GenericData;
-import com.google.api.core.InternalApi;
 import com.google.common.base.Joiner;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
@@ -77,22 +76,26 @@ public final class StsRequestHandler {
   @Nullable private final HttpHeaders headers;
   @Nullable private final String internalOptions;
 
-  private final int connectTimeout;
-  private final int readTimeout;
-
   /**
    * Internal constructor.
    *
+   * @param tokenExchangeEndpoint the token exchange endpoint
+   * @param request the token exchange request
+   * @param headers optional additional headers to pass along the request
+   * @param internalOptions optional GCP specific STS options
    * @return an StsTokenExchangeResponse instance if the request was successful
    */
-  private StsRequestHandler(Builder builder) {
-    this.tokenExchangeEndpoint = builder.tokenExchangeEndpoint;
-    this.request = builder.request;
-    this.httpRequestFactory = builder.httpRequestFactory;
-    this.headers = builder.headers;
-    this.internalOptions = builder.internalOptions;
-    this.connectTimeout = builder.connectTimeout;
-    this.readTimeout = builder.readTimeout;
+  private StsRequestHandler(
+      String tokenExchangeEndpoint,
+      StsTokenExchangeRequest request,
+      HttpRequestFactory httpRequestFactory,
+      @Nullable HttpHeaders headers,
+      @Nullable String internalOptions) {
+    this.tokenExchangeEndpoint = tokenExchangeEndpoint;
+    this.request = request;
+    this.httpRequestFactory = httpRequestFactory;
+    this.headers = headers;
+    this.internalOptions = internalOptions;
   }
 
   /**
@@ -125,8 +128,6 @@ public final class StsRequestHandler {
     if (headers != null) {
       httpRequest.setHeaders(headers);
     }
-    httpRequest.setConnectTimeout(connectTimeout);
-    httpRequest.setReadTimeout(readTimeout);
 
     try {
       LoggingUtils.logRequest(httpRequest, LOGGER_PROVIDER, "Sending request for token exchange");
@@ -225,9 +226,6 @@ public final class StsRequestHandler {
     @Nullable private HttpHeaders headers;
     @Nullable private String internalOptions;
 
-    private int connectTimeout = 20000; // Default to 20000ms = 20s
-    private int readTimeout = 20000; // Default to 20000ms = 20s
-
     private Builder(
         String tokenExchangeEndpoint,
         StsTokenExchangeRequest stsTokenExchangeRequest,
@@ -249,22 +247,9 @@ public final class StsRequestHandler {
       return this;
     }
 
-    /** Warning: Not for public use and can be removed at any time. */
-    @InternalApi
-    public StsRequestHandler.Builder setConnectTimeout(int connectTimeout) {
-      this.connectTimeout = connectTimeout;
-      return this;
-    }
-
-    /** Warning: Not for public use and can be removed at any time. */
-    @InternalApi
-    public StsRequestHandler.Builder setReadTimeout(int readTimeout) {
-      this.readTimeout = readTimeout;
-      return this;
-    }
-
     public StsRequestHandler build() {
-      return new StsRequestHandler(this);
+      return new StsRequestHandler(
+          tokenExchangeEndpoint, request, httpRequestFactory, headers, internalOptions);
     }
   }
 }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
@@ -76,26 +76,12 @@ public final class StsRequestHandler {
   @Nullable private final HttpHeaders headers;
   @Nullable private final String internalOptions;
 
-  /**
-   * Internal constructor.
-   *
-   * @param tokenExchangeEndpoint the token exchange endpoint
-   * @param request the token exchange request
-   * @param headers optional additional headers to pass along the request
-   * @param internalOptions optional GCP specific STS options
-   * @return an StsTokenExchangeResponse instance if the request was successful
-   */
-  private StsRequestHandler(
-      String tokenExchangeEndpoint,
-      StsTokenExchangeRequest request,
-      HttpRequestFactory httpRequestFactory,
-      @Nullable HttpHeaders headers,
-      @Nullable String internalOptions) {
-    this.tokenExchangeEndpoint = tokenExchangeEndpoint;
-    this.request = request;
-    this.httpRequestFactory = httpRequestFactory;
-    this.headers = headers;
-    this.internalOptions = internalOptions;
+  private StsRequestHandler(Builder builder) {
+    this.tokenExchangeEndpoint = builder.tokenExchangeEndpoint;
+    this.request = builder.request;
+    this.httpRequestFactory = builder.httpRequestFactory;
+    this.headers = builder.headers;
+    this.internalOptions = builder.internalOptions;
   }
 
   /**
@@ -248,8 +234,7 @@ public final class StsRequestHandler {
     }
 
     public StsRequestHandler build() {
-      return new StsRequestHandler(
-          tokenExchangeEndpoint, request, httpRequestFactory, headers, internalOptions);
+      return new StsRequestHandler(this);
     }
   }
 }


### PR DESCRIPTION
Introduced in https://github.com/googleapis/google-auth-library-java/pull/1847, this was temporary configurable timeout values for b/461522544 intended to unblock certain customers. However, it does not seem to have resolved the root issue and I am reverting this change.