### PR TITLE
chore(datastore): Clean up a few test files with new V3 changes

### DIFF
--- a/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.fail;
 import com.google.api.gax.grpc.ChannelPoolSettings;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.cloud.NoCredentials;
-import com.google.cloud.TransportOptions;
 import com.google.cloud.datastore.spi.DatastoreRpcFactory;
 import com.google.cloud.datastore.spi.v1.DatastoreRpc;
 import com.google.cloud.datastore.v1.DatastoreSettings;
@@ -217,7 +216,6 @@ public class DatastoreOptionsTest {
             .setServiceRpcFactory(datastoreRpcFactory)
             .setProjectId(PROJECT_ID)
             .setDatabaseId(DATABASE_ID)
-            .setTransportOptions((TransportOptions) GrpcTransportOptions.newBuilder().build())
             .setCredentials(NoCredentials.getInstance())
             .setHost("http://localhost:" + PORT)
             .build();
@@ -250,7 +248,6 @@ public class DatastoreOptionsTest {
             .setServiceRpcFactory(datastoreRpcFactory)
             .setProjectId(PROJECT_ID)
             .setDatabaseId(DATABASE_ID)
-            .setTransportOptions((TransportOptions) GrpcTransportOptions.newBuilder().build())
             .setChannelProvider(channelProvider)
             .setCredentials(NoCredentials.getInstance())
             .setHost("http://localhost:" + PORT)
@@ -275,7 +272,6 @@ public class DatastoreOptionsTest {
     // custom grpc transport
     DatastoreOptions grpcTransportOptions =
         DatastoreOptions.newBuilder()
-            .setTransportOptions((TransportOptions) GrpcTransportOptions.newBuilder().build())
             .setProjectId(PROJECT_ID)
             .setCredentials(NoCredentials.getInstance())
             .build();
@@ -288,7 +284,6 @@ public class DatastoreOptionsTest {
   public void testHostWithGrpcAndHttp() {
     DatastoreOptions grpcTransportOptions =
         DatastoreOptions.newBuilder()
-            .setTransportOptions((TransportOptions) GrpcTransportOptions.newBuilder().build())
             .setProjectId(PROJECT_ID)
             .setCredentials(NoCredentials.getInstance())
             .build();
@@ -298,19 +293,19 @@ public class DatastoreOptionsTest {
     String customHost = "http://localhost:" + PORT;
     DatastoreOptions grpcTransportOptionsCustomHost =
         DatastoreOptions.newBuilder()
-            .setTransportOptions((TransportOptions) GrpcTransportOptions.newBuilder().build())
             .setHost(customHost)
             .setProjectId(PROJECT_ID)
             .setCredentials(NoCredentials.getInstance())
             .build();
     assertThat(grpcTransportOptionsCustomHost.getHost()).isEqualTo(customHost);
 
-    DatastoreOptions defaultTransportOptions =
+    DatastoreOptions httpJsonTransportOptions =
         DatastoreOptions.newBuilder()
             .setProjectId(PROJECT_ID)
             .setCredentials(NoCredentials.getInstance())
             .build();
-    assertThat(defaultTransportOptions.getHost()).isEqualTo(DatastoreSettings.getDefaultEndpoint());
+    assertThat(httpJsonTransportOptions.getHost())
+        .isEqualTo(DatastoreSettings.getDefaultEndpoint());
 
     DatastoreOptions httpTransportOptions =
         DatastoreOptions.newBuilder()

--- a/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
+++ b/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/DatastoreOptionsTest.java
@@ -259,6 +259,14 @@ public class DatastoreOptionsTest {
   public void testTransport() {
     // default grpc transport
     assertThat(options.build().getTransportOptions()).isInstanceOf(GrpcTransportOptions.class);
+    DatastoreOptions grpcTransportOptions =
+        DatastoreOptions.newBuilder()
+            .setProjectId(PROJECT_ID)
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    assertThat(grpcTransportOptions.getTransportOptions()).isInstanceOf(GrpcTransportOptions.class);
+    assertThat(grpcTransportOptions.getTransportChannelProvider())
+        .isInstanceOf(InstantiatingGrpcChannelProvider.class);
 
     // custom http transport
     DatastoreOptions httpTransportOptions =
@@ -268,16 +276,6 @@ public class DatastoreOptionsTest {
             .setCredentials(NoCredentials.getInstance())
             .build();
     assertThat(httpTransportOptions.getTransportOptions()).isInstanceOf(HttpTransportOptions.class);
-
-    // custom grpc transport
-    DatastoreOptions grpcTransportOptions =
-        DatastoreOptions.newBuilder()
-            .setProjectId(PROJECT_ID)
-            .setCredentials(NoCredentials.getInstance())
-            .build();
-    assertThat(grpcTransportOptions.getTransportOptions()).isInstanceOf(GrpcTransportOptions.class);
-    assertThat(grpcTransportOptions.getTransportChannelProvider())
-        .isInstanceOf(InstantiatingGrpcChannelProvider.class);
   }
 
   @Test
@@ -288,7 +286,6 @@ public class DatastoreOptionsTest {
             .setCredentials(NoCredentials.getInstance())
             .build();
     assertThat(grpcTransportOptions.getHost()).isEqualTo(DatastoreSettings.getDefaultEndpoint());
-    assertThat(grpcTransportOptions.getHost()).isEqualTo("datastore.googleapis.com:443");
 
     String customHost = "http://localhost:" + PORT;
     DatastoreOptions grpcTransportOptionsCustomHost =
@@ -301,19 +298,11 @@ public class DatastoreOptionsTest {
 
     DatastoreOptions httpJsonTransportOptions =
         DatastoreOptions.newBuilder()
-            .setProjectId(PROJECT_ID)
-            .setCredentials(NoCredentials.getInstance())
-            .build();
-    assertThat(httpJsonTransportOptions.getHost())
-        .isEqualTo(DatastoreSettings.getDefaultEndpoint());
-
-    DatastoreOptions httpTransportOptions =
-        DatastoreOptions.newBuilder()
             .setTransportOptions(HttpTransportOptions.newBuilder().build())
             .setProjectId(PROJECT_ID)
             .setCredentials(NoCredentials.getInstance())
             .build();
-    assertThat(httpTransportOptions.getHost()).isEqualTo(DatastoreFactory.DEFAULT_HOST);
+    assertThat(httpJsonTransportOptions.getHost()).isEqualTo(DatastoreFactory.DEFAULT_HOST);
 
     DatastoreOptions httpTransportOptionsCustomHost =
         DatastoreOptions.newBuilder()

--- a/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITDatastoreClientSideMetrics.java
+++ b/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/it/ITDatastoreClientSideMetrics.java
@@ -27,7 +27,6 @@ import com.google.cloud.datastore.DatastoreOptions;
 import com.google.cloud.datastore.Entity;
 import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.telemetry.TelemetryConstants;
-import com.google.cloud.grpc.GrpcTransportOptions;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -120,13 +119,8 @@ public class ITDatastoreClientSideMetrics {
                     .setMetricsEnabled(true)
                     .setOpenTelemetry(customOtel)
                     .setExportBuiltinMetricsToGoogleCloudMonitoring(false)
-                    .build());
-
-    if (transportOptions instanceof GrpcTransportOptions) {
-      builder.setTransportOptions(transportOptions);
-    } else {
-      builder.setTransportOptions(transportOptions);
-    }
+                    .build())
+            .setTransportOptions(transportOptions);
 
     datastore = builder.build().getService();
 

--- a/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/RemoteDatastoreHelper.java
+++ b/java-datastore/google-cloud-datastore/src/test/java/com/google/cloud/datastore/testing/RemoteDatastoreHelper.java
@@ -26,7 +26,6 @@ import com.google.cloud.datastore.Key;
 import com.google.cloud.datastore.Query;
 import com.google.cloud.datastore.QueryResults;
 import com.google.cloud.datastore.StructuredQuery;
-import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.http.HttpTransportOptions;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.time.Duration;
@@ -113,11 +112,7 @@ public class RemoteDatastoreHelper {
             .setDatabaseId(databaseId)
             .setNamespace(UUID.randomUUID().toString())
             .setRetrySettings(retrySettings());
-    if (transportOptions instanceof GrpcTransportOptions) {
-      datastoreOptionBuilder = datastoreOptionBuilder.setTransportOptions(transportOptions);
-    } else {
-      datastoreOptionBuilder = datastoreOptionBuilder.setTransportOptions(transportOptions);
-    }
+    datastoreOptionBuilder = datastoreOptionBuilder.setTransportOptions(transportOptions);
 
     if (openTelemetrySdk != null) {
       datastoreOptionBuilder.setOpenTelemetryOptions(


### PR DESCRIPTION
gRPC Transport is the new default so there is no need to explicitly set it.