### PR TITLE
fix(ci): update java-showcase path in excluded_modules

### DIFF
--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -27,7 +27,7 @@ excluded_modules=(
   'sdk-platform-java'
   'sdk-platform-java/java-shared-dependencies/dependency-analyzer'
   'sdk-platform-java/java-shared-dependencies/dependency-convergence-check'
-  'sdk-platform-java/java-showcase'
+  'java-showcase'
   'sdk-platform-java/java-showcase-3.21.0'
   'sdk-platform-java/java-showcase-3.25.8'
   'java-spanner'


### PR DESCRIPTION
Updated the path for java-showcase in the excluded_modules list in .kokoro/common.sh to reflect that it has been moved to the top level of the repository.

This error was observed in the [nightly CI](https://fusion2.corp.google.com/invocations/ece587ad-8a3c-4849-b2c2-5c4c358be12e/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fgoogle-cloud-java%2Fnightly%2Fgraalvm-sub-jobs%2Fnative-a%2Fgraalvm-native-8;config=default/log).