### PR TITLE
docs(logging): update quickstart guidance

### DIFF
--- a/java-logging/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
+++ b/java-logging/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
@@ -28,13 +28,15 @@ import java.util.Collections;
 /**
  * This sample demonstrates writing logs directly with the Cloud Logging API.
  *
- * <p>Authenticate by running `gcloud auth application-default login`, by setting the
- * GOOGLE_APPLICATION_CREDENTIALS environment variable to a service account key path, or by running
- * this sample on Google Cloud where Application Default Credentials are available automatically.
+ * <p>Authenticate by running {@code gcloud auth application-default login}, by setting the
+ * {@code GOOGLE_APPLICATION_CREDENTIALS} environment variable to a service account key path, or by
+ * running this sample on Google Cloud where Application Default Credentials are available
+ * automatically.
  *
  * <p>For production applications, prefer using a standard logging framework with Cloud Logging
- * integration, such as Logback with https://github.com/googleapis/java-logging-logback. If you need
- * more customizable LogEntry fields, see the WriteLogEntry sample.
+ * integration, such as Logback with <a
+ * href="https://github.com/googleapis/java-logging-logback">https://github.com/googleapis/java-logging-logback</a>.
+ * If you need more customizable {@code LogEntry} fields, see the {@code WriteLogEntry} sample.
  */
 public class QuickstartSample {
 

--- a/java-logging/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
+++ b/java-logging/samples/snippets/src/main/java/com/example/logging/QuickstartSample.java
@@ -26,19 +26,22 @@ import com.google.cloud.logging.Severity;
 import java.util.Collections;
 
 /**
- * This sample demonstrates writing logs using the Cloud Logging API. The library also offers a
- * java.util.logging Handler `com.google.cloud.logging.LoggingHandler` Logback integration is also
- * available :
- * https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-clients/google-cloud-contrib/google-cloud-logging-logback
- * Using the java.util.logging handler / Logback appender should be preferred to using the API
- * directly.
+ * This sample demonstrates writing logs directly with the Cloud Logging API.
+ *
+ * <p>Authenticate by running `gcloud auth application-default login`, by setting the
+ * GOOGLE_APPLICATION_CREDENTIALS environment variable to a service account key path, or by running
+ * this sample on Google Cloud where Application Default Credentials are available automatically.
+ *
+ * <p>For production applications, prefer using a standard logging framework with Cloud Logging
+ * integration, such as Logback with https://github.com/googleapis/java-logging-logback. If you need
+ * more customizable LogEntry fields, see the WriteLogEntry sample.
  */
 public class QuickstartSample {
 
   /** Expects a new or existing Cloud log name as the first argument. */
   public static void main(String... args) throws Exception {
     // The name of the log to write to
-    String logName = args[0]; // "my-log";
+    String logName = args.length > 0 ? args[0] : "my-log";
     String textPayload = "Hello, world!";
 
     // Instantiates a client


### PR DESCRIPTION
Fixes #11924.

Updates the Java Cloud Logging quickstart to:
- include authentication guidance in the sample comments
- recommend standard logging framework integration, specifically Logback, for production use
- point users who need custom LogEntry fields to the WriteLogEntry sample
- provide a default log name so the sample can run without command-line arguments

Verification:
- git diff --check

Not run locally:
- mvn test (mvn is not installed in this environment)