### PR TITLE
feat(spanner): add connection properties for min/max RPCs for DCP

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -26,9 +26,12 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.CREDENTIA
 import static com.google.cloud.spanner.connection.ConnectionProperties.CREDENTIALS_URL;
 import static com.google.cloud.spanner.connection.ConnectionProperties.DATABASE_ROLE;
 import static com.google.cloud.spanner.connection.ConnectionProperties.DATA_BOOST_ENABLED;
+import static com.google.cloud.spanner.connection.ConnectionProperties.DCP_CONCURRENT_STREAMS_LOW_WATERMARK;
 import static com.google.cloud.spanner.connection.ConnectionProperties.DCP_INITIAL_CHANNELS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.DCP_MAX_CHANNELS;
+import static com.google.cloud.spanner.connection.ConnectionProperties.DCP_MAX_RPC_PER_CHANNEL;
 import static com.google.cloud.spanner.connection.ConnectionProperties.DCP_MIN_CHANNELS;
+import static com.google.cloud.spanner.connection.ConnectionProperties.DCP_MIN_RPC_PER_CHANNEL;
 import static com.google.cloud.spanner.connection.ConnectionProperties.DIALECT;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_API_TRACING;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_DIRECT_ACCESS;
@@ -165,6 +168,9 @@ public class ConnectionOptions {
   static final Integer DEFAULT_DCP_MIN_CHANNELS = null;
   static final Integer DEFAULT_DCP_MAX_CHANNELS = null;
   static final Integer DEFAULT_DCP_INITIAL_CHANNELS = null;
+  static final Integer DEFAULT_DCP_MIN_RPC_PER_CHANNEL = null;
+  static final Integer DEFAULT_DCP_MAX_RPC_PER_CHANNEL = null;
+  static final Integer DEFAULT_DCP_CONCURRENT_STREAMS_LOW_WATERMARK = null;
   static final String DEFAULT_ENDPOINT = null;
   static final String DEFAULT_CHANNEL_PROVIDER = null;
   static final String DEFAULT_DATABASE_ROLE = null;
@@ -276,6 +282,16 @@ public class ConnectionOptions {
 
   /** Name of the 'dcpInitialChannels' connection property. */
   public static final String DCP_INITIAL_CHANNELS_PROPERTY_NAME = "dcpInitialChannels";
+
+  /** Name of the 'dcpMinRpcPerChannel' connection property. */
+  public static final String DCP_MIN_RPC_PER_CHANNEL_PROPERTY_NAME = "dcpMinRpcPerChannel";
+
+  /** Name of the 'dcpMaxRpcPerChannel' connection property. */
+  public static final String DCP_MAX_RPC_PER_CHANNEL_PROPERTY_NAME = "dcpMaxRpcPerChannel";
+
+  /** Name of the 'dcpConcurrentStreamsLowWatermark' connection property. */
+  public static final String DCP_CONCURRENT_STREAMS_LOW_WATERMARK_PROPERTY_NAME =
+      "dcpConcurrentStreamsLowWatermark";
 
   /** Name of the 'endpoint' connection property. */
   public static final String ENDPOINT_PROPERTY_NAME = "endpoint";
@@ -1039,6 +1055,21 @@ public class ConnectionOptions {
   /** The initial number of channels in the dynamic channel pool. */
   public Integer getDcpInitialChannels() {
     return getInitialConnectionPropertyValue(DCP_INITIAL_CHANNELS);
+  }
+
+  /** The minimum number of RPCs per channel in the dynamic channel pool. */
+  public Integer getDcpMinRpcPerChannel() {
+    return getInitialConnectionPropertyValue(DCP_MIN_RPC_PER_CHANNEL);
+  }
+
+  /** The maximum number of RPCs per channel in the dynamic channel pool. */
+  public Integer getDcpMaxRpcPerChannel() {
+    return getInitialConnectionPropertyValue(DCP_MAX_RPC_PER_CHANNEL);
+  }
+
+  /** The concurrent streams low watermark in the dynamic channel pool. */
+  public Integer getDcpConcurrentStreamsLowWatermark() {
+    return getInitialConnectionPropertyValue(DCP_CONCURRENT_STREAMS_LOW_WATERMARK);
   }
 
   /** Calls the getChannelProvider() method from the supplied class. */

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -515,7 +515,8 @@ public class ConnectionProperties {
           DCP_MIN_RPC_PER_CHANNEL_PROPERTY_NAME,
           "The minimum number of desired RPCs per channel in the dynamic channel pool. Only used when "
               + "enableDynamicChannelPool is true. The default is "
-              + "SpannerOptions.DEFAULT_DYNAMIC_POOL_MIN_RPC (15).",
+              + DEFAULT_DCP_MIN_RPC_PER_CHANNEL
+              + ".",
           DEFAULT_DCP_MIN_RPC_PER_CHANNEL,
           NonNegativeIntegerConverter.INSTANCE,
           Context.STARTUP);
@@ -524,7 +525,8 @@ public class ConnectionProperties {
           DCP_MAX_RPC_PER_CHANNEL_PROPERTY_NAME,
           "The maximum number of desired RPCs per channel in the dynamic channel pool. Only used when "
               + "enableDynamicChannelPool is true. The default is "
-              + "SpannerOptions.DEFAULT_DYNAMIC_POOL_MAX_RPC (90).",
+              + DEFAULT_DCP_MAX_RPC_PER_CHANNEL
+              + ".",
           DEFAULT_DCP_MAX_RPC_PER_CHANNEL,
           NonNegativeIntegerConverter.INSTANCE,
           Context.STARTUP);

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -29,9 +29,12 @@ import static com.google.cloud.spanner.connection.ConnectionOptions.CREDENTIALS_
 import static com.google.cloud.spanner.connection.ConnectionOptions.CREDENTIALS_PROVIDER_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DATABASE_ROLE_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DATA_BOOST_ENABLED_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DCP_CONCURRENT_STREAMS_LOW_WATERMARK_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DCP_INITIAL_CHANNELS_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DCP_MAX_CHANNELS_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DCP_MAX_RPC_PER_CHANNEL_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DCP_MIN_CHANNELS_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DCP_MIN_RPC_PER_CHANNEL_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DDL_IN_TRANSACTION_MODE_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_AUTOCOMMIT;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_AUTO_BATCH_DML;
@@ -45,9 +48,12 @@ import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_CLIE
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_CREDENTIALS;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DATABASE_ROLE;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DATA_BOOST_ENABLED;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DCP_CONCURRENT_STREAMS_LOW_WATERMARK;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DCP_INITIAL_CHANNELS;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DCP_MAX_CHANNELS;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DCP_MAX_RPC_PER_CHANNEL;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DCP_MIN_CHANNELS;
+import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DCP_MIN_RPC_PER_CHANNEL;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DDL_IN_TRANSACTION_MODE;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DEFAULT_SEQUENCE_KIND;
 import static com.google.cloud.spanner.connection.ConnectionOptions.DEFAULT_DELAY_TRANSACTION_START_UNTIL_FIRST_WRITE;
@@ -502,6 +508,32 @@ public class ConnectionProperties {
               + "enableDynamicChannelPool is true. The default is "
               + "SpannerOptions.DEFAULT_DYNAMIC_POOL_INITIAL_SIZE (4).",
           DEFAULT_DCP_INITIAL_CHANNELS,
+          NonNegativeIntegerConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Integer> DCP_MIN_RPC_PER_CHANNEL =
+      create(
+          DCP_MIN_RPC_PER_CHANNEL_PROPERTY_NAME,
+          "The minimum number of desired RPCs per channel in the dynamic channel pool. Only used when "
+              + "enableDynamicChannelPool is true. The default is "
+              + "SpannerOptions.DEFAULT_DYNAMIC_POOL_MIN_RPC (15).",
+          DEFAULT_DCP_MIN_RPC_PER_CHANNEL,
+          NonNegativeIntegerConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Integer> DCP_MAX_RPC_PER_CHANNEL =
+      create(
+          DCP_MAX_RPC_PER_CHANNEL_PROPERTY_NAME,
+          "The maximum number of desired RPCs per channel in the dynamic channel pool. Only used when "
+              + "enableDynamicChannelPool is true. The default is "
+              + "SpannerOptions.DEFAULT_DYNAMIC_POOL_MAX_RPC (90).",
+          DEFAULT_DCP_MAX_RPC_PER_CHANNEL,
+          NonNegativeIntegerConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Integer> DCP_CONCURRENT_STREAMS_LOW_WATERMARK =
+      create(
+          DCP_CONCURRENT_STREAMS_LOW_WATERMARK_PROPERTY_NAME,
+          "The concurrent streams low watermark in the dynamic channel pool. Only used when "
+              + "enableDynamicChannelPool is true.",
+          DEFAULT_DCP_CONCURRENT_STREAMS_LOW_WATERMARK,
           NonNegativeIntegerConverter.INSTANCE,
           Context.STARTUP);
   static final ConnectionProperty<String> CHANNEL_PROVIDER =

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -159,6 +159,9 @@ public class SpannerPool {
     private final Integer dcpMinChannels;
     private final Integer dcpMaxChannels;
     private final Integer dcpInitialChannels;
+    private final Integer dcpMinRpcPerChannel;
+    private final Integer dcpMaxRpcPerChannel;
+    private final Integer dcpConcurrentStreamsLowWatermark;
     private final boolean usePlainText;
     private final String userAgent;
     private final String databaseRole;
@@ -202,6 +205,9 @@ public class SpannerPool {
       this.dcpMinChannels = options.getDcpMinChannels();
       this.dcpMaxChannels = options.getDcpMaxChannels();
       this.dcpInitialChannels = options.getDcpInitialChannels();
+      this.dcpMinRpcPerChannel = options.getDcpMinRpcPerChannel();
+      this.dcpMaxRpcPerChannel = options.getDcpMaxRpcPerChannel();
+      this.dcpConcurrentStreamsLowWatermark = options.getDcpConcurrentStreamsLowWatermark();
       this.usePlainText = options.isUsePlainText();
       this.userAgent = options.getUserAgent();
       this.routeToLeader = options.isRouteToLeader();
@@ -234,6 +240,10 @@ public class SpannerPool {
           && Objects.equals(this.dcpMinChannels, other.dcpMinChannels)
           && Objects.equals(this.dcpMaxChannels, other.dcpMaxChannels)
           && Objects.equals(this.dcpInitialChannels, other.dcpInitialChannels)
+          && Objects.equals(this.dcpMinRpcPerChannel, other.dcpMinRpcPerChannel)
+          && Objects.equals(this.dcpMaxRpcPerChannel, other.dcpMaxRpcPerChannel)
+          && Objects.equals(
+              this.dcpConcurrentStreamsLowWatermark, other.dcpConcurrentStreamsLowWatermark)
           && Objects.equals(this.databaseRole, other.databaseRole)
           && Objects.equals(this.usePlainText, other.usePlainText)
           && Objects.equals(this.userAgent, other.userAgent)
@@ -265,6 +275,9 @@ public class SpannerPool {
           this.dcpMinChannels,
           this.dcpMaxChannels,
           this.dcpInitialChannels,
+          this.dcpMinRpcPerChannel,
+          this.dcpMaxRpcPerChannel,
+          this.dcpConcurrentStreamsLowWatermark,
           this.usePlainText,
           this.databaseRole,
           this.userAgent,
@@ -442,7 +455,10 @@ public class SpannerPool {
         // Build custom GcpChannelPoolOptions if any DCP-specific options are set.
         if (key.dcpMinChannels != null
             || key.dcpMaxChannels != null
-            || key.dcpInitialChannels != null) {
+            || key.dcpInitialChannels != null
+            || key.dcpMinRpcPerChannel != null
+            || key.dcpMaxRpcPerChannel != null
+            || key.dcpConcurrentStreamsLowWatermark != null) {
           // Build GcpChannelPoolOptions from scratch with custom values or Spanner defaults.
           // Note: GcpChannelPoolOptions does not have a toBuilder() method, so we must
           // construct from scratch using SpannerOptions defaults for unspecified values.
@@ -458,19 +474,32 @@ public class SpannerPool {
               key.dcpInitialChannels != null
                   ? key.dcpInitialChannels
                   : SpannerOptions.DEFAULT_DYNAMIC_POOL_INITIAL_SIZE;
-          GcpChannelPoolOptions poolOptions =
+
+          int minRpc =
+              key.dcpMinRpcPerChannel != null
+                  ? key.dcpMinRpcPerChannel
+                  : SpannerOptions.DEFAULT_DYNAMIC_POOL_MIN_RPC;
+          int maxRpc =
+              key.dcpMaxRpcPerChannel != null
+                  ? key.dcpMaxRpcPerChannel
+                  : SpannerOptions.DEFAULT_DYNAMIC_POOL_MAX_RPC;
+
+          GcpChannelPoolOptions.Builder poolOptionsBuilder =
               GcpChannelPoolOptions.newBuilder()
                   .setMinSize(minChannels)
                   .setMaxSize(maxChannels)
                   .setInitSize(initChannels)
                   .setDynamicScaling(
-                      SpannerOptions.DEFAULT_DYNAMIC_POOL_MIN_RPC,
-                      SpannerOptions.DEFAULT_DYNAMIC_POOL_MAX_RPC,
-                      SpannerOptions.DEFAULT_DYNAMIC_POOL_SCALE_DOWN_INTERVAL)
+                      minRpc, maxRpc, SpannerOptions.DEFAULT_DYNAMIC_POOL_SCALE_DOWN_INTERVAL)
                   .setAffinityKeyLifetime(SpannerOptions.DEFAULT_DYNAMIC_POOL_AFFINITY_KEY_LIFETIME)
-                  .setCleanupInterval(SpannerOptions.DEFAULT_DYNAMIC_POOL_CLEANUP_INTERVAL)
-                  .build();
-          builder.setGcpChannelPoolOptions(poolOptions);
+                  .setCleanupInterval(SpannerOptions.DEFAULT_DYNAMIC_POOL_CLEANUP_INTERVAL);
+
+          if (key.dcpConcurrentStreamsLowWatermark != null) {
+            poolOptionsBuilder.setConcurrentStreamsLowWatermark(
+                key.dcpConcurrentStreamsLowWatermark);
+          }
+
+          builder.setGcpChannelPoolOptions(poolOptionsBuilder.build());
         }
       } else {
         // Explicitly disable DCP when enableDynamicChannelPool=false.

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcGcpMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcGcpMockServerTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.connection.StatementResult.ResultType;
+import java.util.Objects;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +57,7 @@ public class GrpcGcpMockServerTest extends AbstractMockServerTest {
   @Test
   public void testDisableGrpcGcp() {
     try (Connection connection = createConnection(";enableGrpcGcp=false")) {
-      Spanner spanner = ((ConnectionImpl) connection).getSpanner();
+      Spanner spanner = connection.getSpanner();
       assertFalse(spanner.getOptions().isGrpcGcpExtensionEnabled());
       verifyConnectionWorks(connection);
     }
@@ -65,7 +66,7 @@ public class GrpcGcpMockServerTest extends AbstractMockServerTest {
   @Test
   public void testEnableGrpcGcp() {
     try (Connection connection = createConnection(";enableGrpcGcp=true")) {
-      Spanner spanner = ((ConnectionImpl) connection).getSpanner();
+      Spanner spanner = connection.getSpanner();
       assertTrue(spanner.getOptions().isGrpcGcpExtensionEnabled());
       verifyConnectionWorks(connection);
     }
@@ -74,9 +75,32 @@ public class GrpcGcpMockServerTest extends AbstractMockServerTest {
   @Test
   public void testDefaultGrpcGcp() {
     try (Connection connection = createConnection()) {
-      Spanner spanner = ((ConnectionImpl) connection).getSpanner();
+      Spanner spanner = connection.getSpanner();
       // Default should be true in SpannerOptions
       assertTrue(spanner.getOptions().isGrpcGcpExtensionEnabled());
+      verifyConnectionWorks(connection);
+    }
+  }
+
+  @Test
+  public void testDcpNewSettings() {
+    try (Connection connection =
+        createConnection(
+            ";enableDynamicChannelPool=true;dcpMinRpcPerChannel=10;dcpMaxRpcPerChannel=100;dcpConcurrentStreamsLowWatermark=5")) {
+      Spanner spanner = connection.getSpanner();
+      assertTrue(spanner.getOptions().isGrpcGcpExtensionEnabled());
+      assertEquals(
+          10,
+          Objects.requireNonNull(spanner.getOptions().getGcpChannelPoolOptions())
+              .getMinRpcPerChannel());
+      assertEquals(
+          100,
+          Objects.requireNonNull(spanner.getOptions().getGcpChannelPoolOptions())
+              .getMaxRpcPerChannel());
+      assertEquals(
+          5,
+          Objects.requireNonNull(spanner.getOptions().getGcpChannelPoolOptions())
+              .getConcurrentStreamsLowWatermark());
       verifyConnectionWorks(connection);
     }
   }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -743,6 +743,39 @@ public class SpannerPoolTest {
   }
 
   @Test
+  public void testDynamicChannelPoolWithNewSettings() {
+    SpannerPoolKey keyWithNewDcpSettings =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri(
+                    "cloudspanner:/projects/p/instances/i/databases/d"
+                        + "?enableDynamicChannelPool=true;dcpMinRpcPerChannel=10;dcpMaxRpcPerChannel=100;dcpConcurrentStreamsLowWatermark=5")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+    SpannerPoolKey keyWithDifferentMinRpc =
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri(
+                    "cloudspanner:/projects/p/instances/i/databases/d"
+                        + "?enableDynamicChannelPool=true;dcpMinRpcPerChannel=20;dcpMaxRpcPerChannel=100;dcpConcurrentStreamsLowWatermark=5")
+                .setCredentials(NoCredentials.getInstance())
+                .build());
+
+    assertNotEquals(keyWithNewDcpSettings, keyWithDifferentMinRpc);
+
+    // Same configuration should be equal
+    assertEquals(
+        keyWithNewDcpSettings,
+        SpannerPoolKey.of(
+            ConnectionOptions.newBuilder()
+                .setUri(
+                    "cloudspanner:/projects/p/instances/i/databases/d"
+                        + "?enableDynamicChannelPool=true;dcpMinRpcPerChannel=10;dcpMaxRpcPerChannel=100;dcpConcurrentStreamsLowWatermark=5")
+                .setCredentials(NoCredentials.getInstance())
+                .build()));
+  }
+
+  @Test
   public void testExplicitlyDisabledDynamicChannelPool() {
     SpannerPoolKey keyWithoutDcpSetting =
         SpannerPoolKey.of(


### PR DESCRIPTION
Adds connection properties for min/max RPCs per channel for the dynamic channel pool. Also adds a connection property for concurrentStreamsLowWaterMark.