### PR TITLE
build: stop managing java-showcase Version.java

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -991,9 +991,6 @@ proto-google-iam-v2:1.65.0:1.65.0
 grpc-google-iam-v2:1.65.0:1.65.0
 google-cloud-core:2.69.0:2.69.0
 google-cloud-shared-dependencies:3.61.0:3.61.0
-gapic-showcase:0.17.0:0.17.0
-proto-gapic-showcase-v1beta1:0.17.0:0.17.0
-grpc-gapic-showcase-v1beta1:0.17.0:0.17.0
 proto-google-iam-v3:1.65.0:1.65.0
 grpc-google-iam-v3:1.65.0:1.65.0
 proto-google-iam-v3beta:1.65.0:1.65.0


### PR DESCRIPTION
Fixes #12914

This will prevent release-please from bumping the version in Versions.java in java-showcase because it won't have a version to replace with.