### PR TITLE
ci: fix unmanaged dependency check

### DIFF
--- a/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
+++ b/.github/workflows/sdk-platform-java-downstream_unmanaged_dependency_check.yaml
@@ -55,18 +55,16 @@ jobs:
           cache: maven
       - name: Install the modules of sdk-platform-java
         shell: bash
-        working-directory: google-cloud-java/sdk-platform-java
-        run: |
-          set -euo pipefail
-          # gapic-generator-java is irrelevant
-          mvn -q -B -ntp install \
-            -Dcheckstyle.skip -Dfmt.skip -DskipTests -T 1C
+        run: .kokoro/build.sh
+        env:
+          BUILD_SUBDIR: sdk-platform-java
+          JOB_TYPE: install
+        working-directory: google-cloud-java
       - name: Build unmanaged dependency check
         shell: bash
         working-directory: google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check
         run: |
           set -euo pipefail
-          pwd
           pwd
           echo "Install Unmanaged Dependency Check in $(pwd)"
           mvn clean install -V --batch-mode --no-transfer-progress -DskipTests

--- a/.github/workflows/unmanaged_dependency_check.yaml
+++ b/.github/workflows/unmanaged_dependency_check.yaml
@@ -14,7 +14,6 @@ jobs:
       shell: bash
       run: .kokoro/build.sh
       env:
-        BUILD_SUBDIR: sdk-platform-java
         JOB_TYPE: install
     - name: Unmanaged dependency check
       uses: ./sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check


### PR DESCRIPTION
Fixes #12704

The current checks are not installing all the required modules from the repository -- this fixes the installation of the scripts especially when the versions referenced are all -SNAPSHOT versions. Tested against the release-please version bumps in https://github.com/googleapis/google-cloud-java/pull/12924