### PR TITLE
fix(spanner): fix flakiness in testCreateSessionDeadlineExceeded

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MultiplexedSessionDatabaseClientMockServerTest.java
@@ -105,7 +105,7 @@ public class MultiplexedSessionDatabaseClientMockServerTest extends AbstractMock
   public void testCreateSessionDeadlineExceeded() {
     // Simulate a problem with the CreateSession RPC making it slow.
     mockSpanner.setCreateSessionExecutionTime(
-        SimulatedExecutionTime.ofException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
+        SimulatedExecutionTime.ofStickyException(Status.DEADLINE_EXCEEDED.asRuntimeException()));
 
     Spanner testSpanner =
         SpannerOptions.newBuilder()


### PR DESCRIPTION
The test `testCreateSessionDeadlineExceeded` in `MultiplexedSessionDatabaseClientMockServerTest` was flaky because it used a non-sticky exception for simulated `DEADLINE_EXCEEDED` on `CreateSession`. This exception could be consumed by background session creation tasks before the test could verify it.

This change uses `ofStickyException` to ensure the exception persists until explicitly cleared by `mockSpanner.removeAllExecutionTimes()`, making the test robust against concurrent background activity.

Fixes: https://github.com/googleapis/google-cloud-java/issues/12890