### PR TITLE
test: fix testOpenTelemetryTracingDatasets by setting explicit location

### DIFF
--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7819,6 +7819,7 @@ class ITBigQueryTest {
               .setDescription(DESCRIPTION)
               .setMaxTimeTravelHours(72L)
               .setLabels(LABELS)
+              .setLocation("US")
               .build();
 
       Dataset dataset = bigquery.create(info);

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7819,7 +7819,6 @@ class ITBigQueryTest {
               .setDescription(DESCRIPTION)
               .setMaxTimeTravelHours(72L)
               .setLabels(LABELS)
-              .setLocation("US")
               .build();
 
       Dataset dataset = bigquery.create(info);

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7818,6 +7818,7 @@ class ITBigQueryTest {
               .setDescription(DESCRIPTION)
               .setMaxTimeTravelHours(72L)
               .setLabels(LABELS)
+              .setLocation("US")
               .build();
 
       Dataset dataset = bigquery.create(info);
@@ -7839,7 +7840,7 @@ class ITBigQueryTest {
       parentSpan.end();
       Map<AttributeKey<?>, Object> createMap =
           OTEL_ATTRIBUTES.get("com.google.cloud.bigquery.BigQuery.createDataset");
-      assertEquals("null", createMap.get(AttributeKey.stringKey("bq.dataset.location")));
+      assertEquals("US", createMap.get(AttributeKey.stringKey("bq.dataset.location")));
       assertEquals(
           "DatasetService",
           OTEL_ATTRIBUTES

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7801,6 +7801,7 @@ class ITBigQueryTest {
         BigQueryOptions.newBuilder()
             .setEnableOpenTelemetryTracing(true)
             .setOpenTelemetryTracer(tracer)
+            .setLocation("US")
             .build();
     BigQuery bigquery = otelOptions.getService();
 


### PR DESCRIPTION
This PR fixes the testOpenTelemetryTracingDatasets failure by explicitly setting the dataset location to US, making it deterministic across environments.

This test has been flaky because the environment would assign a location if it is not set explicitly. See [test failures log](https://fusion2.corp.google.com/ci/kokoro/prod:cloud-devrel%2Fclient-libraries%2Fjava%2Fgoogle-cloud-java%2Fpresubmit%2Fbigquery-integration/activity/705a7514-338b-4268-8725-9506018ae49c/log) for details.