### PR TITLE
build: skip tests in java-showcase when running bulk tests

### DIFF
--- a/java-showcase/pom.xml
+++ b/java-showcase/pom.xml
@@ -256,5 +256,12 @@
         </plugins>
       </build>
     </profile>
+    <!-- skip tests if bulkTests profile is enabled (when testing the rest of the monorepo) -->
+    <profile>
+      <id>bulkTests</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
The showcase integration tests require starting the gapic-showcase server and run as part of the showcase GitHub workflow. When running the "bulk tests" (entire monorepo minus handwritten modules), we should skip the tests.