### PR TITLE
fix(bqjdbc): metadata methods & getSqlTypeName for struct

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
@@ -42,7 +42,7 @@ abstract class BigQueryBaseStruct implements java.sql.Struct {
 
   @Override
   public final String getSQLTypeName() throws SQLException {
-    throw new BigQueryJdbcSqlFeatureNotSupportedException(CUSTOMER_TYPE_MAPPING_NOT_SUPPORTED);
+    return "STRUCT";
   }
 
   @Override

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
@@ -21,6 +21,7 @@ import static com.google.cloud.bigquery.jdbc.BigQueryErrorMessage.CUSTOMER_TYPE_
 
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.exception.BigQueryJdbcSqlFeatureNotSupportedException;
 import java.sql.Date;
 import java.sql.SQLException;
@@ -42,7 +43,7 @@ abstract class BigQueryBaseStruct implements java.sql.Struct {
 
   @Override
   public final String getSQLTypeName() throws SQLException {
-    return "STRUCT";
+    return StandardSQLTypeName.STRUCT.name();
   }
 
   @Override

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -515,27 +515,27 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public boolean supportsCatalogsInDataManipulation() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsCatalogsInProcedureCalls() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsCatalogsInTableDefinitions() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsCatalogsInIndexDefinitions() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsCatalogsInPrivilegeDefinitions() {
-    return false;
+    return true;
   }
 
   @Override
@@ -3305,7 +3305,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   @Override
   public boolean supportsBatchUpdates() {
-    return false;
+    return true;
   }
 
   @Override

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
@@ -227,11 +227,8 @@ public class BigQueryArrowStructTest {
   }
 
   @Test
-  public void getSQLTypeNameIsNotSupported() {
-    Exception exception =
-        assertThrows(
-            SQLFeatureNotSupportedException.class, structWithPrimitiveValues::getSQLTypeName);
-    assertThat(exception.getMessage()).isEqualTo(CUSTOMER_TYPE_MAPPING_NOT_SUPPORTED);
+  public void getSQLTypeNameReturnsStruct() throws SQLException {
+    assertThat(structWithPrimitiveValues.getSQLTypeName()).isEqualTo("STRUCT");
   }
 
   @Test

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStructTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStructTest.java
@@ -246,11 +246,8 @@ public class BigQueryJsonStructTest {
   }
 
   @Test
-  public void getSQLTypeNameIsNotSupported() {
-    Exception exception =
-        assertThrows(
-            SQLFeatureNotSupportedException.class, structWithPrimitiveValues::getSQLTypeName);
-    assertThat(exception.getMessage()).isEqualTo(CUSTOMER_TYPE_MAPPING_NOT_SUPPORTED);
+  public void getSQLTypeName() throws SQLException{
+    assertThat(structWithPrimitiveValues.getSQLTypeName()).isEqualTo("STRUCT");
   }
 
   @Test

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStructTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStructTest.java
@@ -246,7 +246,7 @@ public class BigQueryJsonStructTest {
   }
 
   @Test
-  public void getSQLTypeName() throws SQLException{
+  public void getSQLTypeName() throws SQLException {
     assertThat(structWithPrimitiveValues.getSQLTypeName()).isEqualTo("STRUCT");
   }
 


### PR DESCRIPTION
b/502644660
b/502643873

- Fix various metadata `bool` methods
- Return 'STRUCT' as SqlType name for Struct methods, name chosen due to
  - Matches the keyword for anonymous structured types in modern BigQuery Standard SQL.
  - Consistent with how the generic structural type is identified in the Google Cloud BigQuery Java SDK   (StandardSQLTypeName.STRUCT).
