### PR TITLE
fix(auth): handle null APPDATA environment variable in GoogleAuthUtils.getWellKnownCredentialsFile

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleAuthUtils.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleAuthUtils.java
@@ -32,6 +32,8 @@
 package com.google.auth.oauth2;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.UncheckedIOException;
 
 /**
  * This public class provides shared utilities for common OAuth2 utils or ADC. It also exposes
@@ -70,7 +72,14 @@ public class GoogleAuthUtils {
     if (envPath != null) {
       cloudConfigPath = new File(envPath);
     } else if (provider.getOsName().indexOf("windows") >= 0) {
-      File appDataPath = new File(provider.getEnv("APPDATA"));
+      String appDataEnv = provider.getEnv("APPDATA");
+      if (appDataEnv == null) {
+        throw new UncheckedIOException(
+            new FileNotFoundException(
+                "APPDATA environment variable is not set; cannot locate the well-known"
+                    + " credentials file on Windows."));
+      }
+      File appDataPath = new File(appDataEnv);
       cloudConfigPath = new File(appDataPath, provider.CLOUDSDK_CONFIG_DIRECTORY);
     } else {
       File configPath = new File(provider.getProperty("user.home", ""), ".config");

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleAuthUtils.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleAuthUtils.java
@@ -73,10 +73,10 @@ public class GoogleAuthUtils {
       cloudConfigPath = new File(envPath);
     } else if (provider.getOsName().indexOf("windows") >= 0) {
       String appDataEnv = provider.getEnv("APPDATA");
-      if (appDataEnv == null) {
+      if (appDataEnv == null || appDataEnv.trim().isEmpty()) {
         throw new UncheckedIOException(
             new FileNotFoundException(
-                "APPDATA environment variable is not set; cannot locate the well-known"
+                "APPDATA environment variable is not set or empty; cannot locate the well-known"
                     + " credentials file on Windows."));
       }
       File appDataPath = new File(appDataEnv);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/GoogleAuthUtilsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/GoogleAuthUtilsTest.java
@@ -56,6 +56,39 @@ class GoogleAuthUtilsTest {
             () -> GoogleAuthUtils.getWellKnownCredentialsFile(provider));
     assertTrue(thrown.getCause() instanceof FileNotFoundException);
     assertTrue(thrown.getCause().getMessage().contains("APPDATA"));
+    assertTrue(thrown.getCause().getMessage().contains("not set or empty"));
+  }
+
+  @Test
+  void getWellKnownCredentialsFile_windows_emptyAppData_throwsUncheckedIOException() {
+    DefaultCredentialsProviderTest.TestDefaultCredentialsProvider provider =
+        new DefaultCredentialsProviderTest.TestDefaultCredentialsProvider();
+    provider.setProperty("os.name", "windows");
+    provider.setEnv("APPDATA", "");
+
+    UncheckedIOException thrown =
+        assertThrows(
+            UncheckedIOException.class,
+            () -> GoogleAuthUtils.getWellKnownCredentialsFile(provider));
+    assertTrue(thrown.getCause() instanceof FileNotFoundException);
+    assertTrue(thrown.getCause().getMessage().contains("APPDATA"));
+    assertTrue(thrown.getCause().getMessage().contains("not set or empty"));
+  }
+
+  @Test
+  void getWellKnownCredentialsFile_windows_blankAppData_throwsUncheckedIOException() {
+    DefaultCredentialsProviderTest.TestDefaultCredentialsProvider provider =
+        new DefaultCredentialsProviderTest.TestDefaultCredentialsProvider();
+    provider.setProperty("os.name", "windows");
+    provider.setEnv("APPDATA", "   ");
+
+    UncheckedIOException thrown =
+        assertThrows(
+            UncheckedIOException.class,
+            () -> GoogleAuthUtils.getWellKnownCredentialsFile(provider));
+    assertTrue(thrown.getCause() instanceof FileNotFoundException);
+    assertTrue(thrown.getCause().getMessage().contains("APPDATA"));
+    assertTrue(thrown.getCause().getMessage().contains("not set or empty"));
   }
 
   @Test

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/GoogleAuthUtilsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/GoogleAuthUtilsTest.java
@@ -33,11 +33,30 @@ package com.google.auth.oauth2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.UncheckedIOException;
 import org.junit.jupiter.api.Test;
 
 class GoogleAuthUtilsTest {
+
+  @Test
+  void getWellKnownCredentialsFile_windows_nullAppData_throwsUncheckedIOException() {
+    DefaultCredentialsProviderTest.TestDefaultCredentialsProvider provider =
+        new DefaultCredentialsProviderTest.TestDefaultCredentialsProvider();
+    provider.setProperty("os.name", "windows");
+    // APPDATA is intentionally not set, so getEnv("APPDATA") returns null
+
+    UncheckedIOException thrown =
+        assertThrows(
+            UncheckedIOException.class,
+            () -> GoogleAuthUtils.getWellKnownCredentialsFile(provider));
+    assertTrue(thrown.getCause() instanceof FileNotFoundException);
+    assertTrue(thrown.getCause().getMessage().contains("APPDATA"));
+  }
 
   @Test
   void getWellKnownCredentialsPath_correct() {


### PR DESCRIPTION
In `GoogleAuthUtils.getWellKnownCredentialsFile()`, on Windows systems where `CLOUDSDK_CONFIG` is unset, the code calls `provider.getEnv("APPDATA")` and passes the result directly to `new File(String)`. When `APPDATA` is not present in the environment, `getEnv()` returns `null`, and `new File(null)` immediately throws a raw `NullPointerException` with no useful context.

The fix adds an explicit null check after retrieving the `APPDATA` value. When it is null, the method now throws an `UncheckedIOException` wrapping a `FileNotFoundException` with a descriptive message indicating that `APPDATA` is not set, rather than propagating an opaque `NullPointerException`. This is consistent with the library's overall approach of surfacing meaningful errors when credential paths cannot be resolved.

A regression test in `GoogleAuthUtilsTest` verifies that the new exception type and message are produced when `APPDATA` is absent on a simulated Windows environment.

Fixes #12565
