### PR TITLE
chore(dataplex): backfill release notes and fix override parser

### DIFF
--- a/.github/release-note-generation/generate_module_notes.py
+++ b/.github/release-note-generation/generate_module_notes.py
@@ -120,7 +120,7 @@ def parse_commit_overrides(commit_data, short_name, prefix_regex, commit_hash, c
 
             should_include = False
             if short_name:
-                if f"[{short_name}]" in line_stripped:
+                if f"[{short_name}]" in line_stripped or f"({short_name})" in line_stripped:
                     should_include = True
             else:
                 should_include = True

--- a/.github/release-note-generation/generate_module_notes.py
+++ b/.github/release-note-generation/generate_module_notes.py
@@ -114,7 +114,7 @@ def parse_commit_overrides(commit_data, short_name, prefix_regex, commit_hash, c
 
         if is_new_item:
             if in_module_item and current_item:
-                categorize_callback(commit_hash, " ".join(current_item))
+                categorize_callback(commit_hash, "\n".join(current_item))
                 current_item = []
                 in_module_item = False
 
@@ -136,7 +136,7 @@ def parse_commit_overrides(commit_data, short_name, prefix_regex, commit_hash, c
             current_item.append(line_stripped)
 
     if in_module_item and current_item:
-        categorize_callback(commit_hash, " ".join(current_item))
+        categorize_callback(commit_hash, "\n".join(current_item))
         
     return True
 

--- a/.github/release-note-generation/generate_module_notes.py
+++ b/.github/release-note-generation/generate_module_notes.py
@@ -114,7 +114,7 @@ def parse_commit_overrides(commit_data, short_name, prefix_regex, commit_hash, c
 
         if is_new_item:
             if in_module_item and current_item:
-                categorize_callback(commit_hash, "\n".join(current_item))
+                categorize_callback(commit_hash, " ".join(current_item))
                 current_item = []
                 in_module_item = False
 
@@ -136,7 +136,7 @@ def parse_commit_overrides(commit_data, short_name, prefix_regex, commit_hash, c
             current_item.append(line_stripped)
 
     if in_module_item and current_item:
-        categorize_callback(commit_hash, "\n".join(current_item))
+        categorize_callback(commit_hash, " ".join(current_item))
         
     return True
 

--- a/.github/release-note-generation/test_generate_module_notes.py
+++ b/.github/release-note-generation/test_generate_module_notes.py
@@ -58,5 +58,27 @@ class TestGenerateModuleNotes(unittest.TestCase):
         self.assertEqual(result.stdout, expected_output)
 
 
+    def test_java_dataplex_generation(self):
+        """Test generating release notes for Dataplex module version 1.86.0."""
+        args = [
+            "--module", "google-cloud-dataplex",
+            "--directory", "java-dataplex",
+            "--version", "1.86.0",
+            "--short-name", "dataplex"
+        ]
+        
+        cmd = ["python3", str(self.script_path)] + args
+        result = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        self.assertEqual(result.returncode, 0)
+        
+        golden_path = self.testdata_dir / "golden_java-dataplex_1.86.0.txt"
+        with open(golden_path, "r") as f:
+            expected_output = f.read()
+            
+        self.assertEqual(result.stdout, expected_output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/release-note-generation/test_generate_module_notes.py
+++ b/.github/release-note-generation/test_generate_module_notes.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 
@@ -17,7 +18,7 @@ class TestGenerateModuleNotes(unittest.TestCase):
             expected_output = f.read()
 
         cmd = [
-            "python3",
+            sys.executable,
             str(self.script_path),
             "--module",
             "google-cloud-run",
@@ -29,10 +30,9 @@ class TestGenerateModuleNotes(unittest.TestCase):
             "run",
         ]
         result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            cmd, capture_output=True, text=True, check=True
         )
 
-        self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout, expected_output)
 
     def test_root_generation(self):
@@ -41,7 +41,7 @@ class TestGenerateModuleNotes(unittest.TestCase):
             expected_output = f.read()
 
         cmd = [
-            "python3",
+            sys.executable,
             str(self.script_path),
             "--module",
             "google-cloud-java",
@@ -51,10 +51,9 @@ class TestGenerateModuleNotes(unittest.TestCase):
             "1.85.0",
         ]
         result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            cmd, capture_output=True, text=True, check=True
         )
 
-        self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout, expected_output)
 
 
@@ -67,11 +66,10 @@ class TestGenerateModuleNotes(unittest.TestCase):
             "--short-name", "dataplex"
         ]
         
-        cmd = ["python3", str(self.script_path)] + args
+        cmd = [sys.executable, str(self.script_path)] + args
         result = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            cmd, capture_output=True, text=True, check=True
         )
-        self.assertEqual(result.returncode, 0)
         
         golden_path = self.testdata_dir / "golden_java-dataplex_1.86.0.txt"
         with open(golden_path, "r") as f:

--- a/.github/release-note-generation/testdata/golden_java-dataplex_1.86.0.txt
+++ b/.github/release-note-generation/testdata/golden_java-dataplex_1.86.0.txt
@@ -1,0 +1,22 @@
+## [1.86.0](https://github.com/googleapis/google-cloud-java/compare/601ea6a901e...v1.82.0) (2026-03-20)
+
+### ⚠ BREAKING CHANGES
+
+* fix(dataplex)!: remove deprecated Explore-related methods and messages from public client libraries Breaking Changes: - Removed ContentService and all associated methods (CreateContent, UpdateContent, DeleteContent, GetContent, ListContent, etc.) and request/response messages. - Removed Environment and Session management methods from DataplexService (CreateEnvironment, UpdateEnvironment, DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and their associated messages. [googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+
+### Features
+
+* feat(dataplex): add DataProductService to manage data products and underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add LookupContext to CatalogService for LLM-generated resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add support for attaching aspects to EntryLinks ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): support OneTime triggers for DataScan operations ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add debug query support to Data Quality rules ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): allow selective generation scope for Data Documentation scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add SKIPPED state to DataScan catalog publishing status ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+
+### Documentation
+
+* docs(dataplex): remove deprecated metadata change warnings in Dataplex Catalog The DataProductService provides APIs to curate and manage collections of data assets as data products, enabling more organized sharing and usage for specific business cases. MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE, DELETE) within a specified scope (organization, project, or entry group) and publish them to Pub/Sub. CatalogService now includes a LookupContext API to provide LLM-generated context for resources, and enhanced EntryLink management, including the ability to attach aspects. DataScan operations now support a OneTime trigger for single-run scans, and Data Quality rules support DebugQueries to help investigate rule failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+

--- a/.github/release-note-generation/testdata/golden_java-dataplex_1.86.0.txt
+++ b/.github/release-note-generation/testdata/golden_java-dataplex_1.86.0.txt
@@ -2,21 +2,49 @@
 
 ### ⚠ BREAKING CHANGES
 
-* fix(dataplex)!: remove deprecated Explore-related methods and messages from public client libraries Breaking Changes: - Removed ContentService and all associated methods (CreateContent, UpdateContent, DeleteContent, GetContent, ListContent, etc.) and request/response messages. - Removed Environment and Session management methods from DataplexService (CreateEnvironment, UpdateEnvironment, DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and their associated messages. [googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* fix(dataplex)!: remove deprecated Explore-related methods and messages
+from public client libraries
+Breaking Changes:
+- Removed ContentService and all associated methods (CreateContent,
+UpdateContent, DeleteContent, GetContent, ListContent, etc.) and
+request/response messages.
+- Removed Environment and Session management methods from
+DataplexService (CreateEnvironment, UpdateEnvironment,
+DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and
+their associated messages.
+[googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Features
 
-* feat(dataplex): add DataProductService to manage data products and underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add LookupContext to CatalogService for LLM-generated resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add DataProductService to manage data products and
+underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata
+changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add LookupContext to CatalogService for LLM-generated
+resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add support for attaching aspects to EntryLinks ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to
+CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): support OneTime triggers for DataScan operations ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add debug query support to Data Quality rules ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): allow selective generation scope for Data Documentation scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): allow selective generation scope for Data Documentation
+scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add SKIPPED state to DataScan catalog publishing status ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Documentation
 
-* docs(dataplex): remove deprecated metadata change warnings in Dataplex Catalog The DataProductService provides APIs to curate and manage collections of data assets as data products, enabling more organized sharing and usage for specific business cases. MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE, DELETE) within a specified scope (organization, project, or entry group) and publish them to Pub/Sub. CatalogService now includes a LookupContext API to provide LLM-generated context for resources, and enhanced EntryLink management, including the ability to attach aspects. DataScan operations now support a OneTime trigger for single-run scans, and Data Quality rules support DebugQueries to help investigate rule failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* docs(dataplex): remove deprecated metadata change warnings in Dataplex
+Catalog
+The DataProductService provides APIs to curate and manage collections of
+data assets as data products, enabling more organized sharing and usage
+for specific business cases.
+MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE,
+DELETE) within a specified scope (organization, project, or entry group)
+and publish them to Pub/Sub.
+CatalogService now includes a LookupContext API to provide LLM-generated
+context for resources, and enhanced EntryLink management, including the
+ability to attach aspects.
+DataScan operations now support a OneTime trigger for single-run scans,
+and Data Quality rules support DebugQueries to help investigate rule
+failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 

--- a/.github/release-note-generation/testdata/golden_java-dataplex_1.86.0.txt
+++ b/.github/release-note-generation/testdata/golden_java-dataplex_1.86.0.txt
@@ -2,49 +2,21 @@
 
 ### ⚠ BREAKING CHANGES
 
-* fix(dataplex)!: remove deprecated Explore-related methods and messages
-from public client libraries
-Breaking Changes:
-- Removed ContentService and all associated methods (CreateContent,
-UpdateContent, DeleteContent, GetContent, ListContent, etc.) and
-request/response messages.
-- Removed Environment and Session management methods from
-DataplexService (CreateEnvironment, UpdateEnvironment,
-DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and
-their associated messages.
-[googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* fix(dataplex)!: remove deprecated Explore-related methods and messages from public client libraries Breaking Changes: - Removed ContentService and all associated methods (CreateContent, UpdateContent, DeleteContent, GetContent, ListContent, etc.) and request/response messages. - Removed Environment and Session management methods from DataplexService (CreateEnvironment, UpdateEnvironment, DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and their associated messages. [googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Features
 
-* feat(dataplex): add DataProductService to manage data products and
-underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata
-changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add LookupContext to CatalogService for LLM-generated
-resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add DataProductService to manage data products and underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add LookupContext to CatalogService for LLM-generated resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add support for attaching aspects to EntryLinks ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to
-CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): support OneTime triggers for DataScan operations ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add debug query support to Data Quality rules ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): allow selective generation scope for Data Documentation
-scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): allow selective generation scope for Data Documentation scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add SKIPPED state to DataScan catalog publishing status ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Documentation
 
-* docs(dataplex): remove deprecated metadata change warnings in Dataplex
-Catalog
-The DataProductService provides APIs to curate and manage collections of
-data assets as data products, enabling more organized sharing and usage
-for specific business cases.
-MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE,
-DELETE) within a specified scope (organization, project, or entry group)
-and publish them to Pub/Sub.
-CatalogService now includes a LookupContext API to provide LLM-generated
-context for resources, and enhanced EntryLink management, including the
-ability to attach aspects.
-DataScan operations now support a OneTime trigger for single-run scans,
-and Data Quality rules support DebugQueries to help investigate rule
-failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* docs(dataplex): remove deprecated metadata change warnings in Dataplex Catalog The DataProductService provides APIs to curate and manage collections of data assets as data products, enabling more organized sharing and usage for specific business cases. MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE, DELETE) within a specified scope (organization, project, or entry group) and publish them to Pub/Sub. CatalogService now includes a LookupContext API to provide LLM-generated context for resources, and enhanced EntryLink management, including the ability to attach aspects. DataScan operations now support a OneTime trigger for single-run scans, and Data Quality rules support DebugQueries to help investigate rule failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 

--- a/.github/release-note-generation/testdata/golden_java-run_0.71.0.txt
+++ b/.github/release-note-generation/testdata/golden_java-run_0.71.0.txt
@@ -2,11 +2,19 @@
 
 ### ⚠ BREAKING CHANGES
 
-* fix!: [run] An existing resource_definition `cloudbuild.googleapis.com/WorkerPool` is removed ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
-* fix!: [run] A type of an existing resource_reference option of the field `worker_pool` in message `.google.cloud.run.v2.SubmitBuildRequest` is changed from `cloudbuild.googleapis.com/WorkerPool` to `cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
-* fix!: [run] A type of an existing resource_reference option of the field `worker_pool` in message `.google.cloud.run.v2.BuildConfig` is changed from `cloudbuild.googleapis.com/WorkerPool` to `cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* fix!: [run] An existing resource_definition
+`cloudbuild.googleapis.com/WorkerPool` is removed ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* fix!: [run] A type of an existing resource_reference option of the field
+`worker_pool` in message `.google.cloud.run.v2.SubmitBuildRequest` is
+changed from `cloudbuild.googleapis.com/WorkerPool` to
+`cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* fix!: [run] A type of an existing resource_reference option of the field
+`worker_pool` in message `.google.cloud.run.v2.BuildConfig` is changed
+from `cloudbuild.googleapis.com/WorkerPool` to
+`cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
 
 ### Features
 
-* feat: [run] Adding new resource tpye run.googleapis.com/WorkerPool. [googleapis/googleapis@0998e04](https://github.com/googleapis/googleapis/commit/0998e045cf83a1307ceb158e3da304bdaff5bb3a) ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* feat: [run] Adding new resource tpye run.googleapis.com/WorkerPool.
+[googleapis/googleapis@0998e04](https://github.com/googleapis/googleapis/commit/0998e045cf83a1307ceb158e3da304bdaff5bb3a) ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
 

--- a/.github/release-note-generation/testdata/golden_java-run_0.71.0.txt
+++ b/.github/release-note-generation/testdata/golden_java-run_0.71.0.txt
@@ -2,19 +2,11 @@
 
 ### ⚠ BREAKING CHANGES
 
-* fix!: [run] An existing resource_definition
-`cloudbuild.googleapis.com/WorkerPool` is removed ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
-* fix!: [run] A type of an existing resource_reference option of the field
-`worker_pool` in message `.google.cloud.run.v2.SubmitBuildRequest` is
-changed from `cloudbuild.googleapis.com/WorkerPool` to
-`cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
-* fix!: [run] A type of an existing resource_reference option of the field
-`worker_pool` in message `.google.cloud.run.v2.BuildConfig` is changed
-from `cloudbuild.googleapis.com/WorkerPool` to
-`cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* fix!: [run] An existing resource_definition `cloudbuild.googleapis.com/WorkerPool` is removed ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* fix!: [run] A type of an existing resource_reference option of the field `worker_pool` in message `.google.cloud.run.v2.SubmitBuildRequest` is changed from `cloudbuild.googleapis.com/WorkerPool` to `cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* fix!: [run] A type of an existing resource_reference option of the field `worker_pool` in message `.google.cloud.run.v2.BuildConfig` is changed from `cloudbuild.googleapis.com/WorkerPool` to `cloudbuild.googleapis.com/BuildWorkerPool` ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
 
 ### Features
 
-* feat: [run] Adding new resource tpye run.googleapis.com/WorkerPool.
-[googleapis/googleapis@0998e04](https://github.com/googleapis/googleapis/commit/0998e045cf83a1307ceb158e3da304bdaff5bb3a) ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
+* feat: [run] Adding new resource tpye run.googleapis.com/WorkerPool. [googleapis/googleapis@0998e04](https://github.com/googleapis/googleapis/commit/0998e045cf83a1307ceb158e3da304bdaff5bb3a) ([9f28cd5](https://github.com/googleapis/google-cloud-java/commit/9f28cd5bcd951333fb2a3847edba015840b5029b))
 

--- a/.github/release-note-generation/testdata/golden_root_1.85.0.txt
+++ b/.github/release-note-generation/testdata/golden_root_1.85.0.txt
@@ -2,49 +2,28 @@
 
 ### Features
 
-* feat: [chronicle] Add DataTableService to Chronicle v1 Client Libraries
-[googleapis/googleapis@e182cf5](https://github.com/googleapis/googleapis/commit/e182cf5152967047b763fd88f03094cfc836d194) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [chronicle] Add DataTableService to Chronicle v1 Client Libraries [googleapis/googleapis@e182cf5](https://github.com/googleapis/googleapis/commit/e182cf5152967047b763fd88f03094cfc836d194) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * feat: [vectorsearch] Added CMEK support ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * feat: [vectorsearch] Added UpdateIndex support ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [discoveryengine] add AUTO condition to SearchAsYouTypeSpec in
-v1alpha and v1beta
-[googleapis/googleapis@f01ba6b](https://github.com/googleapis/googleapis/commit/f01ba6bda9ef3a45069a699767ee7dc46f30028a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [kms] support external-μ in the Digest
-[googleapis/googleapis@7fbf256](https://github.com/googleapis/googleapis/commit/7fbf256c9ee4e580bc2ffa825d8d41263d9462d3) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [kms] add a variable to SingleTenantHsmInstanceCreate to control
-whether future key portability features will be usable on the instance
-[googleapis/googleapis@bc600b8](https://github.com/googleapis/googleapis/commit/bc600b8b72913d10eaf1793a0845643fda94e4eb) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [databasecenter] Add support for BigQuery datasets and
-reservations ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [databasecenter] Introduce resource affiliation and lineage
-tracking ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [databasecenter] Enhance maintenance information with state,
-upcoming maintenance, and failure reasons
-[googleapis/googleapis@7f9e9ff](https://github.com/googleapis/googleapis/commit/7f9e9ff15720fac72c4ba3212343ba6e6102c920) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-inventories] a new field `base64_encoded_name`
-is added to the `LocalInventory` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-inventories] new field `base64_encoded_name` is
-added to the `RegionalInventory` message
-[googleapis/googleapis@6db5d2e](https://github.com/googleapis/googleapis/commit/6db5d2e6bc3a762fccebbcbcfb8681a6ebaf008e) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [dataplex] Allow Data Documentation DataScans to support BigQuery
-Dataset resources in addition to BigQuery table resources ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [dataproc] Add `Engine` field to support LightningEngine in
-clusters and add support for stop ttl
-[googleapis/googleapis@2da8658](https://github.com/googleapis/googleapis/commit/2da86587126416eb48d561cd800bb03afa2f501a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-products] a new field `base64_encoded_name` is
-added to the `Product` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-products] new fields - `base64_encoded_name`
-and `base64_encoded_product` added to the `ProductInput` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [infra-manager] adding DeploymentGroups, you can now manage
-deployment of multiple module root dependencies in a single DAG
-[googleapis/googleapis@f5cb7af](https://github.com/googleapis/googleapis/commit/f5cb7afc40b63d52f43bc306cb9b64a87b681aea) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [discoveryengine] add AUTO condition to SearchAsYouTypeSpec in v1alpha and v1beta [googleapis/googleapis@f01ba6b](https://github.com/googleapis/googleapis/commit/f01ba6bda9ef3a45069a699767ee7dc46f30028a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [kms] support external-μ in the Digest [googleapis/googleapis@7fbf256](https://github.com/googleapis/googleapis/commit/7fbf256c9ee4e580bc2ffa825d8d41263d9462d3) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [kms] add a variable to SingleTenantHsmInstanceCreate to control whether future key portability features will be usable on the instance [googleapis/googleapis@bc600b8](https://github.com/googleapis/googleapis/commit/bc600b8b72913d10eaf1793a0845643fda94e4eb) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [databasecenter] Add support for BigQuery datasets and reservations ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [databasecenter] Introduce resource affiliation and lineage tracking ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [databasecenter] Enhance maintenance information with state, upcoming maintenance, and failure reasons [googleapis/googleapis@7f9e9ff](https://github.com/googleapis/googleapis/commit/7f9e9ff15720fac72c4ba3212343ba6e6102c920) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-inventories] a new field `base64_encoded_name` is added to the `LocalInventory` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-inventories] new field `base64_encoded_name` is added to the `RegionalInventory` message [googleapis/googleapis@6db5d2e](https://github.com/googleapis/googleapis/commit/6db5d2e6bc3a762fccebbcbcfb8681a6ebaf008e) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [dataplex] Allow Data Documentation DataScans to support BigQuery Dataset resources in addition to BigQuery table resources ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [dataproc] Add `Engine` field to support LightningEngine in clusters and add support for stop ttl [googleapis/googleapis@2da8658](https://github.com/googleapis/googleapis/commit/2da86587126416eb48d561cd800bb03afa2f501a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-products] a new field `base64_encoded_name` is added to the `Product` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-products] new fields - `base64_encoded_name` and `base64_encoded_product` added to the `ProductInput` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [infra-manager] adding DeploymentGroups, you can now manage deployment of multiple module root dependencies in a single DAG [googleapis/googleapis@f5cb7af](https://github.com/googleapis/googleapis/commit/f5cb7afc40b63d52f43bc306cb9b64a87b681aea) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * feat: [appoptimize] new module for appoptimize (#12768) ([050187d](https://github.com/googleapis/google-cloud-java/commit/050187d934fc78139ec2790c04dd4c1e256591d4))
 
 ### Bug Fixes
 
 * fix: update appoptimize version to 0.0.1 to match released repo (#12782) ([80dfac6](https://github.com/googleapis/google-cloud-java/commit/80dfac6773bfe7e41e1d3f659fa5c9953a4fd83b))
-* fix(deps): update the Java code generator (gapic-generator-java) to
-2.69.0 ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* fix(deps): update the Java code generator (gapic-generator-java) to 2.69.0 ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * fix(bqjdbc): lazily instantiate Statement in BigQueryDatabaseMetaData (#12752) ([72e5508](https://github.com/googleapis/google-cloud-java/commit/72e5508669ea48cde28f02adfeedfb05cd73fc57))
 * fix(gdch): support EC private keys (#1896) ([bf926fb](https://github.com/googleapis/google-cloud-java/commit/bf926fb23a0ee32b5563af7671af3776ca670126))
 * fix(auth): Address ClientSideCredentialAccessBoundary RefreshTask race condition (#12681) ([30088d2](https://github.com/googleapis/google-cloud-java/commit/30088d2140184b64e841b9864a2b9518f797a686))
@@ -52,30 +31,14 @@ deployment of multiple module root dependencies in a single DAG
 ### Documentation
 
 * docs: [vectorsearch] Updated documentation for listing locations ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [vectorsearch] Updated documentation for Collection.data_schema
-[googleapis/googleapis@8d0f6d8](https://github.com/googleapis/googleapis/commit/8d0f6d8615c72d1907aeec8984d68df50fb6b697) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-inventories] A comment for field `name` in
-message `.google.shopping.merchant.products.v1.LocalInventory` is
-changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-inventories] A comment for field `name` in
-message `.google.shopping.merchant.products.v1.RegionalInventory` is
-changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [dataplex] A comment for message `DataDocumentationResult` is
-changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [dataplex] A comment for field `table_result` in message
-`.google.cloud.dataplex.v1.DataDocumentationResult` is changed
-[googleapis/googleapis@1991351](https://github.com/googleapis/googleapis/commit/19913519dae24b82f58b8f1b43822c2c020a123c) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [network-management] Update comment for the `region` field in
-`RouteInfo`
-[googleapis/googleapis@66fcc02](https://github.com/googleapis/googleapis/commit/66fcc021fec9e5249e69da17068bea999f113622)
-chore: [dialogflow-cx] Add ruby_package to missing proto files in
-google-cloud-dialogflow-cx-v3
-[googleapis/googleapis@b6669d7](https://github.com/googleapis/googleapis/commit/b6669d761c84c04682270ae5610106eb81ce1706) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-products] A comment for field `name` in message
-`.google.shopping.merchant.products.v1.ProductInput` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-products] A comment for field `name` in message
-`.google.shopping.merchant.products.v1.Product` is changed
-[googleapis/googleapis@2aba484](https://github.com/googleapis/googleapis/commit/2aba48492ae471bfb717f5e9c5a190b7cc1c6636) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [vectorsearch] Updated documentation for Collection.data_schema [googleapis/googleapis@8d0f6d8](https://github.com/googleapis/googleapis/commit/8d0f6d8615c72d1907aeec8984d68df50fb6b697) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-inventories] A comment for field `name` in message `.google.shopping.merchant.products.v1.LocalInventory` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-inventories] A comment for field `name` in message `.google.shopping.merchant.products.v1.RegionalInventory` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [dataplex] A comment for message `DataDocumentationResult` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [dataplex] A comment for field `table_result` in message `.google.cloud.dataplex.v1.DataDocumentationResult` is changed [googleapis/googleapis@1991351](https://github.com/googleapis/googleapis/commit/19913519dae24b82f58b8f1b43822c2c020a123c) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [network-management] Update comment for the `region` field in `RouteInfo` [googleapis/googleapis@66fcc02](https://github.com/googleapis/googleapis/commit/66fcc021fec9e5249e69da17068bea999f113622) chore: [dialogflow-cx] Add ruby_package to missing proto files in google-cloud-dialogflow-cx-v3 [googleapis/googleapis@b6669d7](https://github.com/googleapis/googleapis/commit/b6669d761c84c04682270ae5610106eb81ce1706) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-products] A comment for field `name` in message `.google.shopping.merchant.products.v1.ProductInput` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-products] A comment for field `name` in message `.google.shopping.merchant.products.v1.Product` is changed [googleapis/googleapis@2aba484](https://github.com/googleapis/googleapis/commit/2aba48492ae471bfb717f5e9c5a190b7cc1c6636) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 
 ### Dependencies
 

--- a/.github/release-note-generation/testdata/golden_root_1.85.0.txt
+++ b/.github/release-note-generation/testdata/golden_root_1.85.0.txt
@@ -2,28 +2,49 @@
 
 ### Features
 
-* feat: [chronicle] Add DataTableService to Chronicle v1 Client Libraries [googleapis/googleapis@e182cf5](https://github.com/googleapis/googleapis/commit/e182cf5152967047b763fd88f03094cfc836d194) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [chronicle] Add DataTableService to Chronicle v1 Client Libraries
+[googleapis/googleapis@e182cf5](https://github.com/googleapis/googleapis/commit/e182cf5152967047b763fd88f03094cfc836d194) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * feat: [vectorsearch] Added CMEK support ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * feat: [vectorsearch] Added UpdateIndex support ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [discoveryengine] add AUTO condition to SearchAsYouTypeSpec in v1alpha and v1beta [googleapis/googleapis@f01ba6b](https://github.com/googleapis/googleapis/commit/f01ba6bda9ef3a45069a699767ee7dc46f30028a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [kms] support external-μ in the Digest [googleapis/googleapis@7fbf256](https://github.com/googleapis/googleapis/commit/7fbf256c9ee4e580bc2ffa825d8d41263d9462d3) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [kms] add a variable to SingleTenantHsmInstanceCreate to control whether future key portability features will be usable on the instance [googleapis/googleapis@bc600b8](https://github.com/googleapis/googleapis/commit/bc600b8b72913d10eaf1793a0845643fda94e4eb) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [databasecenter] Add support for BigQuery datasets and reservations ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [databasecenter] Introduce resource affiliation and lineage tracking ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [databasecenter] Enhance maintenance information with state, upcoming maintenance, and failure reasons [googleapis/googleapis@7f9e9ff](https://github.com/googleapis/googleapis/commit/7f9e9ff15720fac72c4ba3212343ba6e6102c920) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-inventories] a new field `base64_encoded_name` is added to the `LocalInventory` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-inventories] new field `base64_encoded_name` is added to the `RegionalInventory` message [googleapis/googleapis@6db5d2e](https://github.com/googleapis/googleapis/commit/6db5d2e6bc3a762fccebbcbcfb8681a6ebaf008e) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [dataplex] Allow Data Documentation DataScans to support BigQuery Dataset resources in addition to BigQuery table resources ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [dataproc] Add `Engine` field to support LightningEngine in clusters and add support for stop ttl [googleapis/googleapis@2da8658](https://github.com/googleapis/googleapis/commit/2da86587126416eb48d561cd800bb03afa2f501a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-products] a new field `base64_encoded_name` is added to the `Product` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [shopping-merchant-products] new fields - `base64_encoded_name` and `base64_encoded_product` added to the `ProductInput` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* feat: [infra-manager] adding DeploymentGroups, you can now manage deployment of multiple module root dependencies in a single DAG [googleapis/googleapis@f5cb7af](https://github.com/googleapis/googleapis/commit/f5cb7afc40b63d52f43bc306cb9b64a87b681aea) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [discoveryengine] add AUTO condition to SearchAsYouTypeSpec in
+v1alpha and v1beta
+[googleapis/googleapis@f01ba6b](https://github.com/googleapis/googleapis/commit/f01ba6bda9ef3a45069a699767ee7dc46f30028a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [kms] support external-μ in the Digest
+[googleapis/googleapis@7fbf256](https://github.com/googleapis/googleapis/commit/7fbf256c9ee4e580bc2ffa825d8d41263d9462d3) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [kms] add a variable to SingleTenantHsmInstanceCreate to control
+whether future key portability features will be usable on the instance
+[googleapis/googleapis@bc600b8](https://github.com/googleapis/googleapis/commit/bc600b8b72913d10eaf1793a0845643fda94e4eb) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [databasecenter] Add support for BigQuery datasets and
+reservations ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [databasecenter] Introduce resource affiliation and lineage
+tracking ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [databasecenter] Enhance maintenance information with state,
+upcoming maintenance, and failure reasons
+[googleapis/googleapis@7f9e9ff](https://github.com/googleapis/googleapis/commit/7f9e9ff15720fac72c4ba3212343ba6e6102c920) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-inventories] a new field `base64_encoded_name`
+is added to the `LocalInventory` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-inventories] new field `base64_encoded_name` is
+added to the `RegionalInventory` message
+[googleapis/googleapis@6db5d2e](https://github.com/googleapis/googleapis/commit/6db5d2e6bc3a762fccebbcbcfb8681a6ebaf008e) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [dataplex] Allow Data Documentation DataScans to support BigQuery
+Dataset resources in addition to BigQuery table resources ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [dataproc] Add `Engine` field to support LightningEngine in
+clusters and add support for stop ttl
+[googleapis/googleapis@2da8658](https://github.com/googleapis/googleapis/commit/2da86587126416eb48d561cd800bb03afa2f501a) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-products] a new field `base64_encoded_name` is
+added to the `Product` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [shopping-merchant-products] new fields - `base64_encoded_name`
+and `base64_encoded_product` added to the `ProductInput` message ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* feat: [infra-manager] adding DeploymentGroups, you can now manage
+deployment of multiple module root dependencies in a single DAG
+[googleapis/googleapis@f5cb7af](https://github.com/googleapis/googleapis/commit/f5cb7afc40b63d52f43bc306cb9b64a87b681aea) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * feat: [appoptimize] new module for appoptimize (#12768) ([050187d](https://github.com/googleapis/google-cloud-java/commit/050187d934fc78139ec2790c04dd4c1e256591d4))
 
 ### Bug Fixes
 
 * fix: update appoptimize version to 0.0.1 to match released repo (#12782) ([80dfac6](https://github.com/googleapis/google-cloud-java/commit/80dfac6773bfe7e41e1d3f659fa5c9953a4fd83b))
-* fix(deps): update the Java code generator (gapic-generator-java) to 2.69.0 ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* fix(deps): update the Java code generator (gapic-generator-java) to
+2.69.0 ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 * fix(bqjdbc): lazily instantiate Statement in BigQueryDatabaseMetaData (#12752) ([72e5508](https://github.com/googleapis/google-cloud-java/commit/72e5508669ea48cde28f02adfeedfb05cd73fc57))
 * fix(gdch): support EC private keys (#1896) ([bf926fb](https://github.com/googleapis/google-cloud-java/commit/bf926fb23a0ee32b5563af7671af3776ca670126))
 * fix(auth): Address ClientSideCredentialAccessBoundary RefreshTask race condition (#12681) ([30088d2](https://github.com/googleapis/google-cloud-java/commit/30088d2140184b64e841b9864a2b9518f797a686))
@@ -31,14 +52,30 @@
 ### Documentation
 
 * docs: [vectorsearch] Updated documentation for listing locations ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [vectorsearch] Updated documentation for Collection.data_schema [googleapis/googleapis@8d0f6d8](https://github.com/googleapis/googleapis/commit/8d0f6d8615c72d1907aeec8984d68df50fb6b697) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-inventories] A comment for field `name` in message `.google.shopping.merchant.products.v1.LocalInventory` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-inventories] A comment for field `name` in message `.google.shopping.merchant.products.v1.RegionalInventory` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [dataplex] A comment for message `DataDocumentationResult` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [dataplex] A comment for field `table_result` in message `.google.cloud.dataplex.v1.DataDocumentationResult` is changed [googleapis/googleapis@1991351](https://github.com/googleapis/googleapis/commit/19913519dae24b82f58b8f1b43822c2c020a123c) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [network-management] Update comment for the `region` field in `RouteInfo` [googleapis/googleapis@66fcc02](https://github.com/googleapis/googleapis/commit/66fcc021fec9e5249e69da17068bea999f113622) chore: [dialogflow-cx] Add ruby_package to missing proto files in google-cloud-dialogflow-cx-v3 [googleapis/googleapis@b6669d7](https://github.com/googleapis/googleapis/commit/b6669d761c84c04682270ae5610106eb81ce1706) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-products] A comment for field `name` in message `.google.shopping.merchant.products.v1.ProductInput` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
-* docs: [shopping-merchant-products] A comment for field `name` in message `.google.shopping.merchant.products.v1.Product` is changed [googleapis/googleapis@2aba484](https://github.com/googleapis/googleapis/commit/2aba48492ae471bfb717f5e9c5a190b7cc1c6636) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [vectorsearch] Updated documentation for Collection.data_schema
+[googleapis/googleapis@8d0f6d8](https://github.com/googleapis/googleapis/commit/8d0f6d8615c72d1907aeec8984d68df50fb6b697) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-inventories] A comment for field `name` in
+message `.google.shopping.merchant.products.v1.LocalInventory` is
+changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-inventories] A comment for field `name` in
+message `.google.shopping.merchant.products.v1.RegionalInventory` is
+changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [dataplex] A comment for message `DataDocumentationResult` is
+changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [dataplex] A comment for field `table_result` in message
+`.google.cloud.dataplex.v1.DataDocumentationResult` is changed
+[googleapis/googleapis@1991351](https://github.com/googleapis/googleapis/commit/19913519dae24b82f58b8f1b43822c2c020a123c) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [network-management] Update comment for the `region` field in
+`RouteInfo`
+[googleapis/googleapis@66fcc02](https://github.com/googleapis/googleapis/commit/66fcc021fec9e5249e69da17068bea999f113622)
+chore: [dialogflow-cx] Add ruby_package to missing proto files in
+google-cloud-dialogflow-cx-v3
+[googleapis/googleapis@b6669d7](https://github.com/googleapis/googleapis/commit/b6669d761c84c04682270ae5610106eb81ce1706) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-products] A comment for field `name` in message
+`.google.shopping.merchant.products.v1.ProductInput` is changed ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
+* docs: [shopping-merchant-products] A comment for field `name` in message
+`.google.shopping.merchant.products.v1.Product` is changed
+[googleapis/googleapis@2aba484](https://github.com/googleapis/googleapis/commit/2aba48492ae471bfb717f5e9c5a190b7cc1c6636) ([fc62b1e](https://github.com/googleapis/google-cloud-java/commit/fc62b1e80fa239ba8eec34ce1853e6c32126d9f4))
 
 ### Dependencies
 

--- a/java-dataplex/CHANGELOG.md
+++ b/java-dataplex/CHANGELOG.md
@@ -1,9 +1,26 @@
 # Changelog
 
-## 1.86.0 (None)
+## 1.86.0 (2026-03-20)
 
-* No change
+### ⚠ BREAKING CHANGES
 
+* fix(dataplex)!: remove deprecated Explore-related methods and messages from public client libraries Breaking Changes: - Removed ContentService and all associated methods (CreateContent, UpdateContent, DeleteContent, GetContent, ListContent, etc.) and request/response messages. - Removed Environment and Session management methods from DataplexService (CreateEnvironment, UpdateEnvironment, DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and their associated messages. [googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+
+### Features
+
+* feat(dataplex): add DataProductService to manage data products and underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add LookupContext to CatalogService for LLM-generated resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add support for attaching aspects to EntryLinks ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): support OneTime triggers for DataScan operations ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add debug query support to Data Quality rules ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): allow selective generation scope for Data Documentation scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add SKIPPED state to DataScan catalog publishing status ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+
+### Documentation
+
+* docs(dataplex): remove deprecated metadata change warnings in Dataplex Catalog The DataProductService provides APIs to curate and manage collections of data assets as data products, enabling more organized sharing and usage for specific business cases. MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE, DELETE) within a specified scope (organization, project, or entry group) and publish them to Pub/Sub. CatalogService now includes a LookupContext API to provide LLM-generated context for resources, and enhanced EntryLink management, including the ability to attach aspects. DataScan operations now support a OneTime trigger for single-run scans, and Data Quality rules support DebugQueries to help investigate rule failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ## 1.85.0 (2026-03-11)
 

--- a/java-dataplex/CHANGELOG.md
+++ b/java-dataplex/CHANGELOG.md
@@ -4,23 +4,51 @@
 
 ### ⚠ BREAKING CHANGES
 
-* fix(dataplex)!: remove deprecated Explore-related methods and messages from public client libraries Breaking Changes: - Removed ContentService and all associated methods (CreateContent, UpdateContent, DeleteContent, GetContent, ListContent, etc.) and request/response messages. - Removed Environment and Session management methods from DataplexService (CreateEnvironment, UpdateEnvironment, DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and their associated messages. [googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* fix(dataplex)!: remove deprecated Explore-related methods and messages
+from public client libraries
+Breaking Changes:
+- Removed ContentService and all associated methods (CreateContent,
+UpdateContent, DeleteContent, GetContent, ListContent, etc.) and
+request/response messages.
+- Removed Environment and Session management methods from
+DataplexService (CreateEnvironment, UpdateEnvironment,
+DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and
+their associated messages.
+[googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Features
 
-* feat(dataplex): add DataProductService to manage data products and underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add LookupContext to CatalogService for LLM-generated resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add DataProductService to manage data products and
+underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata
+changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add LookupContext to CatalogService for LLM-generated
+resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add support for attaching aspects to EntryLinks ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to
+CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): support OneTime triggers for DataScan operations ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add debug query support to Data Quality rules ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): allow selective generation scope for Data Documentation scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): allow selective generation scope for Data Documentation
+scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add SKIPPED state to DataScan catalog publishing status ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Documentation
 
-* docs(dataplex): remove deprecated metadata change warnings in Dataplex Catalog The DataProductService provides APIs to curate and manage collections of data assets as data products, enabling more organized sharing and usage for specific business cases. MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE, DELETE) within a specified scope (organization, project, or entry group) and publish them to Pub/Sub. CatalogService now includes a LookupContext API to provide LLM-generated context for resources, and enhanced EntryLink management, including the ability to attach aspects. DataScan operations now support a OneTime trigger for single-run scans, and Data Quality rules support DebugQueries to help investigate rule failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* docs(dataplex): remove deprecated metadata change warnings in Dataplex
+Catalog
+The DataProductService provides APIs to curate and manage collections of
+data assets as data products, enabling more organized sharing and usage
+for specific business cases.
+MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE,
+DELETE) within a specified scope (organization, project, or entry group)
+and publish them to Pub/Sub.
+CatalogService now includes a LookupContext API to provide LLM-generated
+context for resources, and enhanced EntryLink management, including the
+ability to attach aspects.
+DataScan operations now support a OneTime trigger for single-run scans,
+and Data Quality rules support DebugQueries to help investigate rule
+failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ## 1.85.0 (2026-03-11)
 

--- a/java-dataplex/CHANGELOG.md
+++ b/java-dataplex/CHANGELOG.md
@@ -4,51 +4,23 @@
 
 ### ⚠ BREAKING CHANGES
 
-* fix(dataplex)!: remove deprecated Explore-related methods and messages
-from public client libraries
-Breaking Changes:
-- Removed ContentService and all associated methods (CreateContent,
-UpdateContent, DeleteContent, GetContent, ListContent, etc.) and
-request/response messages.
-- Removed Environment and Session management methods from
-DataplexService (CreateEnvironment, UpdateEnvironment,
-DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and
-their associated messages.
-[googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* fix(dataplex)!: remove deprecated Explore-related methods and messages from public client libraries Breaking Changes: - Removed ContentService and all associated methods (CreateContent, UpdateContent, DeleteContent, GetContent, ListContent, etc.) and request/response messages. - Removed Environment and Session management methods from DataplexService (CreateEnvironment, UpdateEnvironment, DeleteEnvironment, ListEnvironments, GetEnvironment, ListSessions) and their associated messages. [googleapis/googleapis@69ca7ae](https://github.com/googleapis/googleapis/commit/69ca7ae2e66cd5623cafecc00971ef5397a4b258) ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Features
 
-* feat(dataplex): add DataProductService to manage data products and
-underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata
-changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add LookupContext to CatalogService for LLM-generated
-resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add DataProductService to manage data products and underlying data assets ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add MetadataFeed to CatalogService for tracking metadata changes ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add LookupContext to CatalogService for LLM-generated resource context ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add support for attaching aspects to EntryLinks ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to
-CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): add UpdateEntryLink and LookupEntryLinks methods to CatalogService ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): support OneTime triggers for DataScan operations ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add debug query support to Data Quality rules ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
-* feat(dataplex): allow selective generation scope for Data Documentation
-scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* feat(dataplex): allow selective generation scope for Data Documentation scans ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 * feat(dataplex): add SKIPPED state to DataScan catalog publishing status ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ### Documentation
 
-* docs(dataplex): remove deprecated metadata change warnings in Dataplex
-Catalog
-The DataProductService provides APIs to curate and manage collections of
-data assets as data products, enabling more organized sharing and usage
-for specific business cases.
-MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE,
-DELETE) within a specified scope (organization, project, or entry group)
-and publish them to Pub/Sub.
-CatalogService now includes a LookupContext API to provide LLM-generated
-context for resources, and enhanced EntryLink management, including the
-ability to attach aspects.
-DataScan operations now support a OneTime trigger for single-run scans,
-and Data Quality rules support DebugQueries to help investigate rule
-failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
+* docs(dataplex): remove deprecated metadata change warnings in Dataplex Catalog The DataProductService provides APIs to curate and manage collections of data assets as data products, enabling more organized sharing and usage for specific business cases. MetadataFeeds allow users to monitor metadata changes (CREATE, UPDATE, DELETE) within a specified scope (organization, project, or entry group) and publish them to Pub/Sub. CatalogService now includes a LookupContext API to provide LLM-generated context for resources, and enhanced EntryLink management, including the ability to attach aspects. DataScan operations now support a OneTime trigger for single-run scans, and Data Quality rules support DebugQueries to help investigate rule failures by returning diagnostic values. ([e29dd99](https://github.com/googleapis/google-cloud-java/commit/e29dd99559b04de62d2f91792a6352b5ce980438))
 
 ## 1.85.0 (2026-03-11)
 


### PR DESCRIPTION
Update BEGIN_COMMIT_OVERRIDE parser to support standard conventional commit syntax (e.g., `feat(module):`) in addition to OwlBot bracket syntax (`feat: [module]`).

Backfill missing Dataplex release notes that were previously excluded due to this parsing limitation.

Includes a new integration test using Dataplex 1.86.0 to verify correct parsing of large squashed commits.