### PR TITLE
feat(bqjdbc): extend OpenTelemetry instrumentation for metadata and pagination

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -216,68 +216,69 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean next() throws SQLException {
     checkClosed();
-    try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
-      if (this.isNested) {
-        if (this.currentNestedBatch == null || this.currentNestedBatch.getNestedRecords() == null) {
-          throw new IllegalStateException(
-              "currentNestedBatch/JsonStringArrayList can not be null working with the nested record");
-        }
-        if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
-          /* Check if there's a next record in the array which can be read */
-          this.nestedRowIndex++;
-          return true;
-        }
+    if (this.isNested) {
+      if (this.currentNestedBatch == null || this.currentNestedBatch.getNestedRecords() == null) {
+        throw new IllegalStateException(
+            "currentNestedBatch/JsonStringArrayList can not be null working with the nested record");
+      }
+      if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
+        /* Check if there's a next record in the array which can be read */
+        this.nestedRowIndex++;
+        return true;
+      }
+      this.afterLast = true;
+      return false;
+    } else {
+      /* Non nested */
+      if (this.hasReachedEnd || this.isLast()) {
         this.afterLast = true;
         return false;
-      } else {
-        /* Non nested */
-        if (this.hasReachedEnd || this.isLast()) {
-          this.afterLast = true;
-          return false;
-        }
-        try {
-          if (this.currentBatchRowIndex == -1
-              || this.currentBatchRowIndex == (this.vectorSchemaRoot.getRowCount() - 1)) {
-            /* Start of iteration or we have exhausted the current batch */
-            // Advance the cursor. Potentially blocking operation.
-            BigQueryArrowBatchWrapper batchWrapper = this.buffer.take();
-            if (batchWrapper.getException() != null) {
-              throw new BigQueryJdbcRuntimeException(batchWrapper.getException());
-            }
-            if (batchWrapper.isLast()) {
-              /* Marks the end of the records */
-              if (this.vectorSchemaRoot != null) {
-                // IMP: To avoid memory leak: clear vectorSchemaRoot as it still holds
-                // the last batch
-                this.vectorSchemaRoot.clear();
-              }
-              this.hasReachedEnd = true;
-              this.rowCount++;
-              return false;
-            }
-            // Valid batch, process it
-            ArrowRecordBatch arrowBatch = batchWrapper.getCurrentArrowBatch();
-            // Populates vectorSchemaRoot
-            this.arrowDeserializer.deserializeArrowBatch(arrowBatch);
-            // Pointing to the first row in this fresh batch
-            this.currentBatchRowIndex = 0;
-            this.rowCount++;
-            return true;
-          }
-          // There are rows left in the current batch.
-          else if (this.currentBatchRowIndex < this.vectorSchemaRoot.getRowCount()) {
-            this.currentBatchRowIndex++;
-            this.rowCount++;
-            return true;
-          }
-        } catch (InterruptedException | SQLException ex) {
-          throw new BigQueryJdbcException(
-              "Error occurred while advancing the cursor. This could happen when connection is closed while the next method is being called.",
-              ex);
-        }
       }
-      return false;
+      try {
+        if (this.currentBatchRowIndex == -1
+            || this.currentBatchRowIndex == (this.vectorSchemaRoot.getRowCount() - 1)) {
+          /* Start of iteration or we have exhausted the current batch */
+          // Advance the cursor. Potentially blocking operation.
+          BigQueryArrowBatchWrapper batchWrapper;
+          try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
+            batchWrapper = this.buffer.take();
+          }
+          if (batchWrapper.getException() != null) {
+            throw new BigQueryJdbcRuntimeException(batchWrapper.getException());
+          }
+          if (batchWrapper.isLast()) {
+            /* Marks the end of the records */
+            if (this.vectorSchemaRoot != null) {
+              // IMP: To avoid memory leak: clear vectorSchemaRoot as it still holds
+              // the last batch
+              this.vectorSchemaRoot.clear();
+            }
+            this.hasReachedEnd = true;
+            this.rowCount++;
+            return false;
+          }
+          // Valid batch, process it
+          ArrowRecordBatch arrowBatch = batchWrapper.getCurrentArrowBatch();
+          // Populates vectorSchemaRoot
+          this.arrowDeserializer.deserializeArrowBatch(arrowBatch);
+          // Pointing to the first row in this fresh batch
+          this.currentBatchRowIndex = 0;
+          this.rowCount++;
+          return true;
+        }
+        // There are rows left in the current batch.
+        else if (this.currentBatchRowIndex < this.vectorSchemaRoot.getRowCount()) {
+          this.currentBatchRowIndex++;
+          this.rowCount++;
+          return true;
+        }
+      } catch (InterruptedException | SQLException ex) {
+        throw new BigQueryJdbcException(
+            "Error occurred while advancing the cursor. This could happen when connection is closed while the next method is being called.",
+            ex);
+      }
     }
+    return false;
   }
 
   private Object getObjectInternal(int columnIndex) throws SQLException {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -27,8 +27,6 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
 import com.google.cloud.bigquery.storage.v1.ArrowRecordBatch;
 import com.google.cloud.bigquery.storage.v1.ArrowSchema;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -239,32 +237,31 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
             || this.currentBatchRowIndex == (this.vectorSchemaRoot.getRowCount() - 1)) {
           /* Start of iteration or we have exhausted the current batch */
           // Advance the cursor. Potentially blocking operation.
-          BigQueryArrowBatchWrapper batchWrapper;
-          try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
-            batchWrapper = this.buffer.take();
-          }
-          if (batchWrapper.getException() != null) {
-            throw new BigQueryJdbcRuntimeException(batchWrapper.getException());
-          }
-          if (batchWrapper.isLast()) {
-            /* Marks the end of the records */
-            if (this.vectorSchemaRoot != null) {
-              // IMP: To avoid memory leak: clear vectorSchemaRoot as it still holds
-              // the last batch
-              this.vectorSchemaRoot.clear();
+          try (Scope scope = makeOriginalContextCurrent()) {
+            BigQueryArrowBatchWrapper batchWrapper = this.buffer.take();
+            if (batchWrapper.getException() != null) {
+              throw new BigQueryJdbcRuntimeException(batchWrapper.getException());
             }
-            this.hasReachedEnd = true;
+            if (batchWrapper.isLast()) {
+              /* Marks the end of the records */
+              if (this.vectorSchemaRoot != null) {
+                // IMP: To avoid memory leak: clear vectorSchemaRoot as it still holds
+                // the last batch
+                this.vectorSchemaRoot.clear();
+              }
+              this.hasReachedEnd = true;
+              this.rowCount++;
+              return false;
+            }
+            // Valid batch, process it
+            ArrowRecordBatch arrowBatch = batchWrapper.getCurrentArrowBatch();
+            // Populates vectorSchemaRoot
+            this.arrowDeserializer.deserializeArrowBatch(arrowBatch);
+            // Pointing to the first row in this fresh batch
+            this.currentBatchRowIndex = 0;
             this.rowCount++;
-            return false;
+            return true;
           }
-          // Valid batch, process it
-          ArrowRecordBatch arrowBatch = batchWrapper.getCurrentArrowBatch();
-          // Populates vectorSchemaRoot
-          this.arrowDeserializer.deserializeArrowBatch(arrowBatch);
-          // Pointing to the first row in this fresh batch
-          this.currentBatchRowIndex = 0;
-          this.rowCount++;
-          return true;
         }
         // There are rows left in the current batch.
         else if (this.currentBatchRowIndex < this.vectorSchemaRoot.getRowCount()) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -27,6 +27,9 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
 import com.google.cloud.bigquery.storage.v1.ArrowRecordBatch;
 import com.google.cloud.bigquery.storage.v1.ArrowSchema;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -213,66 +216,68 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean next() throws SQLException {
     checkClosed();
-    if (this.isNested) {
-      if (this.currentNestedBatch == null || this.currentNestedBatch.getNestedRecords() == null) {
-        throw new IllegalStateException(
-            "currentNestedBatch/JsonStringArrayList can not be null working with the nested record");
-      }
-      if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
-        /* Check if there's a next record in the array which can be read */
-        this.nestedRowIndex++;
-        return true;
-      }
-      this.afterLast = true;
-      return false;
-    } else {
-      /* Non nested */
-      if (this.hasReachedEnd || this.isLast()) {
+    try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
+      if (this.isNested) {
+        if (this.currentNestedBatch == null || this.currentNestedBatch.getNestedRecords() == null) {
+          throw new IllegalStateException(
+              "currentNestedBatch/JsonStringArrayList can not be null working with the nested record");
+        }
+        if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
+          /* Check if there's a next record in the array which can be read */
+          this.nestedRowIndex++;
+          return true;
+        }
         this.afterLast = true;
         return false;
-      }
-      try {
-        if (this.currentBatchRowIndex == -1
-            || this.currentBatchRowIndex == (this.vectorSchemaRoot.getRowCount() - 1)) {
-          /* Start of iteration or we have exhausted the current batch */
-          // Advance the cursor. Potentially blocking operation.
-          BigQueryArrowBatchWrapper batchWrapper = this.buffer.take();
-          if (batchWrapper.getException() != null) {
-            throw new BigQueryJdbcRuntimeException(batchWrapper.getException());
-          }
-          if (batchWrapper.isLast()) {
-            /* Marks the end of the records */
-            if (this.vectorSchemaRoot != null) {
-              // IMP: To avoid memory leak: clear vectorSchemaRoot as it still holds
-              // the last batch
-              this.vectorSchemaRoot.clear();
+      } else {
+        /* Non nested */
+        if (this.hasReachedEnd || this.isLast()) {
+          this.afterLast = true;
+          return false;
+        }
+        try {
+          if (this.currentBatchRowIndex == -1
+              || this.currentBatchRowIndex == (this.vectorSchemaRoot.getRowCount() - 1)) {
+            /* Start of iteration or we have exhausted the current batch */
+            // Advance the cursor. Potentially blocking operation.
+            BigQueryArrowBatchWrapper batchWrapper = this.buffer.take();
+            if (batchWrapper.getException() != null) {
+              throw new BigQueryJdbcRuntimeException(batchWrapper.getException());
             }
-            this.hasReachedEnd = true;
+            if (batchWrapper.isLast()) {
+              /* Marks the end of the records */
+              if (this.vectorSchemaRoot != null) {
+                // IMP: To avoid memory leak: clear vectorSchemaRoot as it still holds
+                // the last batch
+                this.vectorSchemaRoot.clear();
+              }
+              this.hasReachedEnd = true;
+              this.rowCount++;
+              return false;
+            }
+            // Valid batch, process it
+            ArrowRecordBatch arrowBatch = batchWrapper.getCurrentArrowBatch();
+            // Populates vectorSchemaRoot
+            this.arrowDeserializer.deserializeArrowBatch(arrowBatch);
+            // Pointing to the first row in this fresh batch
+            this.currentBatchRowIndex = 0;
             this.rowCount++;
-            return false;
+            return true;
           }
-          // Valid batch, process it
-          ArrowRecordBatch arrowBatch = batchWrapper.getCurrentArrowBatch();
-          // Populates vectorSchemaRoot
-          this.arrowDeserializer.deserializeArrowBatch(arrowBatch);
-          // Pointing to the first row in this fresh batch
-          this.currentBatchRowIndex = 0;
-          this.rowCount++;
-          return true;
+          // There are rows left in the current batch.
+          else if (this.currentBatchRowIndex < this.vectorSchemaRoot.getRowCount()) {
+            this.currentBatchRowIndex++;
+            this.rowCount++;
+            return true;
+          }
+        } catch (InterruptedException | SQLException ex) {
+          throw new BigQueryJdbcException(
+              "Error occurred while advancing the cursor. This could happen when connection is closed while the next method is being called.",
+              ex);
         }
-        // There are rows left in the current batch.
-        else if (this.currentBatchRowIndex < this.vectorSchemaRoot.getRowCount()) {
-          this.currentBatchRowIndex++;
-          this.rowCount++;
-          return true;
-        }
-      } catch (InterruptedException | SQLException ex) {
-        throw new BigQueryJdbcException(
-            "Error occurred while advancing the cursor. This could happen when connection is closed while the next method is being called.",
-            ex);
       }
+      return false;
     }
-    return false;
   }
 
   private Object getObjectInternal(int columnIndex) throws SQLException {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -29,6 +29,8 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcCoercionException;
 import com.google.cloud.bigquery.exception.BigQueryJdbcCoercionNotFoundException;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -70,6 +72,10 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
     this.schemaFieldList = schema != null ? schema.getFields() : null;
     this.isNested = isNested;
     this.originalSpanContext = Span.current().getSpanContext();
+  }
+
+  protected Scope makeOriginalContextCurrent() {
+    return Context.current().with(Span.wrap(this.originalSpanContext)).makeCurrent();
   }
 
   public QueryStatistics getQueryStatistics() {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -27,6 +27,8 @@ import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.exception.BigQueryConversionException;
 import com.google.cloud.bigquery.exception.BigQueryJdbcCoercionException;
 import com.google.cloud.bigquery.exception.BigQueryJdbcCoercionNotFoundException;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -58,6 +60,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   protected boolean isClosed = false;
   protected boolean wasNull = false;
   protected final BigQueryTypeCoercer bigQueryTypeCoercer = BigQueryTypeCoercionUtility.INSTANCE;
+  protected final SpanContext originalSpanContext;
 
   protected BigQueryBaseResultSet(
       BigQuery bigQuery, BigQueryStatement statement, Schema schema, boolean isNested) {
@@ -66,6 +69,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
     this.schema = schema;
     this.schemaFieldList = schema != null ? schema.getFields() : null;
     this.isNested = isNested;
+    this.originalSpanContext = Span.current().getSpanContext();
   }
 
   public QueryStatistics getQueryStatistics() {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -44,6 +44,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -1744,6 +1745,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             Span backgroundSpan =
                 tracer
                     .spanBuilder("BigQueryDatabaseMetaData.getTables.background")
+                    .setNoParent()
                     .addLink(parentSpanContext)
                     .startSpan();
 
@@ -1900,6 +1902,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       return resultSet;
     } catch (Exception e) {
       span.recordException(e);
+      span.setStatus(StatusCode.ERROR, e.getMessage());
       throw e;
     } finally {
       span.end();
@@ -2045,6 +2048,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
           catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
     } catch (Exception e) {
       span.recordException(e);
+      span.setStatus(StatusCode.ERROR, e.getMessage());
       throw e;
     } finally {
       span.end();
@@ -2145,6 +2149,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             Span backgroundSpan =
                 tracer
                     .spanBuilder("BigQueryDatabaseMetaData.getColumns.background")
+                    .setNoParent()
                     .addLink(parentSpanContext)
                     .startSpan();
 
@@ -2258,6 +2263,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       return resultSet;
     } catch (Exception e) {
       span.recordException(e);
+      span.setStatus(StatusCode.ERROR, e.getMessage());
       throw e;
     } finally {
       span.end();
@@ -3707,6 +3713,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             Span backgroundSpan =
                 tracer
                     .spanBuilder("BigQueryDatabaseMetaData.getSchemas.background")
+                    .setNoParent()
                     .addLink(parentSpanContext)
                     .startSpan();
 
@@ -3799,6 +3806,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       return resultSet;
     } catch (Exception e) {
       span.recordException(e);
+      span.setStatus(StatusCode.ERROR, e.getMessage());
       throw e;
     } finally {
       span.end();

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -1745,7 +1745,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final String catalogParam = effectiveCatalog;
     final String schemaParam = effectiveSchemaPattern;
 
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Tracer tracer = this.connection.getTracer();
     SpanContext parentSpanContext = Span.current().getSpanContext();
     Runnable tableFetcher =
         () -> {
@@ -2139,7 +2139,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final String catalogParam = effectiveCatalog;
     final String schemaParam = effectiveSchemaPattern;
 
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Tracer tracer = this.connection.getTracer();
     SpanContext parentSpanContext = Span.current().getSpanContext();
     Runnable columnFetcher =
         () -> {
@@ -3699,7 +3699,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
     final String catalogParam = catalog;
 
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Tracer tracer = this.connection.getTracer();
     SpanContext parentSpanContext = Span.current().getSpanContext();
     Runnable schemaFetcher =
         () -> {
@@ -5377,7 +5377,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   private <T> T withTracing(String spanName, TracedMetadataOperation<T> operation)
       throws SQLException {
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Tracer tracer = this.connection.getTracer();
     Span span = tracer.spanBuilder(spanName).startSpan();
     try (Scope scope = span.makeCurrent()) {
       return operation.run();

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -42,6 +42,10 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.exception.BigQueryJdbcException;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1699,179 +1703,193 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getTables(
       String catalog, String schemaPattern, String tableNamePattern, String[] types) {
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getTables").startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      Tuple<String, String> effectiveIdentifiers =
+          determineEffectiveCatalogAndSchema(catalog, schemaPattern);
+      String effectiveCatalog = effectiveIdentifiers.x();
+      String effectiveSchemaPattern = effectiveIdentifiers.y();
 
-    Tuple<String, String> effectiveIdentifiers =
-        determineEffectiveCatalogAndSchema(catalog, schemaPattern);
-    String effectiveCatalog = effectiveIdentifiers.x();
-    String effectiveSchemaPattern = effectiveIdentifiers.y();
+      if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
+          || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
+          || (tableNamePattern != null && tableNamePattern.isEmpty())) {
+        LOG.warning(
+            "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
+        return new BigQueryJsonResultSet();
+      }
 
-    if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
-        || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
-        || (tableNamePattern != null && tableNamePattern.isEmpty())) {
-      LOG.warning(
-          "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
-      return new BigQueryJsonResultSet();
-    }
+      LOG.info(
+          "getTables called for catalog: %s, schemaPattern: %s, tableNamePattern: %s, types: %s",
+          effectiveCatalog, effectiveSchemaPattern, tableNamePattern, Arrays.toString(types));
 
-    LOG.info(
-        "getTables called for catalog: %s, schemaPattern: %s, tableNamePattern: %s, types: %s",
-        effectiveCatalog, effectiveSchemaPattern, tableNamePattern, Arrays.toString(types));
+      final Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
+      final Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
+      final Set<String> requestedTypes =
+          (types == null || types.length == 0) ? null : new HashSet<>(Arrays.asList(types));
 
-    final Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
-    final Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
-    final Set<String> requestedTypes =
-        (types == null || types.length == 0) ? null : new HashSet<>(Arrays.asList(types));
+      final Schema resultSchema = defineGetTablesSchema();
+      final FieldList resultSchemaFields = resultSchema.getFields();
 
-    final Schema resultSchema = defineGetTablesSchema();
-    final FieldList resultSchemaFields = resultSchema.getFields();
+      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+          new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+      final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
+      final String catalogParam = effectiveCatalog;
+      final String schemaParam = effectiveSchemaPattern;
 
-    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-        new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
-    final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
-    final String catalogParam = effectiveCatalog;
-    final String schemaParam = effectiveSchemaPattern;
+      Runnable tableFetcher =
+          () -> {
+            ExecutorService apiExecutor = null;
+            ExecutorService tableProcessorExecutor = null;
+            final FieldList localResultSchemaFields = resultSchemaFields;
+            final List<Future<List<Table>>> apiFutures = new ArrayList<>();
+            final List<Future<?>> processingFutures = new ArrayList<>();
 
-    Runnable tableFetcher =
-        () -> {
-          ExecutorService apiExecutor = null;
-          ExecutorService tableProcessorExecutor = null;
-          final FieldList localResultSchemaFields = resultSchemaFields;
-          final List<Future<List<Table>>> apiFutures = new ArrayList<>();
-          final List<Future<?>> processingFutures = new ArrayList<>();
+            try {
+              List<Dataset> datasetsToScan =
+                  findMatchingBigQueryObjects(
+                      "Dataset",
+                      () ->
+                          bigquery.listDatasets(
+                              catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                      (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
+                      (ds) -> ds.getDatasetId().getDataset(),
+                      schemaParam,
+                      schemaRegex,
+                      LOG);
 
-          try {
-            List<Dataset> datasetsToScan =
-                findMatchingBigQueryObjects(
-                    "Dataset",
-                    () ->
-                        bigquery.listDatasets(
-                            catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                    (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
-                    (ds) -> ds.getDatasetId().getDataset(),
-                    schemaParam,
-                    schemaRegex,
-                    LOG);
-
-            if (datasetsToScan.isEmpty()) {
-              LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
-              return;
-            }
-
-            apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
-            tableProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
-
-            LOG.fine("Submitting parallel findMatchingTables tasks...");
-            for (Dataset dataset : datasetsToScan) {
-              if (Thread.currentThread().isInterrupted()) {
-                LOG.warning("Table fetcher interrupted during dataset iteration.");
-                break;
+              if (datasetsToScan.isEmpty()) {
+                LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
+                return;
               }
 
-              final DatasetId currentDatasetId = dataset.getDatasetId();
-              Callable<List<Table>> apiCallable =
-                  () ->
-                      findMatchingBigQueryObjects(
-                          "Table",
-                          () ->
-                              bigquery.listTables(
-                                  currentDatasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                          (name) ->
-                              bigquery.getTable(
-                                  TableId.of(
-                                      currentDatasetId.getProject(),
-                                      currentDatasetId.getDataset(),
-                                      name)),
-                          (tbl) -> tbl.getTableId().getTable(),
-                          tableNamePattern,
-                          tableNameRegex,
-                          LOG);
-              Future<List<Table>> apiFuture = apiExecutor.submit(apiCallable);
-              apiFutures.add(apiFuture);
-            }
-            LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
-            apiExecutor.shutdown();
+              apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
+              tableProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
 
-            LOG.fine("Processing results from findMatchingTables tasks...");
-            for (Future<List<Table>> apiFuture : apiFutures) {
-              if (Thread.currentThread().isInterrupted()) {
-                LOG.warning("Table fetcher interrupted while processing API futures.");
-                break;
-              }
-              try {
-                List<Table> tablesResult = apiFuture.get();
-                if (tablesResult != null) {
-                  for (Table table : tablesResult) {
-                    if (Thread.currentThread().isInterrupted()) break;
-
-                    final Table currentTable = table;
-                    Future<?> processFuture =
-                        tableProcessorExecutor.submit(
-                            () ->
-                                processTableInfo(
-                                    currentTable,
-                                    requestedTypes,
-                                    collectedResults,
-                                    localResultSchemaFields));
-                    processingFutures.add(processFuture);
-                  }
+              LOG.fine("Submitting parallel findMatchingTables tasks...");
+              for (Dataset dataset : datasetsToScan) {
+                if (Thread.currentThread().isInterrupted()) {
+                  LOG.warning("Table fetcher interrupted during dataset iteration.");
+                  break;
                 }
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                LOG.warning("Fetcher thread interrupted while waiting for API future result.");
-                break;
-              } catch (ExecutionException e) {
-                LOG.warning(
-                    "Error executing findMatchingTables task: "
-                        + e.getMessage()
-                        + ". Cause: "
-                        + e.getCause());
-              } catch (CancellationException e) {
-                LOG.warning("A findMatchingTables task was cancelled.");
+
+                final DatasetId currentDatasetId = dataset.getDatasetId();
+                Callable<List<Table>> apiCallable =
+                    () ->
+                        findMatchingBigQueryObjects(
+                            "Table",
+                            () ->
+                                bigquery.listTables(
+                                    currentDatasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                            (name) ->
+                                bigquery.getTable(
+                                    TableId.of(
+                                        currentDatasetId.getProject(),
+                                        currentDatasetId.getDataset(),
+                                        name)),
+                            (tbl) -> tbl.getTableId().getTable(),
+                            tableNamePattern,
+                            tableNameRegex,
+                            LOG);
+
+                Callable<List<Table>> wrappedApiCallable = Context.current().wrap(apiCallable);
+                Future<List<Table>> apiFuture = apiExecutor.submit(wrappedApiCallable);
+                apiFutures.add(apiFuture);
               }
-            }
+              LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
+              apiExecutor.shutdown();
 
-            LOG.fine(
-                "Finished submitting " + processingFutures.size() + " processTableInfo tasks.");
+              LOG.fine("Processing results from findMatchingTables tasks...");
+              for (Future<List<Table>> apiFuture : apiFutures) {
+                if (Thread.currentThread().isInterrupted()) {
+                  LOG.warning("Table fetcher interrupted while processing API futures.");
+                  break;
+                }
+                try {
+                  List<Table> tablesResult = apiFuture.get();
+                  if (tablesResult != null) {
+                    for (Table table : tablesResult) {
+                      if (Thread.currentThread().isInterrupted()) break;
 
-            if (Thread.currentThread().isInterrupted()) {
-              LOG.warning(
-                  "Fetcher interrupted before waiting for processing tasks; cancelling remaining.");
+                      final Table currentTable = table;
+                      Runnable processRunnable =
+                          () ->
+                              processTableInfo(
+                                  currentTable,
+                                  requestedTypes,
+                                  collectedResults,
+                                  localResultSchemaFields);
+                      Runnable wrappedProcessRunnable = Context.current().wrap(processRunnable);
+                      Future<?> processFuture =
+                          tableProcessorExecutor.submit(wrappedProcessRunnable);
+                      processingFutures.add(processFuture);
+                    }
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  LOG.warning("Fetcher thread interrupted while waiting for API future result.");
+                  break;
+                } catch (ExecutionException e) {
+                  LOG.warning(
+                      "Error executing findMatchingTables task: "
+                          + e.getMessage()
+                          + ". Cause: "
+                          + e.getCause());
+                } catch (CancellationException e) {
+                  LOG.warning("A findMatchingTables task was cancelled.");
+                }
+              }
+
+              LOG.fine(
+                  "Finished submitting " + processingFutures.size() + " processTableInfo tasks.");
+
+              if (Thread.currentThread().isInterrupted()) {
+                LOG.warning(
+                    "Fetcher interrupted before waiting for processing tasks; cancelling remaining.");
+                processingFutures.forEach(f -> f.cancel(true));
+              } else {
+                LOG.fine("Waiting for processTableInfo tasks to complete...");
+                waitForTasksCompletion(processingFutures);
+                LOG.fine("All processTableInfo tasks completed.");
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                Comparator<FieldValueList> comparator =
+                    defineGetTablesComparator(localResultSchemaFields);
+                sortResults(collectedResults, comparator, "getTables", LOG);
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                populateQueue(collectedResults, queue, localResultSchemaFields);
+              }
+
+            } catch (Throwable t) {
+              LOG.severe("Unexpected error in table fetcher runnable: " + t.getMessage());
+              apiFutures.forEach(f -> f.cancel(true));
               processingFutures.forEach(f -> f.cancel(true));
-            } else {
-              LOG.fine("Waiting for processTableInfo tasks to complete...");
-              waitForTasksCompletion(processingFutures);
-              LOG.fine("All processTableInfo tasks completed.");
+            } finally {
+              signalEndOfData(queue, localResultSchemaFields);
+              shutdownExecutor(apiExecutor);
+              shutdownExecutor(tableProcessorExecutor);
+              LOG.info("Table fetcher thread finished.");
             }
+          };
 
-            if (!Thread.currentThread().isInterrupted()) {
-              Comparator<FieldValueList> comparator =
-                  defineGetTablesComparator(localResultSchemaFields);
-              sortResults(collectedResults, comparator, "getTables", LOG);
-            }
+      Runnable wrappedTableFetcher = Context.current().wrap(tableFetcher);
+      Thread fetcherThread =
+          new Thread(wrappedTableFetcher, "getTables-fetcher-" + effectiveCatalog);
+      BigQueryJsonResultSet resultSet =
+          BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
-            if (!Thread.currentThread().isInterrupted()) {
-              populateQueue(collectedResults, queue, localResultSchemaFields);
-            }
-
-          } catch (Throwable t) {
-            LOG.severe("Unexpected error in table fetcher runnable: " + t.getMessage());
-            apiFutures.forEach(f -> f.cancel(true));
-            processingFutures.forEach(f -> f.cancel(true));
-          } finally {
-            signalEndOfData(queue, localResultSchemaFields);
-            shutdownExecutor(apiExecutor);
-            shutdownExecutor(tableProcessorExecutor);
-            LOG.info("Table fetcher thread finished.");
-          }
-        };
-
-    Thread fetcherThread = new Thread(tableFetcher, "getTables-fetcher-" + effectiveCatalog);
-    BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
-
-    fetcherThread.start();
-    LOG.info("Started background thread for getTables");
-    return resultSet;
+      fetcherThread.start();
+      LOG.info("Started background thread for getTables");
+      return resultSet;
+    } catch (Exception e) {
+      span.recordException(e);
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   Schema defineGetTablesSchema() {
@@ -1994,20 +2012,29 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getCatalogs() {
     LOG.info("getCatalogs() called");
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getCatalogs").startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      final List<String> accessibleCatalogs = getAccessibleCatalogNames();
+      final Schema catalogsSchema = defineGetCatalogsSchema();
+      final FieldList schemaFields = catalogsSchema.getFields();
+      final List<FieldValueList> catalogRows =
+          prepareGetCatalogsRows(schemaFields, accessibleCatalogs);
 
-    final List<String> accessibleCatalogs = getAccessibleCatalogNames();
-    final Schema catalogsSchema = defineGetCatalogsSchema();
-    final FieldList schemaFields = catalogsSchema.getFields();
-    final List<FieldValueList> catalogRows =
-        prepareGetCatalogsRows(schemaFields, accessibleCatalogs);
+      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+          new LinkedBlockingQueue<>(catalogRows.isEmpty() ? 1 : catalogRows.size() + 1);
 
-    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-        new LinkedBlockingQueue<>(catalogRows.isEmpty() ? 1 : catalogRows.size() + 1);
+      populateQueue(catalogRows, queue, schemaFields);
+      signalEndOfData(queue, schemaFields);
 
-    populateQueue(catalogRows, queue, schemaFields);
-    signalEndOfData(queue, schemaFields);
-
-    return BigQueryJsonResultSet.of(catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
+      return BigQueryJsonResultSet.of(
+          catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
+    } catch (Exception e) {
+      span.recordException(e);
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   Schema defineGetCatalogsSchema() {
@@ -2064,140 +2091,152 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   @Override
   public ResultSet getColumns(
       String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) {
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getColumns").startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      Tuple<String, String> effectiveIdentifiers =
+          determineEffectiveCatalogAndSchema(catalog, schemaPattern);
+      String effectiveCatalog = effectiveIdentifiers.x();
+      String effectiveSchemaPattern = effectiveIdentifiers.y();
 
-    Tuple<String, String> effectiveIdentifiers =
-        determineEffectiveCatalogAndSchema(catalog, schemaPattern);
-    String effectiveCatalog = effectiveIdentifiers.x();
-    String effectiveSchemaPattern = effectiveIdentifiers.y();
+      if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
+          || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
+          || (tableNamePattern != null && tableNamePattern.isEmpty())
+          || (columnNamePattern != null && columnNamePattern.isEmpty())) {
+        LOG.warning(
+            "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
+        return new BigQueryJsonResultSet();
+      }
 
-    if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
-        || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
-        || (tableNamePattern != null && tableNamePattern.isEmpty())
-        || (columnNamePattern != null && columnNamePattern.isEmpty())) {
-      LOG.warning(
-          "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
-      return new BigQueryJsonResultSet();
-    }
+      LOG.info(
+          "getColumns called for catalog: %s, schemaPattern: %s, tableNamePattern: %s,"
+              + " columnNamePattern: %s",
+          effectiveCatalog, effectiveSchemaPattern, tableNamePattern, columnNamePattern);
 
-    LOG.info(
-        "getColumns called for catalog: %s, schemaPattern: %s, tableNamePattern: %s,"
-            + " columnNamePattern: %s",
-        effectiveCatalog, effectiveSchemaPattern, tableNamePattern, columnNamePattern);
+      Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
+      Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
+      Pattern columnNameRegex = compileSqlLikePattern(columnNamePattern);
 
-    Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
-    Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
-    Pattern columnNameRegex = compileSqlLikePattern(columnNamePattern);
+      final Schema resultSchema = defineGetColumnsSchema();
+      final FieldList resultSchemaFields = resultSchema.getFields();
+      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+          new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+      final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
+      final String catalogParam = effectiveCatalog;
+      final String schemaParam = effectiveSchemaPattern;
 
-    final Schema resultSchema = defineGetColumnsSchema();
-    final FieldList resultSchemaFields = resultSchema.getFields();
-    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-        new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
-    final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
-    final String catalogParam = effectiveCatalog;
-    final String schemaParam = effectiveSchemaPattern;
+      Runnable columnFetcher =
+          () -> {
+            ExecutorService columnExecutor = null;
+            final List<Future<?>> taskFutures = new ArrayList<>();
+            final FieldList localResultSchemaFields = resultSchemaFields;
 
-    Runnable columnFetcher =
-        () -> {
-          ExecutorService columnExecutor = null;
-          final List<Future<?>> taskFutures = new ArrayList<>();
-          final FieldList localResultSchemaFields = resultSchemaFields;
-
-          try {
-            List<Dataset> datasetsToScan =
-                findMatchingBigQueryObjects(
-                    "Dataset",
-                    () ->
-                        bigquery.listDatasets(
-                            catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                    (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
-                    (ds) -> ds.getDatasetId().getDataset(),
-                    schemaParam,
-                    schemaRegex,
-                    LOG);
-
-            if (datasetsToScan.isEmpty()) {
-              LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
-              return;
-            }
-
-            columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
-
-            for (Dataset dataset : datasetsToScan) {
-              if (Thread.currentThread().isInterrupted()) {
-                LOG.warning("Fetcher interrupted during dataset iteration.");
-                break;
-              }
-
-              DatasetId datasetId = dataset.getDatasetId();
-              LOG.info("Processing dataset: " + datasetId.getDataset());
-
-              List<Table> tablesToScan =
+            try {
+              List<Dataset> datasetsToScan =
                   findMatchingBigQueryObjects(
-                      "Table",
+                      "Dataset",
                       () ->
-                          bigquery.listTables(
-                              datasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                      (name) ->
-                          bigquery.getTable(
-                              TableId.of(datasetId.getProject(), datasetId.getDataset(), name)),
-                      (tbl) -> tbl.getTableId().getTable(),
-                      tableNamePattern,
-                      tableNameRegex,
+                          bigquery.listDatasets(
+                              catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                      (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
+                      (ds) -> ds.getDatasetId().getDataset(),
+                      schemaParam,
+                      schemaRegex,
                       LOG);
 
-              for (Table table : tablesToScan) {
+              if (datasetsToScan.isEmpty()) {
+                LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
+                return;
+              }
+
+              columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+
+              for (Dataset dataset : datasetsToScan) {
                 if (Thread.currentThread().isInterrupted()) {
-                  LOG.warning(
-                      "Fetcher interrupted during table iteration for dataset "
-                          + datasetId.getDataset());
+                  LOG.warning("Fetcher interrupted during dataset iteration.");
                   break;
                 }
 
-                TableId tableId = table.getTableId();
-                LOG.fine("Submitting task for table: " + tableId);
-                final Table finalTable = table;
-                Future<?> future =
-                    columnExecutor.submit(
+                DatasetId datasetId = dataset.getDatasetId();
+                LOG.info("Processing dataset: " + datasetId.getDataset());
+
+                List<Table> tablesToScan =
+                    findMatchingBigQueryObjects(
+                        "Table",
                         () ->
-                            processTableColumns(
-                                finalTable,
-                                columnNameRegex,
-                                collectedResults,
-                                localResultSchemaFields));
-                taskFutures.add(future);
+                            bigquery.listTables(
+                                datasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                        (name) ->
+                            bigquery.getTable(
+                                TableId.of(datasetId.getProject(), datasetId.getDataset(), name)),
+                        (tbl) -> tbl.getTableId().getTable(),
+                        tableNamePattern,
+                        tableNameRegex,
+                        LOG);
+
+                for (Table table : tablesToScan) {
+                  if (Thread.currentThread().isInterrupted()) {
+                    LOG.warning(
+                        "Fetcher interrupted during table iteration for dataset "
+                            + datasetId.getDataset());
+                    break;
+                  }
+
+                  TableId tableId = table.getTableId();
+                  LOG.fine("Submitting task for table: " + tableId);
+                  final Table finalTable = table;
+
+                  Runnable columnTask =
+                      () ->
+                          processTableColumns(
+                              finalTable,
+                              columnNameRegex,
+                              collectedResults,
+                              localResultSchemaFields);
+                  Runnable wrappedColumnTask = Context.current().wrap(columnTask);
+                  Future<?> future = columnExecutor.submit(wrappedColumnTask);
+                  taskFutures.add(future);
+                }
+                if (Thread.currentThread().isInterrupted()) break;
               }
-              if (Thread.currentThread().isInterrupted()) break;
+
+              waitForTasksCompletion(taskFutures);
+
+              if (!Thread.currentThread().isInterrupted()) {
+                Comparator<FieldValueList> comparator =
+                    defineGetColumnsComparator(localResultSchemaFields);
+                sortResults(collectedResults, comparator, "getColumns", LOG);
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                populateQueue(collectedResults, queue, localResultSchemaFields);
+              }
+
+            } catch (Throwable t) {
+              LOG.severe("Unexpected error in column fetcher runnable: " + t.getMessage());
+              taskFutures.forEach(f -> f.cancel(true));
+            } finally {
+              signalEndOfData(queue, localResultSchemaFields);
+              shutdownExecutor(columnExecutor);
+              LOG.info("Column fetcher thread finished.");
             }
+          };
 
-            waitForTasksCompletion(taskFutures);
+      Runnable wrappedColumnFetcher = Context.current().wrap(columnFetcher);
+      Thread fetcherThread =
+          new Thread(wrappedColumnFetcher, "getColumns-fetcher-" + effectiveCatalog);
+      BigQueryJsonResultSet resultSet =
+          BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
-            if (!Thread.currentThread().isInterrupted()) {
-              Comparator<FieldValueList> comparator =
-                  defineGetColumnsComparator(localResultSchemaFields);
-              sortResults(collectedResults, comparator, "getColumns", LOG);
-            }
-
-            if (!Thread.currentThread().isInterrupted()) {
-              populateQueue(collectedResults, queue, localResultSchemaFields);
-            }
-
-          } catch (Throwable t) {
-            LOG.severe("Unexpected error in column fetcher runnable: " + t.getMessage());
-            taskFutures.forEach(f -> f.cancel(true));
-          } finally {
-            signalEndOfData(queue, localResultSchemaFields);
-            shutdownExecutor(columnExecutor);
-            LOG.info("Column fetcher thread finished.");
-          }
-        };
-
-    Thread fetcherThread = new Thread(columnFetcher, "getColumns-fetcher-" + effectiveCatalog);
-    BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
-
-    fetcherThread.start();
-    LOG.info("Started background thread for getColumns");
-    return resultSet;
+      fetcherThread.start();
+      LOG.info("Started background thread for getColumns");
+      return resultSet;
+    } catch (Exception e) {
+      span.recordException(e);
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   private void processTableColumns(
@@ -3617,107 +3656,117 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public ResultSet getSchemas(String catalog, String schemaPattern) {
-    if ((catalog != null && catalog.isEmpty())
-        || (schemaPattern != null && schemaPattern.isEmpty())) {
-      LOG.warning("Returning empty ResultSet as catalog or schemaPattern is an empty string.");
-      return new BigQueryJsonResultSet();
-    }
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getSchemas").startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      if ((catalog != null && catalog.isEmpty())
+          || (schemaPattern != null && schemaPattern.isEmpty())) {
+        LOG.warning("Returning empty ResultSet as catalog or schemaPattern is an empty string.");
+        return new BigQueryJsonResultSet();
+      }
 
-    LOG.info("getSchemas called for catalog: %s, schemaPattern: %s", catalog, schemaPattern);
+      LOG.info("getSchemas called for catalog: %s, schemaPattern: %s", catalog, schemaPattern);
 
-    final Pattern schemaRegex = compileSqlLikePattern(schemaPattern);
-    final Schema resultSchema = defineGetSchemasSchema();
-    final FieldList resultSchemaFields = resultSchema.getFields();
+      final Pattern schemaRegex = compileSqlLikePattern(schemaPattern);
+      final Schema resultSchema = defineGetSchemasSchema();
+      final FieldList resultSchemaFields = resultSchema.getFields();
 
-    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-        new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
-    final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
-    final String catalogParam = catalog;
+      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+          new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+      final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
+      final String catalogParam = catalog;
 
-    Runnable schemaFetcher =
-        () -> {
-          final FieldList localResultSchemaFields = resultSchemaFields;
-          List<String> projectsToScanList = new ArrayList<>();
+      Runnable schemaFetcher =
+          () -> {
+            final FieldList localResultSchemaFields = resultSchemaFields;
+            List<String> projectsToScanList = new ArrayList<>();
 
-          if (catalogParam != null) {
-            projectsToScanList.add(catalogParam);
-          } else {
-            projectsToScanList.addAll(getAccessibleCatalogNames());
-          }
+            if (catalogParam != null) {
+              projectsToScanList.add(catalogParam);
+            } else {
+              projectsToScanList.addAll(getAccessibleCatalogNames());
+            }
 
-          if (projectsToScanList.isEmpty()) {
-            LOG.info(
-                "No valid projects to scan (primary, specified, or additional). Returning empty"
-                    + " resultset.");
-            return;
-          }
+            if (projectsToScanList.isEmpty()) {
+              LOG.info(
+                  "No valid projects to scan (primary, specified, or additional). Returning empty"
+                      + " resultset.");
+              return;
+            }
 
-          try {
-            for (String currentProjectToScan : projectsToScanList) {
-              if (Thread.currentThread().isInterrupted()) {
-                LOG.warning(
-                    "Schema fetcher interrupted during project iteration for project: "
-                        + currentProjectToScan);
-                break;
-              }
-              LOG.info("Fetching schemas for project: " + currentProjectToScan);
-              List<Dataset> datasetsInProject =
-                  findMatchingBigQueryObjects(
-                      "Dataset",
-                      () ->
-                          bigquery.listDatasets(
-                              currentProjectToScan,
-                              BigQuery.DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                      (name) -> bigquery.getDataset(DatasetId.of(currentProjectToScan, name)),
-                      (ds) -> ds.getDatasetId().getDataset(),
-                      schemaPattern,
-                      schemaRegex,
-                      LOG);
-
-              if (datasetsInProject.isEmpty() || Thread.currentThread().isInterrupted()) {
-                LOG.info(
-                    "Fetcher thread found no matching datasets in project: "
-                        + currentProjectToScan);
-                continue;
-              }
-
-              LOG.fine("Processing found datasets for project: " + currentProjectToScan);
-              for (Dataset dataset : datasetsInProject) {
+            try {
+              for (String currentProjectToScan : projectsToScanList) {
                 if (Thread.currentThread().isInterrupted()) {
                   LOG.warning(
-                      "Schema fetcher interrupted during dataset iteration for project: "
+                      "Schema fetcher interrupted during project iteration for project: "
                           + currentProjectToScan);
                   break;
                 }
-                processSchemaInfo(dataset, collectedResults, localResultSchemaFields);
+                LOG.info("Fetching schemas for project: " + currentProjectToScan);
+                List<Dataset> datasetsInProject =
+                    findMatchingBigQueryObjects(
+                        "Dataset",
+                        () ->
+                            bigquery.listDatasets(
+                                currentProjectToScan,
+                                BigQuery.DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                        (name) -> bigquery.getDataset(DatasetId.of(currentProjectToScan, name)),
+                        (ds) -> ds.getDatasetId().getDataset(),
+                        schemaPattern,
+                        schemaRegex,
+                        LOG);
+
+                if (datasetsInProject.isEmpty() || Thread.currentThread().isInterrupted()) {
+                  LOG.info(
+                      "Fetcher thread found no matching datasets in project: "
+                          + currentProjectToScan);
+                  continue;
+                }
+
+                LOG.fine("Processing found datasets for project: " + currentProjectToScan);
+                for (Dataset dataset : datasetsInProject) {
+                  if (Thread.currentThread().isInterrupted()) {
+                    LOG.warning(
+                        "Schema fetcher interrupted during dataset iteration for project: "
+                            + currentProjectToScan);
+                    break;
+                  }
+                  processSchemaInfo(dataset, collectedResults, localResultSchemaFields);
+                }
               }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                Comparator<FieldValueList> comparator =
+                    defineGetSchemasComparator(localResultSchemaFields);
+                sortResults(collectedResults, comparator, "getSchemas", LOG);
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                populateQueue(collectedResults, queue, localResultSchemaFields);
+              }
+
+            } catch (Throwable t) {
+              LOG.severe("Unexpected error in schema fetcher runnable: " + t.getMessage());
+            } finally {
+              signalEndOfData(queue, localResultSchemaFields);
+              LOG.info("Schema fetcher thread finished.");
             }
+          };
 
-            if (!Thread.currentThread().isInterrupted()) {
-              Comparator<FieldValueList> comparator =
-                  defineGetSchemasComparator(localResultSchemaFields);
-              sortResults(collectedResults, comparator, "getSchemas", LOG);
-            }
+      Runnable wrappedFetcher = Context.current().wrap(schemaFetcher);
+      Thread fetcherThread = new Thread(wrappedFetcher, "getSchemas-fetcher-" + catalog);
+      BigQueryJsonResultSet resultSet =
+          BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
-            if (!Thread.currentThread().isInterrupted()) {
-              populateQueue(collectedResults, queue, localResultSchemaFields);
-            }
-
-          } catch (Throwable t) {
-            LOG.severe("Unexpected error in schema fetcher runnable: " + t.getMessage());
-          } finally {
-            signalEndOfData(queue, localResultSchemaFields);
-            LOG.info("Schema fetcher thread finished.");
-          }
-        };
-
-    Thread fetcherThread = new Thread(schemaFetcher, "getSchemas-fetcher-" + catalog);
-    BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
-
-    fetcherThread.start();
-    LOG.info("Started background thread for getSchemas");
-    return resultSet;
+      fetcherThread.start();
+      LOG.info("Started background thread for getSchemas");
+      return resultSet;
+    } catch (Exception e) {
+      span.recordException(e);
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   Schema defineGetSchemasSchema() {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -43,6 +43,7 @@ import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -1737,141 +1738,154 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       final String catalogParam = effectiveCatalog;
       final String schemaParam = effectiveSchemaPattern;
 
+      SpanContext parentSpanContext = span.getSpanContext();
       Runnable tableFetcher =
           () -> {
-            ExecutorService apiExecutor = null;
-            ExecutorService tableProcessorExecutor = null;
-            final FieldList localResultSchemaFields = resultSchemaFields;
-            final List<Future<List<Table>>> apiFutures = new ArrayList<>();
-            final List<Future<?>> processingFutures = new ArrayList<>();
+            Span backgroundSpan =
+                tracer
+                    .spanBuilder("BigQueryDatabaseMetaData.getTables.background")
+                    .addLink(parentSpanContext)
+                    .startSpan();
 
-            try {
-              List<Dataset> datasetsToScan =
-                  findMatchingBigQueryObjects(
-                      "Dataset",
-                      () ->
-                          bigquery.listDatasets(
-                              catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                      (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
-                      (ds) -> ds.getDatasetId().getDataset(),
-                      schemaParam,
-                      schemaRegex,
-                      LOG);
+            try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
+              ExecutorService apiExecutor = null;
+              ExecutorService tableProcessorExecutor = null;
+              final FieldList localResultSchemaFields = resultSchemaFields;
+              final List<Future<List<Table>>> apiFutures = new ArrayList<>();
+              final List<Future<?>> processingFutures = new ArrayList<>();
 
-              if (datasetsToScan.isEmpty()) {
-                LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
-                return;
-              }
+              try {
+                List<Dataset> datasetsToScan =
+                    findMatchingBigQueryObjects(
+                        "Dataset",
+                        () ->
+                            bigquery.listDatasets(
+                                catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                        (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
+                        (ds) -> ds.getDatasetId().getDataset(),
+                        schemaParam,
+                        schemaRegex,
+                        LOG);
 
-              apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
-              tableProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
-
-              LOG.fine("Submitting parallel findMatchingTables tasks...");
-              for (Dataset dataset : datasetsToScan) {
-                if (Thread.currentThread().isInterrupted()) {
-                  LOG.warning("Table fetcher interrupted during dataset iteration.");
-                  break;
+                if (datasetsToScan.isEmpty()) {
+                  LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
+                  return;
                 }
 
-                final DatasetId currentDatasetId = dataset.getDatasetId();
-                Callable<List<Table>> apiCallable =
-                    () ->
-                        findMatchingBigQueryObjects(
-                            "Table",
-                            () ->
-                                bigquery.listTables(
-                                    currentDatasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                            (name) ->
-                                bigquery.getTable(
-                                    TableId.of(
-                                        currentDatasetId.getProject(),
-                                        currentDatasetId.getDataset(),
-                                        name)),
-                            (tbl) -> tbl.getTableId().getTable(),
-                            tableNamePattern,
-                            tableNameRegex,
-                            LOG);
+                apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
+                tableProcessorExecutor =
+                    Executors.newFixedThreadPool(this.metadataFetchThreadCount);
 
-                Callable<List<Table>> wrappedApiCallable = Context.current().wrap(apiCallable);
-                Future<List<Table>> apiFuture = apiExecutor.submit(wrappedApiCallable);
-                apiFutures.add(apiFuture);
-              }
-              LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
-              apiExecutor.shutdown();
-
-              LOG.fine("Processing results from findMatchingTables tasks...");
-              for (Future<List<Table>> apiFuture : apiFutures) {
-                if (Thread.currentThread().isInterrupted()) {
-                  LOG.warning("Table fetcher interrupted while processing API futures.");
-                  break;
-                }
-                try {
-                  List<Table> tablesResult = apiFuture.get();
-                  if (tablesResult != null) {
-                    for (Table table : tablesResult) {
-                      if (Thread.currentThread().isInterrupted()) break;
-
-                      final Table currentTable = table;
-                      Runnable processRunnable =
-                          () ->
-                              processTableInfo(
-                                  currentTable,
-                                  requestedTypes,
-                                  collectedResults,
-                                  localResultSchemaFields);
-                      Runnable wrappedProcessRunnable = Context.current().wrap(processRunnable);
-                      Future<?> processFuture =
-                          tableProcessorExecutor.submit(wrappedProcessRunnable);
-                      processingFutures.add(processFuture);
-                    }
+                LOG.fine("Submitting parallel findMatchingTables tasks...");
+                for (Dataset dataset : datasetsToScan) {
+                  if (Thread.currentThread().isInterrupted()) {
+                    LOG.warning("Table fetcher interrupted during dataset iteration.");
+                    break;
                   }
-                } catch (InterruptedException e) {
-                  Thread.currentThread().interrupt();
-                  LOG.warning("Fetcher thread interrupted while waiting for API future result.");
-                  break;
-                } catch (ExecutionException e) {
-                  LOG.warning(
-                      "Error executing findMatchingTables task: "
-                          + e.getMessage()
-                          + ". Cause: "
-                          + e.getCause());
-                } catch (CancellationException e) {
-                  LOG.warning("A findMatchingTables task was cancelled.");
+
+                  final DatasetId currentDatasetId = dataset.getDatasetId();
+                  Callable<List<Table>> apiCallable =
+                      () ->
+                          findMatchingBigQueryObjects(
+                              "Table",
+                              () ->
+                                  bigquery.listTables(
+                                      currentDatasetId,
+                                      TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                              (name) ->
+                                  bigquery.getTable(
+                                      TableId.of(
+                                          currentDatasetId.getProject(),
+                                          currentDatasetId.getDataset(),
+                                          name)),
+                              (tbl) -> tbl.getTableId().getTable(),
+                              tableNamePattern,
+                              tableNameRegex,
+                              LOG);
+
+                  Callable<List<Table>> wrappedApiCallable = Context.current().wrap(apiCallable);
+                  Future<List<Table>> apiFuture = apiExecutor.submit(wrappedApiCallable);
+                  apiFutures.add(apiFuture);
                 }
-              }
+                LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
+                apiExecutor.shutdown();
 
-              LOG.fine(
-                  "Finished submitting " + processingFutures.size() + " processTableInfo tasks.");
+                LOG.fine("Processing results from findMatchingTables tasks...");
+                for (Future<List<Table>> apiFuture : apiFutures) {
+                  if (Thread.currentThread().isInterrupted()) {
+                    LOG.warning("Table fetcher interrupted while processing API futures.");
+                    break;
+                  }
+                  try {
+                    List<Table> tablesResult = apiFuture.get();
+                    if (tablesResult != null) {
+                      for (Table table : tablesResult) {
+                        if (Thread.currentThread().isInterrupted()) break;
 
-              if (Thread.currentThread().isInterrupted()) {
-                LOG.warning(
-                    "Fetcher interrupted before waiting for processing tasks; cancelling remaining.");
+                        final Table currentTable = table;
+                        Runnable processRunnable =
+                            () ->
+                                processTableInfo(
+                                    currentTable,
+                                    requestedTypes,
+                                    collectedResults,
+                                    localResultSchemaFields);
+                        Runnable wrappedProcessRunnable = Context.current().wrap(processRunnable);
+                        Future<?> processFuture =
+                            tableProcessorExecutor.submit(wrappedProcessRunnable);
+                        processingFutures.add(processFuture);
+                      }
+                    }
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    LOG.warning("Fetcher thread interrupted while waiting for API future result.");
+                    break;
+                  } catch (ExecutionException e) {
+                    LOG.warning(
+                        "Error executing findMatchingTables task: "
+                            + e.getMessage()
+                            + ". Cause: "
+                            + e.getCause());
+                  } catch (CancellationException e) {
+                    LOG.warning("A findMatchingTables task was cancelled.");
+                  }
+                }
+
+                LOG.fine(
+                    "Finished submitting " + processingFutures.size() + " processTableInfo tasks.");
+
+                if (Thread.currentThread().isInterrupted()) {
+                  LOG.warning(
+                      "Fetcher interrupted before waiting for processing tasks; cancelling remaining.");
+                  processingFutures.forEach(f -> f.cancel(true));
+                } else {
+                  LOG.fine("Waiting for processTableInfo tasks to complete...");
+                  waitForTasksCompletion(processingFutures);
+                  LOG.fine("All processTableInfo tasks completed.");
+                }
+
+                if (!Thread.currentThread().isInterrupted()) {
+                  Comparator<FieldValueList> comparator =
+                      defineGetTablesComparator(localResultSchemaFields);
+                  sortResults(collectedResults, comparator, "getTables", LOG);
+                }
+
+                if (!Thread.currentThread().isInterrupted()) {
+                  populateQueue(collectedResults, queue, localResultSchemaFields);
+                }
+
+              } catch (Throwable t) {
+                LOG.severe("Unexpected error in table fetcher runnable: " + t.getMessage());
+                apiFutures.forEach(f -> f.cancel(true));
                 processingFutures.forEach(f -> f.cancel(true));
-              } else {
-                LOG.fine("Waiting for processTableInfo tasks to complete...");
-                waitForTasksCompletion(processingFutures);
-                LOG.fine("All processTableInfo tasks completed.");
+              } finally {
+                signalEndOfData(queue, localResultSchemaFields);
+                shutdownExecutor(apiExecutor);
+                shutdownExecutor(tableProcessorExecutor);
+                LOG.info("Table fetcher thread finished.");
               }
-
-              if (!Thread.currentThread().isInterrupted()) {
-                Comparator<FieldValueList> comparator =
-                    defineGetTablesComparator(localResultSchemaFields);
-                sortResults(collectedResults, comparator, "getTables", LOG);
-              }
-
-              if (!Thread.currentThread().isInterrupted()) {
-                populateQueue(collectedResults, queue, localResultSchemaFields);
-              }
-
-            } catch (Throwable t) {
-              LOG.severe("Unexpected error in table fetcher runnable: " + t.getMessage());
-              apiFutures.forEach(f -> f.cancel(true));
-              processingFutures.forEach(f -> f.cancel(true));
             } finally {
-              signalEndOfData(queue, localResultSchemaFields);
-              shutdownExecutor(apiExecutor);
-              shutdownExecutor(tableProcessorExecutor);
-              LOG.info("Table fetcher thread finished.");
+              backgroundSpan.end();
             }
           };
 
@@ -2125,100 +2139,111 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       final String catalogParam = effectiveCatalog;
       final String schemaParam = effectiveSchemaPattern;
 
+      SpanContext parentSpanContext = span.getSpanContext();
       Runnable columnFetcher =
           () -> {
-            ExecutorService columnExecutor = null;
-            final List<Future<?>> taskFutures = new ArrayList<>();
-            final FieldList localResultSchemaFields = resultSchemaFields;
+            Span backgroundSpan =
+                tracer
+                    .spanBuilder("BigQueryDatabaseMetaData.getColumns.background")
+                    .addLink(parentSpanContext)
+                    .startSpan();
 
-            try {
-              List<Dataset> datasetsToScan =
-                  findMatchingBigQueryObjects(
-                      "Dataset",
-                      () ->
-                          bigquery.listDatasets(
-                              catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                      (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
-                      (ds) -> ds.getDatasetId().getDataset(),
-                      schemaParam,
-                      schemaRegex,
-                      LOG);
+            try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
+              ExecutorService columnExecutor = null;
+              final List<Future<?>> taskFutures = new ArrayList<>();
+              final FieldList localResultSchemaFields = resultSchemaFields;
 
-              if (datasetsToScan.isEmpty()) {
-                LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
-                return;
-              }
-
-              columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
-
-              for (Dataset dataset : datasetsToScan) {
-                if (Thread.currentThread().isInterrupted()) {
-                  LOG.warning("Fetcher interrupted during dataset iteration.");
-                  break;
-                }
-
-                DatasetId datasetId = dataset.getDatasetId();
-                LOG.info("Processing dataset: " + datasetId.getDataset());
-
-                List<Table> tablesToScan =
+              try {
+                List<Dataset> datasetsToScan =
                     findMatchingBigQueryObjects(
-                        "Table",
+                        "Dataset",
                         () ->
-                            bigquery.listTables(
-                                datasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                        (name) ->
-                            bigquery.getTable(
-                                TableId.of(datasetId.getProject(), datasetId.getDataset(), name)),
-                        (tbl) -> tbl.getTableId().getTable(),
-                        tableNamePattern,
-                        tableNameRegex,
+                            bigquery.listDatasets(
+                                catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                        (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
+                        (ds) -> ds.getDatasetId().getDataset(),
+                        schemaParam,
+                        schemaRegex,
                         LOG);
 
-                for (Table table : tablesToScan) {
+                if (datasetsToScan.isEmpty()) {
+                  LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
+                  return;
+                }
+
+                columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+
+                for (Dataset dataset : datasetsToScan) {
                   if (Thread.currentThread().isInterrupted()) {
-                    LOG.warning(
-                        "Fetcher interrupted during table iteration for dataset "
-                            + datasetId.getDataset());
+                    LOG.warning("Fetcher interrupted during dataset iteration.");
                     break;
                   }
 
-                  TableId tableId = table.getTableId();
-                  LOG.fine("Submitting task for table: " + tableId);
-                  final Table finalTable = table;
+                  DatasetId datasetId = dataset.getDatasetId();
+                  LOG.info("Processing dataset: " + datasetId.getDataset());
 
-                  Runnable columnTask =
-                      () ->
-                          processTableColumns(
-                              finalTable,
-                              columnNameRegex,
-                              collectedResults,
-                              localResultSchemaFields);
-                  Runnable wrappedColumnTask = Context.current().wrap(columnTask);
-                  Future<?> future = columnExecutor.submit(wrappedColumnTask);
-                  taskFutures.add(future);
+                  List<Table> tablesToScan =
+                      findMatchingBigQueryObjects(
+                          "Table",
+                          () ->
+                              bigquery.listTables(
+                                  datasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                          (name) ->
+                              bigquery.getTable(
+                                  TableId.of(datasetId.getProject(), datasetId.getDataset(), name)),
+                          (tbl) -> tbl.getTableId().getTable(),
+                          tableNamePattern,
+                          tableNameRegex,
+                          LOG);
+
+                  for (Table table : tablesToScan) {
+                    if (Thread.currentThread().isInterrupted()) {
+                      LOG.warning(
+                          "Fetcher interrupted during table iteration for dataset "
+                              + datasetId.getDataset());
+                      break;
+                    }
+
+                    TableId tableId = table.getTableId();
+                    LOG.fine("Submitting task for table: " + tableId);
+                    final Table finalTable = table;
+
+                    Runnable columnTask =
+                        () ->
+                            processTableColumns(
+                                finalTable,
+                                columnNameRegex,
+                                collectedResults,
+                                localResultSchemaFields);
+                    Runnable wrappedColumnTask = Context.current().wrap(columnTask);
+                    Future<?> future = columnExecutor.submit(wrappedColumnTask);
+                    taskFutures.add(future);
+                  }
+                  if (Thread.currentThread().isInterrupted()) break;
                 }
-                if (Thread.currentThread().isInterrupted()) break;
+
+                waitForTasksCompletion(taskFutures);
+
+                if (!Thread.currentThread().isInterrupted()) {
+                  Comparator<FieldValueList> comparator =
+                      defineGetColumnsComparator(localResultSchemaFields);
+                  sortResults(collectedResults, comparator, "getColumns", LOG);
+                }
+
+                if (!Thread.currentThread().isInterrupted()) {
+                  populateQueue(collectedResults, queue, localResultSchemaFields);
+                }
+
+              } catch (Throwable t) {
+                LOG.severe("Unexpected error in column fetcher runnable: " + t.getMessage());
+                taskFutures.forEach(f -> f.cancel(true));
+              } finally {
+                signalEndOfData(queue, localResultSchemaFields);
+                shutdownExecutor(columnExecutor);
+                LOG.info("Column fetcher thread finished.");
               }
-
-              waitForTasksCompletion(taskFutures);
-
-              if (!Thread.currentThread().isInterrupted()) {
-                Comparator<FieldValueList> comparator =
-                    defineGetColumnsComparator(localResultSchemaFields);
-                sortResults(collectedResults, comparator, "getColumns", LOG);
-              }
-
-              if (!Thread.currentThread().isInterrupted()) {
-                populateQueue(collectedResults, queue, localResultSchemaFields);
-              }
-
-            } catch (Throwable t) {
-              LOG.severe("Unexpected error in column fetcher runnable: " + t.getMessage());
-              taskFutures.forEach(f -> f.cancel(true));
             } finally {
-              signalEndOfData(queue, localResultSchemaFields);
-              shutdownExecutor(columnExecutor);
-              LOG.info("Column fetcher thread finished.");
+              backgroundSpan.end();
             }
           };
 
@@ -3676,80 +3701,91 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
       final String catalogParam = catalog;
 
+      SpanContext parentSpanContext = span.getSpanContext();
       Runnable schemaFetcher =
           () -> {
-            final FieldList localResultSchemaFields = resultSchemaFields;
-            List<String> projectsToScanList = new ArrayList<>();
+            Span backgroundSpan =
+                tracer
+                    .spanBuilder("BigQueryDatabaseMetaData.getSchemas.background")
+                    .addLink(parentSpanContext)
+                    .startSpan();
 
-            if (catalogParam != null) {
-              projectsToScanList.add(catalogParam);
-            } else {
-              projectsToScanList.addAll(getAccessibleCatalogNames());
-            }
+            try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
+              final FieldList localResultSchemaFields = resultSchemaFields;
+              List<String> projectsToScanList = new ArrayList<>();
 
-            if (projectsToScanList.isEmpty()) {
-              LOG.info(
-                  "No valid projects to scan (primary, specified, or additional). Returning empty"
-                      + " resultset.");
-              return;
-            }
+              if (catalogParam != null) {
+                projectsToScanList.add(catalogParam);
+              } else {
+                projectsToScanList.addAll(getAccessibleCatalogNames());
+              }
 
-            try {
-              for (String currentProjectToScan : projectsToScanList) {
-                if (Thread.currentThread().isInterrupted()) {
-                  LOG.warning(
-                      "Schema fetcher interrupted during project iteration for project: "
-                          + currentProjectToScan);
-                  break;
-                }
-                LOG.info("Fetching schemas for project: " + currentProjectToScan);
-                List<Dataset> datasetsInProject =
-                    findMatchingBigQueryObjects(
-                        "Dataset",
-                        () ->
-                            bigquery.listDatasets(
-                                currentProjectToScan,
-                                BigQuery.DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                        (name) -> bigquery.getDataset(DatasetId.of(currentProjectToScan, name)),
-                        (ds) -> ds.getDatasetId().getDataset(),
-                        schemaPattern,
-                        schemaRegex,
-                        LOG);
+              if (projectsToScanList.isEmpty()) {
+                LOG.info(
+                    "No valid projects to scan (primary, specified, or additional). Returning empty"
+                        + " resultset.");
+                return;
+              }
 
-                if (datasetsInProject.isEmpty() || Thread.currentThread().isInterrupted()) {
-                  LOG.info(
-                      "Fetcher thread found no matching datasets in project: "
-                          + currentProjectToScan);
-                  continue;
-                }
-
-                LOG.fine("Processing found datasets for project: " + currentProjectToScan);
-                for (Dataset dataset : datasetsInProject) {
+              try {
+                for (String currentProjectToScan : projectsToScanList) {
                   if (Thread.currentThread().isInterrupted()) {
                     LOG.warning(
-                        "Schema fetcher interrupted during dataset iteration for project: "
+                        "Schema fetcher interrupted during project iteration for project: "
                             + currentProjectToScan);
                     break;
                   }
-                  processSchemaInfo(dataset, collectedResults, localResultSchemaFields);
+                  LOG.info("Fetching schemas for project: " + currentProjectToScan);
+                  List<Dataset> datasetsInProject =
+                      findMatchingBigQueryObjects(
+                          "Dataset",
+                          () ->
+                              bigquery.listDatasets(
+                                  currentProjectToScan,
+                                  BigQuery.DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                          (name) -> bigquery.getDataset(DatasetId.of(currentProjectToScan, name)),
+                          (ds) -> ds.getDatasetId().getDataset(),
+                          schemaPattern,
+                          schemaRegex,
+                          LOG);
+
+                  if (datasetsInProject.isEmpty() || Thread.currentThread().isInterrupted()) {
+                    LOG.info(
+                        "Fetcher thread found no matching datasets in project: "
+                            + currentProjectToScan);
+                    continue;
+                  }
+
+                  LOG.fine("Processing found datasets for project: " + currentProjectToScan);
+                  for (Dataset dataset : datasetsInProject) {
+                    if (Thread.currentThread().isInterrupted()) {
+                      LOG.warning(
+                          "Schema fetcher interrupted during dataset iteration for project: "
+                              + currentProjectToScan);
+                      break;
+                    }
+                    processSchemaInfo(dataset, collectedResults, localResultSchemaFields);
+                  }
                 }
-              }
 
-              if (!Thread.currentThread().isInterrupted()) {
-                Comparator<FieldValueList> comparator =
-                    defineGetSchemasComparator(localResultSchemaFields);
-                sortResults(collectedResults, comparator, "getSchemas", LOG);
-              }
+                if (!Thread.currentThread().isInterrupted()) {
+                  Comparator<FieldValueList> comparator =
+                      defineGetSchemasComparator(localResultSchemaFields);
+                  sortResults(collectedResults, comparator, "getSchemas", LOG);
+                }
 
-              if (!Thread.currentThread().isInterrupted()) {
-                populateQueue(collectedResults, queue, localResultSchemaFields);
-              }
+                if (!Thread.currentThread().isInterrupted()) {
+                  populateQueue(collectedResults, queue, localResultSchemaFields);
+                }
 
-            } catch (Throwable t) {
-              LOG.severe("Unexpected error in schema fetcher runnable: " + t.getMessage());
+              } catch (Throwable t) {
+                LOG.severe("Unexpected error in schema fetcher runnable: " + t.getMessage());
+              } finally {
+                signalEndOfData(queue, localResultSchemaFields);
+                LOG.info("Schema fetcher thread finished.");
+              }
             } finally {
-              signalEndOfData(queue, localResultSchemaFields);
-              LOG.info("Schema fetcher thread finished.");
+              backgroundSpan.end();
             }
           };
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -1704,209 +1704,206 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public ResultSet getTables(
-      String catalog, String schemaPattern, String tableNamePattern, String[] types) {
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
-    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getTables").startSpan();
-    try (Scope scope = span.makeCurrent()) {
-      Tuple<String, String> effectiveIdentifiers =
-          determineEffectiveCatalogAndSchema(catalog, schemaPattern);
-      String effectiveCatalog = effectiveIdentifiers.x();
-      String effectiveSchemaPattern = effectiveIdentifiers.y();
+      String catalog, String schemaPattern, String tableNamePattern, String[] types)
+      throws SQLException {
+    return withTracing(
+        "BigQueryDatabaseMetaData.getTables",
+        () -> getTablesImpl(catalog, schemaPattern, tableNamePattern, types));
+  }
 
-      if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
-          || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
-          || (tableNamePattern != null && tableNamePattern.isEmpty())) {
-        LOG.warning(
-            "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
-        return new BigQueryJsonResultSet();
-      }
+  private ResultSet getTablesImpl(
+      String catalog, String schemaPattern, String tableNamePattern, String[] types)
+      throws SQLException {
+    Tuple<String, String> effectiveIdentifiers =
+        determineEffectiveCatalogAndSchema(catalog, schemaPattern);
+    String effectiveCatalog = effectiveIdentifiers.x();
+    String effectiveSchemaPattern = effectiveIdentifiers.y();
 
-      LOG.info(
-          "getTables called for catalog: %s, schemaPattern: %s, tableNamePattern: %s, types: %s",
-          effectiveCatalog, effectiveSchemaPattern, tableNamePattern, Arrays.toString(types));
-
-      final Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
-      final Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
-      final Set<String> requestedTypes =
-          (types == null || types.length == 0) ? null : new HashSet<>(Arrays.asList(types));
-
-      final Schema resultSchema = defineGetTablesSchema();
-      final FieldList resultSchemaFields = resultSchema.getFields();
-
-      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-          new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
-      final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
-      final String catalogParam = effectiveCatalog;
-      final String schemaParam = effectiveSchemaPattern;
-
-      SpanContext parentSpanContext = span.getSpanContext();
-      Runnable tableFetcher =
-          () -> {
-            Span backgroundSpan =
-                tracer
-                    .spanBuilder("BigQueryDatabaseMetaData.getTables.background")
-                    .setNoParent()
-                    .addLink(parentSpanContext)
-                    .startSpan();
-
-            try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
-              ExecutorService apiExecutor = null;
-              ExecutorService tableProcessorExecutor = null;
-              final FieldList localResultSchemaFields = resultSchemaFields;
-              final List<Future<List<Table>>> apiFutures = new ArrayList<>();
-              final List<Future<?>> processingFutures = new ArrayList<>();
-
-              try {
-                List<Dataset> datasetsToScan =
-                    findMatchingBigQueryObjects(
-                        "Dataset",
-                        () ->
-                            bigquery.listDatasets(
-                                catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                        (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
-                        (ds) -> ds.getDatasetId().getDataset(),
-                        schemaParam,
-                        schemaRegex,
-                        LOG);
-
-                if (datasetsToScan.isEmpty()) {
-                  LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
-                  return;
-                }
-
-                apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
-                tableProcessorExecutor =
-                    Executors.newFixedThreadPool(this.metadataFetchThreadCount);
-
-                LOG.fine("Submitting parallel findMatchingTables tasks...");
-                for (Dataset dataset : datasetsToScan) {
-                  if (Thread.currentThread().isInterrupted()) {
-                    LOG.warning("Table fetcher interrupted during dataset iteration.");
-                    break;
-                  }
-
-                  final DatasetId currentDatasetId = dataset.getDatasetId();
-                  Callable<List<Table>> apiCallable =
-                      () ->
-                          findMatchingBigQueryObjects(
-                              "Table",
-                              () ->
-                                  bigquery.listTables(
-                                      currentDatasetId,
-                                      TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                              (name) ->
-                                  bigquery.getTable(
-                                      TableId.of(
-                                          currentDatasetId.getProject(),
-                                          currentDatasetId.getDataset(),
-                                          name)),
-                              (tbl) -> tbl.getTableId().getTable(),
-                              tableNamePattern,
-                              tableNameRegex,
-                              LOG);
-
-                  Callable<List<Table>> wrappedApiCallable = Context.current().wrap(apiCallable);
-                  Future<List<Table>> apiFuture = apiExecutor.submit(wrappedApiCallable);
-                  apiFutures.add(apiFuture);
-                }
-                LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
-                apiExecutor.shutdown();
-
-                LOG.fine("Processing results from findMatchingTables tasks...");
-                for (Future<List<Table>> apiFuture : apiFutures) {
-                  if (Thread.currentThread().isInterrupted()) {
-                    LOG.warning("Table fetcher interrupted while processing API futures.");
-                    break;
-                  }
-                  try {
-                    List<Table> tablesResult = apiFuture.get();
-                    if (tablesResult != null) {
-                      for (Table table : tablesResult) {
-                        if (Thread.currentThread().isInterrupted()) break;
-
-                        final Table currentTable = table;
-                        Runnable processRunnable =
-                            () ->
-                                processTableInfo(
-                                    currentTable,
-                                    requestedTypes,
-                                    collectedResults,
-                                    localResultSchemaFields);
-                        Runnable wrappedProcessRunnable = Context.current().wrap(processRunnable);
-                        Future<?> processFuture =
-                            tableProcessorExecutor.submit(wrappedProcessRunnable);
-                        processingFutures.add(processFuture);
-                      }
-                    }
-                  } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    LOG.warning("Fetcher thread interrupted while waiting for API future result.");
-                    break;
-                  } catch (ExecutionException e) {
-                    LOG.warning(
-                        "Error executing findMatchingTables task: "
-                            + e.getMessage()
-                            + ". Cause: "
-                            + e.getCause());
-                  } catch (CancellationException e) {
-                    LOG.warning("A findMatchingTables task was cancelled.");
-                  }
-                }
-
-                LOG.fine(
-                    "Finished submitting " + processingFutures.size() + " processTableInfo tasks.");
-
-                if (Thread.currentThread().isInterrupted()) {
-                  LOG.warning(
-                      "Fetcher interrupted before waiting for processing tasks; cancelling remaining.");
-                  processingFutures.forEach(f -> f.cancel(true));
-                } else {
-                  LOG.fine("Waiting for processTableInfo tasks to complete...");
-                  waitForTasksCompletion(processingFutures);
-                  LOG.fine("All processTableInfo tasks completed.");
-                }
-
-                if (!Thread.currentThread().isInterrupted()) {
-                  Comparator<FieldValueList> comparator =
-                      defineGetTablesComparator(localResultSchemaFields);
-                  sortResults(collectedResults, comparator, "getTables", LOG);
-                }
-
-                if (!Thread.currentThread().isInterrupted()) {
-                  populateQueue(collectedResults, queue, localResultSchemaFields);
-                }
-
-              } catch (Throwable t) {
-                LOG.severe("Unexpected error in table fetcher runnable: " + t.getMessage());
-                apiFutures.forEach(f -> f.cancel(true));
-                processingFutures.forEach(f -> f.cancel(true));
-              } finally {
-                signalEndOfData(queue, localResultSchemaFields);
-                shutdownExecutor(apiExecutor);
-                shutdownExecutor(tableProcessorExecutor);
-                LOG.info("Table fetcher thread finished.");
-              }
-            } finally {
-              backgroundSpan.end();
-            }
-          };
-
-      Runnable wrappedTableFetcher = Context.current().wrap(tableFetcher);
-      Thread fetcherThread =
-          new Thread(wrappedTableFetcher, "getTables-fetcher-" + effectiveCatalog);
-      BigQueryJsonResultSet resultSet =
-          BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
-
-      fetcherThread.start();
-      LOG.info("Started background thread for getTables");
-      return resultSet;
-    } catch (Exception e) {
-      span.recordException(e);
-      span.setStatus(StatusCode.ERROR, e.getMessage());
-      throw e;
-    } finally {
-      span.end();
+    if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
+        || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
+        || (tableNamePattern != null && tableNamePattern.isEmpty())) {
+      LOG.warning(
+          "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
+      return new BigQueryJsonResultSet();
     }
+
+    LOG.info(
+        "getTables called for catalog: %s, schemaPattern: %s, tableNamePattern: %s, types: %s",
+        effectiveCatalog, effectiveSchemaPattern, tableNamePattern, Arrays.toString(types));
+
+    final Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
+    final Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
+    final Set<String> requestedTypes =
+        (types == null || types.length == 0) ? null : new HashSet<>(Arrays.asList(types));
+
+    final Schema resultSchema = defineGetTablesSchema();
+    final FieldList resultSchemaFields = resultSchema.getFields();
+
+    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+        new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+    final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
+    final String catalogParam = effectiveCatalog;
+    final String schemaParam = effectiveSchemaPattern;
+
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    SpanContext parentSpanContext = Span.current().getSpanContext();
+    Runnable tableFetcher =
+        () -> {
+          Span backgroundSpan =
+              tracer
+                  .spanBuilder("BigQueryDatabaseMetaData.getTables.background")
+                  .setNoParent()
+                  .addLink(parentSpanContext)
+                  .startSpan();
+
+          try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
+            ExecutorService apiExecutor = null;
+            ExecutorService tableProcessorExecutor = null;
+            final FieldList localResultSchemaFields = resultSchemaFields;
+            final List<Future<List<Table>>> apiFutures = new ArrayList<>();
+            final List<Future<?>> processingFutures = new ArrayList<>();
+
+            try {
+              List<Dataset> datasetsToScan =
+                  findMatchingBigQueryObjects(
+                      "Dataset",
+                      () ->
+                          bigquery.listDatasets(
+                              catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                      (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
+                      (ds) -> ds.getDatasetId().getDataset(),
+                      schemaParam,
+                      schemaRegex,
+                      LOG);
+
+              if (datasetsToScan.isEmpty()) {
+                LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
+                return;
+              }
+
+              apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
+              tableProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+
+              LOG.fine("Submitting parallel findMatchingTables tasks...");
+              for (Dataset dataset : datasetsToScan) {
+                if (Thread.currentThread().isInterrupted()) {
+                  LOG.warning("Table fetcher interrupted during dataset iteration.");
+                  break;
+                }
+
+                final DatasetId currentDatasetId = dataset.getDatasetId();
+                Callable<List<Table>> apiCallable =
+                    () ->
+                        findMatchingBigQueryObjects(
+                            "Table",
+                            () ->
+                                bigquery.listTables(
+                                    currentDatasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                            (name) ->
+                                bigquery.getTable(
+                                    TableId.of(
+                                        currentDatasetId.getProject(),
+                                        currentDatasetId.getDataset(),
+                                        name)),
+                            (tbl) -> tbl.getTableId().getTable(),
+                            tableNamePattern,
+                            tableNameRegex,
+                            LOG);
+
+                Callable<List<Table>> wrappedApiCallable = Context.current().wrap(apiCallable);
+                Future<List<Table>> apiFuture = apiExecutor.submit(wrappedApiCallable);
+                apiFutures.add(apiFuture);
+              }
+              LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
+              apiExecutor.shutdown();
+
+              LOG.fine("Processing results from findMatchingTables tasks...");
+              for (Future<List<Table>> apiFuture : apiFutures) {
+                if (Thread.currentThread().isInterrupted()) {
+                  LOG.warning("Table fetcher interrupted while processing API futures.");
+                  break;
+                }
+                try {
+                  List<Table> tablesResult = apiFuture.get();
+                  if (tablesResult != null) {
+                    for (Table table : tablesResult) {
+                      if (Thread.currentThread().isInterrupted()) break;
+
+                      final Table currentTable = table;
+                      Runnable processRunnable =
+                          () ->
+                              processTableInfo(
+                                  currentTable,
+                                  requestedTypes,
+                                  collectedResults,
+                                  localResultSchemaFields);
+                      Runnable wrappedProcessRunnable = Context.current().wrap(processRunnable);
+                      Future<?> processFuture =
+                          tableProcessorExecutor.submit(wrappedProcessRunnable);
+                      processingFutures.add(processFuture);
+                    }
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  LOG.warning("Fetcher thread interrupted while waiting for API future result.");
+                  break;
+                } catch (ExecutionException e) {
+                  LOG.warning(
+                      "Error executing findMatchingTables task: "
+                          + e.getMessage()
+                          + ". Cause: "
+                          + e.getCause());
+                } catch (CancellationException e) {
+                  LOG.warning("A findMatchingTables task was cancelled.");
+                }
+              }
+
+              LOG.fine(
+                  "Finished submitting " + processingFutures.size() + " processTableInfo tasks.");
+
+              if (Thread.currentThread().isInterrupted()) {
+                LOG.warning(
+                    "Fetcher interrupted before waiting for processing tasks; cancelling remaining.");
+                processingFutures.forEach(f -> f.cancel(true));
+              } else {
+                LOG.fine("Waiting for processTableInfo tasks to complete...");
+                waitForTasksCompletion(processingFutures);
+                LOG.fine("All processTableInfo tasks completed.");
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                Comparator<FieldValueList> comparator =
+                    defineGetTablesComparator(localResultSchemaFields);
+                sortResults(collectedResults, comparator, "getTables", LOG);
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                populateQueue(collectedResults, queue, localResultSchemaFields);
+              }
+
+            } catch (Throwable t) {
+              LOG.severe("Unexpected error in table fetcher runnable: " + t.getMessage());
+              apiFutures.forEach(f -> f.cancel(true));
+              processingFutures.forEach(f -> f.cancel(true));
+            } finally {
+              signalEndOfData(queue, localResultSchemaFields);
+              shutdownExecutor(apiExecutor);
+              shutdownExecutor(tableProcessorExecutor);
+              LOG.info("Table fetcher thread finished.");
+            }
+          } finally {
+            backgroundSpan.end();
+          }
+        };
+
+    Runnable wrappedTableFetcher = Context.current().wrap(tableFetcher);
+    Thread fetcherThread = new Thread(wrappedTableFetcher, "getTables-fetcher-" + effectiveCatalog);
+    BigQueryJsonResultSet resultSet =
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+
+    fetcherThread.start();
+    LOG.info("Started background thread for getTables");
+    return resultSet;
   }
 
   Schema defineGetTablesSchema() {
@@ -2020,39 +2017,32 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getSchemas() {
+  public ResultSet getSchemas() throws SQLException {
     LOG.info("getSchemas() called");
 
     return getSchemas(null, null);
   }
 
   @Override
-  public ResultSet getCatalogs() {
+  public ResultSet getCatalogs() throws SQLException {
+    return withTracing("BigQueryDatabaseMetaData.getCatalogs", () -> getCatalogsImpl());
+  }
+
+  private ResultSet getCatalogsImpl() throws SQLException {
     LOG.info("getCatalogs() called");
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
-    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getCatalogs").startSpan();
-    try (Scope scope = span.makeCurrent()) {
-      final List<String> accessibleCatalogs = getAccessibleCatalogNames();
-      final Schema catalogsSchema = defineGetCatalogsSchema();
-      final FieldList schemaFields = catalogsSchema.getFields();
-      final List<FieldValueList> catalogRows =
-          prepareGetCatalogsRows(schemaFields, accessibleCatalogs);
+    final List<String> accessibleCatalogs = getAccessibleCatalogNames();
+    final Schema catalogsSchema = defineGetCatalogsSchema();
+    final FieldList schemaFields = catalogsSchema.getFields();
+    final List<FieldValueList> catalogRows =
+        prepareGetCatalogsRows(schemaFields, accessibleCatalogs);
 
-      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-          new LinkedBlockingQueue<>(catalogRows.isEmpty() ? 1 : catalogRows.size() + 1);
+    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+        new LinkedBlockingQueue<>(catalogRows.isEmpty() ? 1 : catalogRows.size() + 1);
 
-      populateQueue(catalogRows, queue, schemaFields);
-      signalEndOfData(queue, schemaFields);
+    populateQueue(catalogRows, queue, schemaFields);
+    signalEndOfData(queue, schemaFields);
 
-      return BigQueryJsonResultSet.of(
-          catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
-    } catch (Exception e) {
-      span.recordException(e);
-      span.setStatus(StatusCode.ERROR, e.getMessage());
-      throw e;
-    } finally {
-      span.end();
-    }
+    return BigQueryJsonResultSet.of(catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
   }
 
   Schema defineGetCatalogsSchema() {
@@ -2108,166 +2098,166 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public ResultSet getColumns(
-      String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) {
+      String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+      throws SQLException {
+    return withTracing(
+        "BigQueryDatabaseMetaData.getColumns",
+        () -> getColumnsImpl(catalog, schemaPattern, tableNamePattern, columnNamePattern));
+  }
+
+  private ResultSet getColumnsImpl(
+      String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
+      throws SQLException {
+    Tuple<String, String> effectiveIdentifiers =
+        determineEffectiveCatalogAndSchema(catalog, schemaPattern);
+    String effectiveCatalog = effectiveIdentifiers.x();
+    String effectiveSchemaPattern = effectiveIdentifiers.y();
+
+    if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
+        || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
+        || (tableNamePattern != null && tableNamePattern.isEmpty())
+        || (columnNamePattern != null && columnNamePattern.isEmpty())) {
+      LOG.warning(
+          "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
+      return new BigQueryJsonResultSet();
+    }
+
+    LOG.info(
+        "getColumns called for catalog: %s, schemaPattern: %s, tableNamePattern: %s,"
+            + " columnNamePattern: %s",
+        effectiveCatalog, effectiveSchemaPattern, tableNamePattern, columnNamePattern);
+
+    Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
+    Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
+    Pattern columnNameRegex = compileSqlLikePattern(columnNamePattern);
+
+    final Schema resultSchema = defineGetColumnsSchema();
+    final FieldList resultSchemaFields = resultSchema.getFields();
+    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+        new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+    final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
+    final String catalogParam = effectiveCatalog;
+    final String schemaParam = effectiveSchemaPattern;
+
     Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
-    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getColumns").startSpan();
-    try (Scope scope = span.makeCurrent()) {
-      Tuple<String, String> effectiveIdentifiers =
-          determineEffectiveCatalogAndSchema(catalog, schemaPattern);
-      String effectiveCatalog = effectiveIdentifiers.x();
-      String effectiveSchemaPattern = effectiveIdentifiers.y();
+    SpanContext parentSpanContext = Span.current().getSpanContext();
+    Runnable columnFetcher =
+        () -> {
+          Span backgroundSpan =
+              tracer
+                  .spanBuilder("BigQueryDatabaseMetaData.getColumns.background")
+                  .setNoParent()
+                  .addLink(parentSpanContext)
+                  .startSpan();
 
-      if ((effectiveCatalog == null || effectiveCatalog.isEmpty())
-          || (effectiveSchemaPattern != null && effectiveSchemaPattern.isEmpty())
-          || (tableNamePattern != null && tableNamePattern.isEmpty())
-          || (columnNamePattern != null && columnNamePattern.isEmpty())) {
-        LOG.warning(
-            "Returning empty ResultSet as one or more patterns are empty or catalog is null.");
-        return new BigQueryJsonResultSet();
-      }
+          try (Scope scope = backgroundSpan.makeCurrent()) {
+            ExecutorService columnExecutor = null;
+            final List<Future<?>> taskFutures = new ArrayList<>();
+            final FieldList localResultSchemaFields = resultSchemaFields;
 
-      LOG.info(
-          "getColumns called for catalog: %s, schemaPattern: %s, tableNamePattern: %s,"
-              + " columnNamePattern: %s",
-          effectiveCatalog, effectiveSchemaPattern, tableNamePattern, columnNamePattern);
+            try {
+              List<Dataset> datasetsToScan =
+                  findMatchingBigQueryObjects(
+                      "Dataset",
+                      () ->
+                          bigquery.listDatasets(
+                              catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                      (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
+                      (ds) -> ds.getDatasetId().getDataset(),
+                      schemaParam,
+                      schemaRegex,
+                      LOG);
 
-      Pattern schemaRegex = compileSqlLikePattern(effectiveSchemaPattern);
-      Pattern tableNameRegex = compileSqlLikePattern(tableNamePattern);
-      Pattern columnNameRegex = compileSqlLikePattern(columnNamePattern);
+              if (datasetsToScan.isEmpty()) {
+                LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
+                return;
+              }
 
-      final Schema resultSchema = defineGetColumnsSchema();
-      final FieldList resultSchemaFields = resultSchema.getFields();
-      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-          new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
-      final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
-      final String catalogParam = effectiveCatalog;
-      final String schemaParam = effectiveSchemaPattern;
+              columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
 
-      SpanContext parentSpanContext = span.getSpanContext();
-      Runnable columnFetcher =
-          () -> {
-            Span backgroundSpan =
-                tracer
-                    .spanBuilder("BigQueryDatabaseMetaData.getColumns.background")
-                    .setNoParent()
-                    .addLink(parentSpanContext)
-                    .startSpan();
-
-            try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
-              ExecutorService columnExecutor = null;
-              final List<Future<?>> taskFutures = new ArrayList<>();
-              final FieldList localResultSchemaFields = resultSchemaFields;
-
-              try {
-                List<Dataset> datasetsToScan =
-                    findMatchingBigQueryObjects(
-                        "Dataset",
-                        () ->
-                            bigquery.listDatasets(
-                                catalogParam, DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                        (name) -> bigquery.getDataset(DatasetId.of(catalogParam, name)),
-                        (ds) -> ds.getDatasetId().getDataset(),
-                        schemaParam,
-                        schemaRegex,
-                        LOG);
-
-                if (datasetsToScan.isEmpty()) {
-                  LOG.info("Fetcher thread found no matching datasets. Returning empty resultset.");
-                  return;
+              for (Dataset dataset : datasetsToScan) {
+                if (Thread.currentThread().isInterrupted()) {
+                  LOG.warning("Fetcher interrupted during dataset iteration.");
+                  break;
                 }
 
-                columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+                DatasetId datasetId = dataset.getDatasetId();
+                LOG.info("Processing dataset: " + datasetId.getDataset());
 
-                for (Dataset dataset : datasetsToScan) {
+                List<Table> tablesToScan =
+                    findMatchingBigQueryObjects(
+                        "Table",
+                        () ->
+                            bigquery.listTables(
+                                datasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                        (name) ->
+                            bigquery.getTable(
+                                TableId.of(datasetId.getProject(), datasetId.getDataset(), name)),
+                        (tbl) -> tbl.getTableId().getTable(),
+                        tableNamePattern,
+                        tableNameRegex,
+                        LOG);
+
+                for (Table table : tablesToScan) {
                   if (Thread.currentThread().isInterrupted()) {
-                    LOG.warning("Fetcher interrupted during dataset iteration.");
+                    LOG.warning(
+                        "Fetcher interrupted during table iteration for dataset "
+                            + datasetId.getDataset());
                     break;
                   }
 
-                  DatasetId datasetId = dataset.getDatasetId();
-                  LOG.info("Processing dataset: " + datasetId.getDataset());
+                  TableId tableId = table.getTableId();
+                  LOG.fine("Submitting task for table: " + tableId);
+                  final Table finalTable = table;
 
-                  List<Table> tablesToScan =
-                      findMatchingBigQueryObjects(
-                          "Table",
-                          () ->
-                              bigquery.listTables(
-                                  datasetId, TableListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                          (name) ->
-                              bigquery.getTable(
-                                  TableId.of(datasetId.getProject(), datasetId.getDataset(), name)),
-                          (tbl) -> tbl.getTableId().getTable(),
-                          tableNamePattern,
-                          tableNameRegex,
-                          LOG);
-
-                  for (Table table : tablesToScan) {
-                    if (Thread.currentThread().isInterrupted()) {
-                      LOG.warning(
-                          "Fetcher interrupted during table iteration for dataset "
-                              + datasetId.getDataset());
-                      break;
-                    }
-
-                    TableId tableId = table.getTableId();
-                    LOG.fine("Submitting task for table: " + tableId);
-                    final Table finalTable = table;
-
-                    Runnable columnTask =
-                        () ->
-                            processTableColumns(
-                                finalTable,
-                                columnNameRegex,
-                                collectedResults,
-                                localResultSchemaFields);
-                    Runnable wrappedColumnTask = Context.current().wrap(columnTask);
-                    Future<?> future = columnExecutor.submit(wrappedColumnTask);
-                    taskFutures.add(future);
-                  }
-                  if (Thread.currentThread().isInterrupted()) break;
+                  Runnable columnTask =
+                      () ->
+                          processTableColumns(
+                              finalTable,
+                              columnNameRegex,
+                              collectedResults,
+                              localResultSchemaFields);
+                  Runnable wrappedColumnTask = Context.current().wrap(columnTask);
+                  Future<?> future = columnExecutor.submit(wrappedColumnTask);
+                  taskFutures.add(future);
                 }
-
-                waitForTasksCompletion(taskFutures);
-
-                if (!Thread.currentThread().isInterrupted()) {
-                  Comparator<FieldValueList> comparator =
-                      defineGetColumnsComparator(localResultSchemaFields);
-                  sortResults(collectedResults, comparator, "getColumns", LOG);
-                }
-
-                if (!Thread.currentThread().isInterrupted()) {
-                  populateQueue(collectedResults, queue, localResultSchemaFields);
-                }
-
-              } catch (Throwable t) {
-                LOG.severe("Unexpected error in column fetcher runnable: " + t.getMessage());
-                taskFutures.forEach(f -> f.cancel(true));
-              } finally {
-                signalEndOfData(queue, localResultSchemaFields);
-                shutdownExecutor(columnExecutor);
-                LOG.info("Column fetcher thread finished.");
+                if (Thread.currentThread().isInterrupted()) break;
               }
+
+              waitForTasksCompletion(taskFutures);
+
+              if (!Thread.currentThread().isInterrupted()) {
+                Comparator<FieldValueList> comparator =
+                    defineGetColumnsComparator(localResultSchemaFields);
+                sortResults(collectedResults, comparator, "getColumns", LOG);
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                populateQueue(collectedResults, queue, localResultSchemaFields);
+              }
+
+            } catch (Throwable t) {
+              LOG.severe("Unexpected error in column fetcher runnable: " + t.getMessage());
+              taskFutures.forEach(f -> f.cancel(true));
             } finally {
-              backgroundSpan.end();
+              signalEndOfData(queue, localResultSchemaFields);
+              shutdownExecutor(columnExecutor);
+              LOG.info("Column fetcher thread finished.");
             }
-          };
+          } finally {
+            backgroundSpan.end();
+          }
+        };
 
-      Runnable wrappedColumnFetcher = Context.current().wrap(columnFetcher);
-      Thread fetcherThread =
-          new Thread(wrappedColumnFetcher, "getColumns-fetcher-" + effectiveCatalog);
-      BigQueryJsonResultSet resultSet =
-          BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+    Runnable wrappedColumnFetcher = Context.current().wrap(columnFetcher);
+    Thread fetcherThread =
+        new Thread(wrappedColumnFetcher, "getColumns-fetcher-" + effectiveCatalog);
+    BigQueryJsonResultSet resultSet =
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
-      fetcherThread.start();
-      LOG.info("Started background thread for getColumns");
-      return resultSet;
-    } catch (Exception e) {
-      span.recordException(e);
-      span.setStatus(StatusCode.ERROR, e.getMessage());
-      throw e;
-    } finally {
-      span.end();
-    }
+    fetcherThread.start();
+    LOG.info("Started background thread for getColumns");
+    return resultSet;
   }
 
   private void processTableColumns(
@@ -3686,131 +3676,127 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   }
 
   @Override
-  public ResultSet getSchemas(String catalog, String schemaPattern) {
+  public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
+    return withTracing(
+        "BigQueryDatabaseMetaData.getSchemas", () -> getSchemasImpl(catalog, schemaPattern));
+  }
+
+  private ResultSet getSchemasImpl(String catalog, String schemaPattern) throws SQLException {
+    if ((catalog != null && catalog.isEmpty())
+        || (schemaPattern != null && schemaPattern.isEmpty())) {
+      LOG.warning("Returning empty ResultSet as catalog or schemaPattern is an empty string.");
+      return new BigQueryJsonResultSet();
+    }
+
+    LOG.info("getSchemas called for catalog: %s, schemaPattern: %s", catalog, schemaPattern);
+
+    final Pattern schemaRegex = compileSqlLikePattern(schemaPattern);
+    final Schema resultSchema = defineGetSchemasSchema();
+    final FieldList resultSchemaFields = resultSchema.getFields();
+
+    final BlockingQueue<BigQueryFieldValueListWrapper> queue =
+        new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
+    final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
+    final String catalogParam = catalog;
+
     Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
-    Span span = tracer.spanBuilder("BigQueryDatabaseMetaData.getSchemas").startSpan();
-    try (Scope scope = span.makeCurrent()) {
-      if ((catalog != null && catalog.isEmpty())
-          || (schemaPattern != null && schemaPattern.isEmpty())) {
-        LOG.warning("Returning empty ResultSet as catalog or schemaPattern is an empty string.");
-        return new BigQueryJsonResultSet();
-      }
+    SpanContext parentSpanContext = Span.current().getSpanContext();
+    Runnable schemaFetcher =
+        () -> {
+          Span backgroundSpan =
+              tracer
+                  .spanBuilder("BigQueryDatabaseMetaData.getSchemas.background")
+                  .setNoParent()
+                  .addLink(parentSpanContext)
+                  .startSpan();
 
-      LOG.info("getSchemas called for catalog: %s, schemaPattern: %s", catalog, schemaPattern);
+          try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
+            final FieldList localResultSchemaFields = resultSchemaFields;
+            List<String> projectsToScanList = new ArrayList<>();
 
-      final Pattern schemaRegex = compileSqlLikePattern(schemaPattern);
-      final Schema resultSchema = defineGetSchemasSchema();
-      final FieldList resultSchemaFields = resultSchema.getFields();
+            if (catalogParam != null) {
+              projectsToScanList.add(catalogParam);
+            } else {
+              projectsToScanList.addAll(getAccessibleCatalogNames());
+            }
 
-      final BlockingQueue<BigQueryFieldValueListWrapper> queue =
-          new LinkedBlockingQueue<>(DEFAULT_QUEUE_CAPACITY);
-      final List<FieldValueList> collectedResults = Collections.synchronizedList(new ArrayList<>());
-      final String catalogParam = catalog;
+            if (projectsToScanList.isEmpty()) {
+              LOG.info(
+                  "No valid projects to scan (primary, specified, or additional). Returning empty"
+                      + " resultset.");
+              return;
+            }
 
-      SpanContext parentSpanContext = span.getSpanContext();
-      Runnable schemaFetcher =
-          () -> {
-            Span backgroundSpan =
-                tracer
-                    .spanBuilder("BigQueryDatabaseMetaData.getSchemas.background")
-                    .setNoParent()
-                    .addLink(parentSpanContext)
-                    .startSpan();
+            try {
+              for (String currentProjectToScan : projectsToScanList) {
+                if (Thread.currentThread().isInterrupted()) {
+                  LOG.warning(
+                      "Schema fetcher interrupted during project iteration for project: "
+                          + currentProjectToScan);
+                  break;
+                }
+                LOG.info("Fetching schemas for project: " + currentProjectToScan);
+                List<Dataset> datasetsInProject =
+                    findMatchingBigQueryObjects(
+                        "Dataset",
+                        () ->
+                            bigquery.listDatasets(
+                                currentProjectToScan,
+                                BigQuery.DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
+                        (name) -> bigquery.getDataset(DatasetId.of(currentProjectToScan, name)),
+                        (ds) -> ds.getDatasetId().getDataset(),
+                        schemaPattern,
+                        schemaRegex,
+                        LOG);
 
-            try (Scope backgroundScope = backgroundSpan.makeCurrent()) {
-              final FieldList localResultSchemaFields = resultSchemaFields;
-              List<String> projectsToScanList = new ArrayList<>();
+                if (datasetsInProject.isEmpty() || Thread.currentThread().isInterrupted()) {
+                  LOG.info(
+                      "Fetcher thread found no matching datasets in project: "
+                          + currentProjectToScan);
+                  continue;
+                }
 
-              if (catalogParam != null) {
-                projectsToScanList.add(catalogParam);
-              } else {
-                projectsToScanList.addAll(getAccessibleCatalogNames());
-              }
-
-              if (projectsToScanList.isEmpty()) {
-                LOG.info(
-                    "No valid projects to scan (primary, specified, or additional). Returning empty"
-                        + " resultset.");
-                return;
-              }
-
-              try {
-                for (String currentProjectToScan : projectsToScanList) {
+                LOG.fine("Processing found datasets for project: " + currentProjectToScan);
+                for (Dataset dataset : datasetsInProject) {
                   if (Thread.currentThread().isInterrupted()) {
                     LOG.warning(
-                        "Schema fetcher interrupted during project iteration for project: "
+                        "Schema fetcher interrupted during dataset iteration for project: "
                             + currentProjectToScan);
                     break;
                   }
-                  LOG.info("Fetching schemas for project: " + currentProjectToScan);
-                  List<Dataset> datasetsInProject =
-                      findMatchingBigQueryObjects(
-                          "Dataset",
-                          () ->
-                              bigquery.listDatasets(
-                                  currentProjectToScan,
-                                  BigQuery.DatasetListOption.pageSize(DEFAULT_PAGE_SIZE)),
-                          (name) -> bigquery.getDataset(DatasetId.of(currentProjectToScan, name)),
-                          (ds) -> ds.getDatasetId().getDataset(),
-                          schemaPattern,
-                          schemaRegex,
-                          LOG);
-
-                  if (datasetsInProject.isEmpty() || Thread.currentThread().isInterrupted()) {
-                    LOG.info(
-                        "Fetcher thread found no matching datasets in project: "
-                            + currentProjectToScan);
-                    continue;
-                  }
-
-                  LOG.fine("Processing found datasets for project: " + currentProjectToScan);
-                  for (Dataset dataset : datasetsInProject) {
-                    if (Thread.currentThread().isInterrupted()) {
-                      LOG.warning(
-                          "Schema fetcher interrupted during dataset iteration for project: "
-                              + currentProjectToScan);
-                      break;
-                    }
-                    processSchemaInfo(dataset, collectedResults, localResultSchemaFields);
-                  }
+                  processSchemaInfo(dataset, collectedResults, localResultSchemaFields);
                 }
-
-                if (!Thread.currentThread().isInterrupted()) {
-                  Comparator<FieldValueList> comparator =
-                      defineGetSchemasComparator(localResultSchemaFields);
-                  sortResults(collectedResults, comparator, "getSchemas", LOG);
-                }
-
-                if (!Thread.currentThread().isInterrupted()) {
-                  populateQueue(collectedResults, queue, localResultSchemaFields);
-                }
-
-              } catch (Throwable t) {
-                LOG.severe("Unexpected error in schema fetcher runnable: " + t.getMessage());
-              } finally {
-                signalEndOfData(queue, localResultSchemaFields);
-                LOG.info("Schema fetcher thread finished.");
               }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                Comparator<FieldValueList> comparator =
+                    defineGetSchemasComparator(localResultSchemaFields);
+                sortResults(collectedResults, comparator, "getSchemas", LOG);
+              }
+
+              if (!Thread.currentThread().isInterrupted()) {
+                populateQueue(collectedResults, queue, localResultSchemaFields);
+              }
+
+            } catch (Throwable t) {
+              LOG.severe("Unexpected error in schema fetcher runnable: " + t.getMessage());
             } finally {
-              backgroundSpan.end();
+              signalEndOfData(queue, localResultSchemaFields);
+              LOG.info("Schema fetcher thread finished.");
             }
-          };
+          } finally {
+            backgroundSpan.end();
+          }
+        };
 
-      Runnable wrappedFetcher = Context.current().wrap(schemaFetcher);
-      Thread fetcherThread = new Thread(wrappedFetcher, "getSchemas-fetcher-" + catalog);
-      BigQueryJsonResultSet resultSet =
-          BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+    Runnable wrappedFetcher = Context.current().wrap(schemaFetcher);
+    Thread fetcherThread = new Thread(wrappedFetcher, "getSchemas-fetcher-" + catalog);
+    BigQueryJsonResultSet resultSet =
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
 
-      fetcherThread.start();
-      LOG.info("Started background thread for getSchemas");
-      return resultSet;
-    } catch (Exception e) {
-      span.recordException(e);
-      span.setStatus(StatusCode.ERROR, e.getMessage());
-      throw e;
-    } finally {
-      span.end();
-    }
+    fetcherThread.start();
+    LOG.info("Started background thread for getSchemas");
+    return resultSet;
   }
 
   Schema defineGetSchemasSchema() {
@@ -5382,6 +5368,25 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               + e.getMessage();
       LOG.severe(errorMessage);
       throw new IllegalStateException(errorMessage, e);
+    }
+  }
+
+  private interface TracedMetadataOperation<T> {
+    T run() throws SQLException;
+  }
+
+  private <T> T withTracing(String spanName, TracedMetadataOperation<T> operation)
+      throws SQLException {
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Span span = tracer.spanBuilder(spanName).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+      return operation.run();
+    } catch (Exception ex) {
+      span.recordException(ex);
+      span.setStatus(StatusCode.ERROR, ex.getMessage());
+      throw ex;
+    } finally {
+      span.end();
     }
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -49,4 +49,12 @@ public class BigQueryJdbcOpenTelemetry {
   public static Tracer getTracer(OpenTelemetry openTelemetry) {
     return openTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
   }
+
+  /** Gets a Tracer for the JDBC driver, fallback to noop if connection has no tracer. */
+  public static Tracer getSafeTracer(BigQueryConnection connection) {
+    if (connection != null && connection.getTracer() != null) {
+      return connection.getTracer();
+    }
+    return getOpenTelemetry(false, false, null).getTracer(INSTRUMENTATION_SCOPE_NAME);
+  }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -49,12 +49,4 @@ public class BigQueryJdbcOpenTelemetry {
   public static Tracer getTracer(OpenTelemetry openTelemetry) {
     return openTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
   }
-
-  /** Gets a Tracer for the JDBC driver, fallback to noop if connection has no tracer. */
-  public static Tracer getSafeTracer(BigQueryConnection connection) {
-    if (connection != null && connection.getTracer() != null) {
-      return connection.getTracer();
-    }
-    return getOpenTelemetry(false, false, null).getTracer(INSTRUMENTATION_SCOPE_NAME);
-  }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -136,51 +136,51 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   /* Advances the result set to the next row, returning false if no such row exists. Potentially blocking operation */
   public boolean next() throws SQLException {
     checkClosed();
-    try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
-      if (this.isNested) {
-        // We are working with the nested record, the cursor would have been
-        // populated.
-        if (this.cursor == null || this.cursor.getArrayFieldValueList() == null) {
-          throw new IllegalStateException(
-              "Cursor/ArrayFieldValueList can not be null working with the nested record");
-        }
-        // Check if there's a next record in the array which can be read
-        if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
-          this.nestedRowIndex++;
-          return true;
-        }
+    if (this.isNested) {
+      // We are working with the nested record, the cursor would have been
+      // populated.
+      if (this.cursor == null || this.cursor.getArrayFieldValueList() == null) {
+        throw new IllegalStateException(
+            "Cursor/ArrayFieldValueList can not be null working with the nested record");
+      }
+      // Check if there's a next record in the array which can be read
+      if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
+        this.nestedRowIndex++;
+        return true;
+      }
+      this.afterLast = true;
+      return false;
+
+    } else {
+      // If end of stream is reached or we are past the last row i.e
+      // rowcnt == totalRows (rowcnt starts at 0)
+      // then we can simply return false
+      if (this.hasReachedEnd || this.isLast()) {
         this.afterLast = true;
         return false;
-
-      } else {
-        // If end of stream is reached or we are past the last row i.e
-        // rowcnt == totalRows (rowcnt starts at 0)
-        // then we can simply return false
-        if (this.hasReachedEnd || this.isLast()) {
-          this.afterLast = true;
+      }
+      try {
+        // Advance the cursor,Potentially blocking operation
+        try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
+          this.cursor = this.buffer.take();
+        }
+        if (this.cursor.getException() != null) {
+          throw new BigQueryJdbcRuntimeException(this.cursor.getException());
+        }
+        this.rowCnt++;
+        // Check for end of stream
+        if (this.cursor.isLast()) {
+          this.cursor = null;
+          this.hasReachedEnd = true;
           return false;
         }
-        try {
-          // Advance the cursor,Potentially blocking operation
-          this.cursor = this.buffer.take();
-          if (this.cursor.getException() != null) {
-            throw new BigQueryJdbcRuntimeException(this.cursor.getException());
-          }
-          this.rowCnt++;
-          // Check for end of stream
-          if (this.cursor.isLast()) {
-            this.cursor = null;
-            this.hasReachedEnd = true;
-            return false;
-          }
-          // Cursor has been advanced
-          return true;
+        // Cursor has been advanced
+        return true;
 
-        } catch (InterruptedException ex) {
-          throw new BigQueryJdbcRuntimeException(
-              "Error occurred while advancing the cursor. This could happen when connection is closed while we call the next method",
-              ex);
-        }
+      } catch (InterruptedException ex) {
+        throw new BigQueryJdbcRuntimeException(
+            "Error occurred while advancing the cursor. This could happen when connection is closed while we call the next method",
+            ex);
       }
     }
   }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -25,7 +25,6 @@ import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValue.Attribute;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
-import io.opentelemetry.context.Scope;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.BlockingQueue;
@@ -159,9 +158,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
       }
       try {
         // Advance the cursor,Potentially blocking operation
-        try (Scope scope = makeOriginalContextCurrent()) {
-          this.cursor = this.buffer.take();
-        }
+        this.cursor = this.buffer.take();
         if (this.cursor.getException() != null) {
           throw new BigQueryJdbcRuntimeException(this.cursor.getException());
         }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -25,8 +25,6 @@ import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValue.Attribute;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -161,7 +159,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
       }
       try {
         // Advance the cursor,Potentially blocking operation
-        try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
+        try (Scope scope = makeOriginalContextCurrent()) {
           this.cursor = this.buffer.take();
         }
         if (this.cursor.getException() != null) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -25,6 +25,9 @@ import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValue.Attribute;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.BlockingQueue;
@@ -133,49 +136,51 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   /* Advances the result set to the next row, returning false if no such row exists. Potentially blocking operation */
   public boolean next() throws SQLException {
     checkClosed();
-    if (this.isNested) {
-      // We are working with the nested record, the cursor would have been
-      // populated.
-      if (this.cursor == null || this.cursor.getArrayFieldValueList() == null) {
-        throw new IllegalStateException(
-            "Cursor/ArrayFieldValueList can not be null working with the nested record");
-      }
-      // Check if there's a next record in the array which can be read
-      if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
-        this.nestedRowIndex++;
-        return true;
-      }
-      this.afterLast = true;
-      return false;
-
-    } else {
-      // If end of stream is reached or we are past the last row i.e
-      // rowcnt == totalRows (rowcnt starts at 0)
-      // then we can simply return false
-      if (this.hasReachedEnd || this.isLast()) {
+    try (Scope scope = Context.current().with(Span.wrap(originalSpanContext)).makeCurrent()) {
+      if (this.isNested) {
+        // We are working with the nested record, the cursor would have been
+        // populated.
+        if (this.cursor == null || this.cursor.getArrayFieldValueList() == null) {
+          throw new IllegalStateException(
+              "Cursor/ArrayFieldValueList can not be null working with the nested record");
+        }
+        // Check if there's a next record in the array which can be read
+        if (this.nestedRowIndex < (this.toIndexExclusive - 1)) {
+          this.nestedRowIndex++;
+          return true;
+        }
         this.afterLast = true;
         return false;
-      }
-      try {
-        // Advance the cursor,Potentially blocking operation
-        this.cursor = this.buffer.take();
-        if (this.cursor.getException() != null) {
-          throw new BigQueryJdbcRuntimeException(this.cursor.getException());
-        }
-        this.rowCnt++;
-        // Check for end of stream
-        if (this.cursor.isLast()) {
-          this.cursor = null;
-          this.hasReachedEnd = true;
+
+      } else {
+        // If end of stream is reached or we are past the last row i.e
+        // rowcnt == totalRows (rowcnt starts at 0)
+        // then we can simply return false
+        if (this.hasReachedEnd || this.isLast()) {
+          this.afterLast = true;
           return false;
         }
-        // Cursor has been advanced
-        return true;
+        try {
+          // Advance the cursor,Potentially blocking operation
+          this.cursor = this.buffer.take();
+          if (this.cursor.getException() != null) {
+            throw new BigQueryJdbcRuntimeException(this.cursor.getException());
+          }
+          this.rowCnt++;
+          // Check for end of stream
+          if (this.cursor.isLast()) {
+            this.cursor = null;
+            this.hasReachedEnd = true;
+            return false;
+          }
+          // Cursor has been advanced
+          return true;
 
-      } catch (InterruptedException ex) {
-        throw new BigQueryJdbcRuntimeException(
-            "Error occurred while advancing the cursor. This could happen when connection is closed while we call the next method",
-            ex);
+        } catch (InterruptedException ex) {
+          throw new BigQueryJdbcRuntimeException(
+              "Error occurred while advancing the cursor. This could happen when connection is closed while we call the next method",
+              ex);
+        }
       }
     }
   }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -60,6 +60,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
@@ -848,86 +849,83 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     Runnable arrowStreamProcessor =
         Context.current()
             .wrap(
-                () -> {
-                  long rowsRead = 0;
-                  int retryCount = 0;
-                  try {
-                    // Use the first stream to perform reading.
-                    String streamName = readSession.getStreams(0).getName();
-
-                    while (true) {
-                      try {
-                        ReadRowsRequest readRowsRequest =
-                            ReadRowsRequest.newBuilder()
-                                .setReadStream(streamName)
-                                .setOffset(rowsRead)
-                                .build();
-
-                        // Process each block of rows as they arrive and decode using our simple row
-                        // reader.
-                        com.google.api.gax.rpc.ServerStream<ReadRowsResponse> stream =
-                            bqReadClient.readRowsCallable().call(readRowsRequest);
-                        for (ReadRowsResponse response : stream) {
-                          if (Thread.currentThread().isInterrupted()
-                              || queryTaskExecutor.isShutdown()) {
-                            break;
-                          }
-
-                          ArrowRecordBatch currentBatch = response.getArrowRecordBatch();
-                          Uninterruptibles.putUninterruptibly(
-                              arrowBatchWrapperBlockingQueue,
-                              BigQueryArrowBatchWrapper.of(currentBatch));
-                          rowsRead += response.getRowCount();
-                        }
-                        break;
-                      } catch (com.google.api.gax.rpc.ApiException e) {
-                        if (e.getStatusCode().getCode()
-                            == com.google.api.gax.rpc.StatusCode.Code.NOT_FOUND) {
-                          LOG.warning("Read session expired or not found: %s", e.getMessage());
-                          enqueueError(arrowBatchWrapperBlockingQueue, e);
-                          break;
-                        }
-                        if (retryCount >= MAX_RETRY_COUNT) {
-                          LOG.log(
-                              Level.SEVERE,
-                              "\n"
-                                  + Thread.currentThread().getName()
-                                  + " Interrupted @ arrowStreamProcessor, max retries exceeded",
-                              e);
-                          enqueueError(arrowBatchWrapperBlockingQueue, e);
-                          break;
-                        }
-                        retryCount++;
-                        LOG.warning(
-                            "Connection interrupted during arrow stream read, retrying. attempt: %d",
-                            retryCount);
-                        Thread.sleep(RETRY_DELAY_MS);
-                      }
-                    }
-
-                  } catch (InterruptedException e) {
-                    LOG.log(
-                        Level.WARNING,
-                        "\n"
-                            + Thread.currentThread().getName()
-                            + " Interrupted @ arrowStreamProcessor",
-                        e);
-                    enqueueError(arrowBatchWrapperBlockingQueue, e);
-                    Thread.currentThread().interrupt();
-                  } catch (Exception e) {
-                    LOG.log(
-                        Level.WARNING,
-                        "\n" + Thread.currentThread().getName() + " Error @ arrowStreamProcessor",
-                        e);
-                    enqueueError(arrowBatchWrapperBlockingQueue, e);
-                  } finally { // logic needed for graceful shutdown
-                    enqueueEndOfStream(arrowBatchWrapperBlockingQueue);
-                  }
-                });
+                () ->
+                    processArrowStream(readSession, arrowBatchWrapperBlockingQueue, bqReadClient));
 
     Thread populateBufferWorker = JDBC_THREAD_FACTORY.newThread(arrowStreamProcessor);
     populateBufferWorker.start();
     return populateBufferWorker;
+  }
+
+  private void processArrowStream(
+      ReadSession readSession,
+      BlockingQueue<BigQueryArrowBatchWrapper> arrowBatchWrapperBlockingQueue,
+      BigQueryReadClient bqReadClient) {
+    long rowsRead = 0;
+    int retryCount = 0;
+    try {
+      // Use the first stream to perform reading.
+      String streamName = readSession.getStreams(0).getName();
+
+      while (true) {
+        try {
+          ReadRowsRequest readRowsRequest =
+              ReadRowsRequest.newBuilder().setReadStream(streamName).setOffset(rowsRead).build();
+
+          // Process each block of rows as they arrive and decode using our simple row
+          // reader.
+          com.google.api.gax.rpc.ServerStream<ReadRowsResponse> stream =
+              bqReadClient.readRowsCallable().call(readRowsRequest);
+          for (ReadRowsResponse response : stream) {
+            if (Thread.currentThread().isInterrupted() || queryTaskExecutor.isShutdown()) {
+              break;
+            }
+
+            ArrowRecordBatch currentBatch = response.getArrowRecordBatch();
+            Uninterruptibles.putUninterruptibly(
+                arrowBatchWrapperBlockingQueue, BigQueryArrowBatchWrapper.of(currentBatch));
+            rowsRead += response.getRowCount();
+          }
+          break;
+        } catch (com.google.api.gax.rpc.ApiException e) {
+          if (e.getStatusCode().getCode() == com.google.api.gax.rpc.StatusCode.Code.NOT_FOUND) {
+            LOG.warning("Read session expired or not found: %s", e.getMessage());
+            enqueueError(arrowBatchWrapperBlockingQueue, e);
+            break;
+          }
+          if (retryCount >= MAX_RETRY_COUNT) {
+            LOG.log(
+                Level.SEVERE,
+                "\n"
+                    + Thread.currentThread().getName()
+                    + " Interrupted @ arrowStreamProcessor, max retries exceeded",
+                e);
+            enqueueError(arrowBatchWrapperBlockingQueue, e);
+            break;
+          }
+          retryCount++;
+          LOG.warning(
+              "Connection interrupted during arrow stream read, retrying. attempt: %d", retryCount);
+          Thread.sleep(RETRY_DELAY_MS);
+        }
+      }
+
+    } catch (InterruptedException e) {
+      LOG.log(
+          Level.WARNING,
+          "\n" + Thread.currentThread().getName() + " Interrupted @ arrowStreamProcessor",
+          e);
+      enqueueError(arrowBatchWrapperBlockingQueue, e);
+      Thread.currentThread().interrupt();
+    } catch (Exception e) {
+      LOG.log(
+          Level.WARNING,
+          "\n" + Thread.currentThread().getName() + " Error @ arrowStreamProcessor",
+          e);
+      enqueueError(arrowBatchWrapperBlockingQueue, e);
+    } finally { // logic needed for graceful shutdown
+      enqueueEndOfStream(arrowBatchWrapperBlockingQueue);
+    }
   }
 
   /** Executes SQL query using either fast query path or read API */
@@ -1544,7 +1542,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   }
 
   private <T> T withTracing(String spanName, TracedOperation<T> operation) throws SQLException {
-    Tracer tracer = getSafeTracer();
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
     Span span = tracer.spanBuilder(spanName).startSpan();
     try (Scope scope = span.makeCurrent()) {
       return operation.run(span);
@@ -1563,7 +1561,8 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       BlockingQueue<Tuple<TableResult, Boolean>> rpcResponseQueue,
       BlockingQueue<BigQueryFieldValueListWrapper> bigQueryFieldValueListWrapperBlockingQueue,
       TableResult result) {
-    Tracer tracer = getSafeTracer();
+    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    SpanContext parentSpanContext = Span.current().getSpanContext();
     String currentPageToken = firstPageToken;
     TableResult currentResults = result;
     TableId destinationTable = null;
@@ -1579,6 +1578,9 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
         }
 
         SpanBuilder spanBuilder = tracer.spanBuilder("BigQueryStatement.pagination");
+        if (parentSpanContext != null) {
+          spanBuilder.addLink(parentSpanContext);
+        }
         Span paginationSpan = spanBuilder.startSpan();
         try (Scope scope = paginationSpan.makeCurrent()) {
           paginationSpan.setAttribute("db.pagination.page_token", currentPageToken);
@@ -1671,13 +1673,5 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     } finally {
       enqueueBufferEndOfStream(bigQueryFieldValueListWrapperBlockingQueue);
     }
-  }
-
-  private Tracer getSafeTracer() {
-    if (connection != null && connection.getTracer() != null) {
-      return connection.getTracer();
-    }
-    return BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, null)
-        .getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME);
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -1578,7 +1578,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
         }
 
         SpanBuilder spanBuilder = tracer.spanBuilder("BigQueryStatement.pagination");
-        if (parentSpanContext != null) {
+        if (parentSpanContext.isValid()) {
           spanBuilder.addLink(parentSpanContext);
         }
         Span paginationSpan = spanBuilder.startSpan();

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -1542,7 +1542,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   }
 
   private <T> T withTracing(String spanName, TracedOperation<T> operation) throws SQLException {
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Tracer tracer = this.connection.getTracer();
     Span span = tracer.spanBuilder(spanName).startSpan();
     try (Scope scope = span.makeCurrent()) {
       return operation.run(span);
@@ -1561,7 +1561,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       BlockingQueue<Tuple<TableResult, Boolean>> rpcResponseQueue,
       BlockingQueue<BigQueryFieldValueListWrapper> bigQueryFieldValueListWrapperBlockingQueue,
       TableResult result) {
-    Tracer tracer = BigQueryJdbcOpenTelemetry.getSafeTracer(this.connection);
+    Tracer tracer = this.connection.getTracer();
     SpanContext parentSpanContext = Span.current().getSpanContext();
     String currentPageToken = firstPageToken;
     TableResult currentResults = result;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -2917,7 +2917,7 @@ public class BigQueryDatabaseMetaDataTest {
   }
 
   @Test
-  public void testGetSchemas_NoArgs_DelegatesCorrectly() {
+  public void testGetSchemas_NoArgs_DelegatesCorrectly() throws Exception {
     BigQueryDatabaseMetaData spiedDbMetadata = spy(dbMetadata);
     ResultSet mockResultSet = mock(ResultSet.class);
     doReturn(mockResultSet).when(spiedDbMetadata).getSchemas(null, null);

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -52,6 +52,7 @@ import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import io.opentelemetry.api.OpenTelemetry;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -127,6 +128,9 @@ public class BigQueryStatementTest {
   @BeforeEach
   public void setUp() throws IOException, SQLException {
     bigQueryConnection = mock(BigQueryConnection.class);
+    doReturn(OpenTelemetry.noop().getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME))
+        .when(bigQueryConnection)
+        .getTracer();
     rpcFactoryMock = mock(BigQueryRpcFactory.class);
     bigquery = mock(BigQuery.class);
     bigQueryConnection.bigQuery = bigquery;


### PR DESCRIPTION
b/491245568

### Key Changes

#### Core Instrumentation Logic
*   **Database Metadata Tracing**: Added OTel spans to key methods in `BigQueryDatabaseMetaData.java` (`getCatalogs`, `getSchemas`, `getTables`, `getColumns`) to capture underlying API calls.
*   **Pagination Span Links**: Captured the parent span context at the start of `fetchNextPages` in `BigQueryStatement.java` and linked background pagination spans back to it, avoiding timeline anomalies.
*   **Cross-Thread Context Propagation**: Stored the `SpanContext` in `BigQueryBaseResultSet.java` at creation time and made it current during `next()` in `BigQueryJsonResultSet.java` and `BigQueryArrowResultSet.java` to survive thread hops.
*   **Tracer Reuse**: Extracted `getSafeTracer` to `BigQueryJdbcOpenTelemetry.java` as a static utility to ensure consistent fallback behavior across the driver.
*   **Lambda Extraction**: Extracted the large lambda function in `populateArrowBufferedQueue` in `BigQueryStatement.java` to its own private method `processArrowStream` to improve readability and maintainability.
