### PR TITLE
docs(logging): improve write log entry sample

### DIFF
--- a/java-logging/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
+++ b/java-logging/samples/snippets/src/main/java/com/example/logging/WriteLogEntry.java
@@ -22,9 +22,12 @@ import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.cloud.logging.Payload.JsonPayload;
+import com.google.cloud.logging.Payload.StringPayload;
 import com.google.cloud.logging.Severity;
 import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class WriteLogEntry {
@@ -35,23 +38,44 @@ public class WriteLogEntry {
 
     // Instantiates a client
     try (Logging logging = LoggingOptions.getDefaultInstance().getService()) {
-      Map<String, String> payload =
-          ImmutableMap.of(
-              "name", "King Arthur", "quest", "Find the Holy Grail", "favorite_color", "Blue");
-      LogEntry entry =
-          LogEntry.newBuilder(JsonPayload.of(payload))
-              .setSeverity(Severity.INFO)
-              .setLogName(logName)
-              .setResource(MonitoredResource.newBuilder("global").build())
-              .build();
+      List<LogEntry> entries = createLogEntries(logName);
 
-      // Writes the log entry asynchronously
-      logging.write(Collections.singleton(entry));
+      // Writes one text log entry.
+      logging.write(Collections.singleton(entries.get(0)));
+
+      // Writes a batch of text and structured log entries.
+      logging.write(entries);
 
       // Optional - flush any pending log entries just before Logging is closed
       logging.flush();
     }
     System.out.printf("Wrote to %s\n", logName);
+  }
+
+  static List<LogEntry> createLogEntries(String logName) {
+    MonitoredResource resource = MonitoredResource.newBuilder("global").build();
+    Map<String, String> labels = ImmutableMap.of("sample", "write-log-entry");
+
+    LogEntry textEntry =
+        LogEntry.newBuilder(StringPayload.of("Text log entry written from Java."))
+            .setSeverity(Severity.INFO)
+            .setLogName(logName)
+            .setResource(resource)
+            .setLabels(labels)
+            .build();
+
+    Map<String, Object> jsonPayload =
+        ImmutableMap.of(
+            "message", "Structured log entry written from Java.", "component", "sample");
+    LogEntry structEntry =
+        LogEntry.newBuilder(JsonPayload.of(jsonPayload))
+            .setSeverity(Severity.WARNING)
+            .setLogName(logName)
+            .setResource(resource)
+            .setLabels(labels)
+            .build();
+
+    return Arrays.asList(textEntry, structEntry);
   }
 }
 // [END logging_write_log_entry]

--- a/java-logging/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
+++ b/java-logging/samples/snippets/src/test/java/com/example/logging/LoggingIT.java
@@ -24,11 +24,14 @@ import com.google.cloud.logging.HttpRequest;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
+import com.google.cloud.logging.Payload.JsonPayload;
 import com.google.cloud.logging.Payload.StringPayload;
+import com.google.cloud.logging.Severity;
 import com.google.cloud.logging.Synchronicity;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Collections;
+import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -152,6 +155,27 @@ public class LoggingIT {
 
   @Test(timeout = 60000)
   public void testWriteLogEntrySample() throws Exception {
+    List<LogEntry> entries = WriteLogEntry.createLogEntries(TEST_LOG);
+    assertThat(entries).hasSize(2);
+
+    LogEntry textEntry = entries.get(0);
+    assertThat(textEntry.getLogName()).isEqualTo(TEST_LOG);
+    assertThat(textEntry.getResource().getType()).isEqualTo("global");
+    assertThat(textEntry.getSeverity()).isEqualTo(Severity.INFO);
+    assertThat(textEntry.getLabels()).containsEntry("sample", "write-log-entry");
+    assertThat(textEntry.getPayload()).isInstanceOf(StringPayload.class);
+    assertThat(((StringPayload) textEntry.getPayload()).getData())
+        .isEqualTo("Text log entry written from Java.");
+
+    LogEntry structEntry = entries.get(1);
+    assertThat(structEntry.getLogName()).isEqualTo(TEST_LOG);
+    assertThat(structEntry.getResource().getType()).isEqualTo("global");
+    assertThat(structEntry.getSeverity()).isEqualTo(Severity.WARNING);
+    assertThat(structEntry.getLabels()).containsEntry("sample", "write-log-entry");
+    assertThat(structEntry.getPayload()).isInstanceOf(JsonPayload.class);
+    assertThat(((JsonPayload) structEntry.getPayload()).getData())
+        .containsEntry("message", "Structured log entry written from Java.");
+
     WriteLogEntry.main(new String[] {TEST_LOG});
     String got = bout.toString();
     assertThat(got).contains(String.format("Wrote to %s", TEST_LOG));


### PR DESCRIPTION
Fixes #11923.

Updates the Java Cloud Logging write log entry sample to demonstrate:
- textPayload and jsonPayload entries
- severity, labels, and the global monitored resource
- writing one log entry and writing a batch of entries

The accompanying sample test now asserts the constructed entry metadata and payload types before exercising the sample.

Verification:
- git diff --check

Not run locally:
- mvn -pl java-logging/samples/snippets -Dtest=LoggingIT#testWriteLogEntrySample test (mvn is not installed in this environment)