### PR TITLE
fix(bqjdbc): pre-populate Named Job ID to enable robust query cancellation waits

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -482,8 +482,10 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
           } catch (BigQueryException e) {
             if (e.getMessage() != null
                 && (e.getMessage().contains("Job is already in state DONE")
-                    || e.getMessage().contains("Error: 3848323"))) {
-              LOG.warning("Attempted to cancel a job that was already done: " + jobId);
+                    || e.getMessage().contains("Error: 3848323")
+                    || e.getMessage().contains("Not found")
+                    || e.getCode() == 404)) {
+              LOG.warning("Attempted to cancel a job that was not found or already done: " + jobId);
             } else {
               throw new BigQueryJdbcException(e);
             }
@@ -577,41 +579,63 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       throws InterruptedException, BigQueryException, BigQueryJdbcException {
     LOG.finest("++enter++");
     Job job = null;
-    // Location is not properly passed from the connection,
-    // so we need to explicitly set it;
-    // Do not set custom JobId here or it will disable jobless queries.
+    // Location is not properly passed from the connection, so we need to explicitly set it;
     JobId jobId = JobId.newBuilder().setLocation(connection.getLocation()).build();
-    Object result = bigQuery.queryWithTimeout(jobConfiguration, jobId, null);
-    if (result instanceof TableResult) {
-      TableResult tableResult = (TableResult) result;
-      if (tableResult.getJobId() != null) {
-        return new ExecuteResult(tableResult, bigQuery.getJob(tableResult.getJobId()));
-      }
-      return new ExecuteResult((TableResult) result, null);
-    }
+    boolean shouldPrepopulate = !connection.isReadOnlyTokenUsed() && !connection.getUseStatelessQueryMode();
 
-    if (result instanceof Job) {
-      job = (Job) result;
-    } else {
-      throw new BigQueryJdbcException("Unexpected result type from queryWithTimeout");
+    if (shouldPrepopulate) {
+      jobId = jobId.toBuilder().setJob(generateJobId()).build();
     }
 
     synchronized (cancelLock) {
       if (isCanceled) {
-        job.cancel();
         throw new BigQueryJdbcException("Query was cancelled.");
       }
-      jobId = job.getJobId();
-      jobIds.add(jobId);
+      if (shouldPrepopulate) {
+        jobIds.add(jobId);
+      }
     }
-    LOG.info("Query submitted with Job ID: " + job.getJobId().getJob());
-    TableResult tableResult =
-        job.getQueryResults(QueryResultsOption.pageSize(querySettings.getMaxResultPerPage()));
-    synchronized (cancelLock) {
-      jobIds.remove(jobId);
+
+    try {
+      Object result = bigQuery.queryWithTimeout(jobConfiguration, jobId, null);
+      if (result instanceof TableResult) {
+        TableResult tableResult = (TableResult) result;
+        if (tableResult.getJobId() != null) {
+          return new ExecuteResult(tableResult, bigQuery.getJob(tableResult.getJobId()));
+        }
+        return new ExecuteResult((TableResult) result, null);
+      }
+
+      if (result instanceof Job) {
+        job = (Job) result;
+      } else {
+        throw new BigQueryJdbcException("Unexpected result type from queryWithTimeout");
+      }
+
+      synchronized (cancelLock) {
+        if (isCanceled) {
+          job.cancel();
+          throw new BigQueryJdbcException("Query was cancelled.");
+        }
+        JobId returnedId = job.getJobId();
+        if (!jobIds.contains(returnedId)) {
+          jobIds.add(returnedId);
+        }
+      }
+      LOG.info("Query submitted with Job ID: " + job.getJobId().getJob());
+      TableResult tableResult =
+          job.getQueryResults(QueryResultsOption.pageSize(querySettings.getMaxResultPerPage()));
+      return new ExecuteResult(tableResult, job);
+    } finally {
+      synchronized (cancelLock) {
+        jobIds.remove(jobId);
+        if (job != null) {
+          jobIds.remove(job.getJobId());
+        }
+      }
     }
-    return new ExecuteResult(tableResult, job);
   }
+
 
   /**
    * Execute the SQL script and sets the reference of the underlying job, passing null querySettings

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -494,4 +494,82 @@ public class BigQueryStatementTest {
     verify(bigquery, isReadOnlyTokenUsed ? Mockito.never() : Mockito.times(1))
         .create(any(JobInfo.class));
   }
+
+  @Test
+  public void testExecuteJobPrepopulatesJobId() throws SQLException, InterruptedException {
+    doReturn(false).when(bigQueryConnection).isReadOnlyTokenUsed();
+    doReturn(false).when(bigQueryConnection).getUseStatelessQueryMode();
+
+    BigQueryStatement statement = new BigQueryStatement(bigQueryConnection);
+    BigQueryStatement statementSpy = Mockito.spy(statement);
+
+    TableResult tableResultMock = mock(TableResult.class);
+    doReturn(null).when(tableResultMock).getJobId();
+
+    ArgumentCaptor<JobId> jobIdCaptor = ArgumentCaptor.forClass(JobId.class);
+
+    Mockito.when(bigquery.queryWithTimeout(any(QueryJobConfiguration.class), jobIdCaptor.capture(), any()))
+        .thenAnswer(invocation -> {
+            JobId capturedId = jobIdCaptor.getValue();
+            assertThat(capturedId).isNotNull();
+            assertThat(capturedId.getJob()).isNotNull(); // Prepopulated Job name unique UUID
+            assertThat(statementSpy.jobIds).contains(capturedId); // Registered BEFORE wait blocks!
+            return tableResultMock;
+        });
+
+    doReturn(mock(BigQueryJsonResultSet.class))
+        .when(statementSpy)
+        .processJsonResultSet(tableResultMock);
+
+    statementSpy.executeQuery("SELECT 1");
+
+    // Cleaned up safely in the finally block
+    assertThat(statementSpy.jobIds).isEmpty();
+  }
+
+  @Test
+  public void testExecuteJobNoPrepopulateForStateless() throws SQLException, InterruptedException {
+    doReturn(true).when(bigQueryConnection).isReadOnlyTokenUsed();
+
+    BigQueryStatement statement = new BigQueryStatement(bigQueryConnection);
+    BigQueryStatement statementSpy = Mockito.spy(statement);
+
+    TableResult tableResultMock = mock(TableResult.class);
+    doReturn(null).when(tableResultMock).getJobId();
+
+    ArgumentCaptor<JobId> jobIdCaptor = ArgumentCaptor.forClass(JobId.class);
+
+    Mockito.when(bigquery.queryWithTimeout(any(QueryJobConfiguration.class), jobIdCaptor.capture(), any()))
+        .thenAnswer(invocation -> {
+            JobId capturedId = jobIdCaptor.getValue();
+            assertThat(capturedId).isNotNull();
+            assertThat(capturedId.getJob()).isNull(); // Bypassed for stateless/fast-path
+            assertThat(statementSpy.jobIds).isEmpty(); // No Statement hook addition
+            return tableResultMock;
+        });
+
+    doReturn(mock(BigQueryJsonResultSet.class))
+        .when(statementSpy)
+        .processJsonResultSet(tableResultMock);
+
+    statementSpy.executeQuery("SELECT 1");
+    assertThat(statementSpy.jobIds).isEmpty();
+  }
+
+  @Test
+  public void testCancelGracefullyHandles404() throws SQLException {
+    BigQueryStatement statement = new BigQueryStatement(bigQueryConnection);
+    JobId dummyJobId = JobId.of("dummy-project", "dummy-job");
+    statement.jobIds.add(dummyJobId);
+
+    com.google.cloud.bigquery.BigQueryException missingJobException =
+        new com.google.cloud.bigquery.BigQueryException(404, "Not found: Job dummy-project:dummy-job");
+    Mockito.doThrow(missingJobException).when(bigquery).cancel(dummyJobId);
+
+    // Verify that Statement.cancel() ignores HTTP 404 gracefully without throwing SQLException
+    statement.cancel();
+
+    verify(bigquery).cancel(dummyJobId);
+    assertThat(statement.jobIds).isEmpty();
+  }
 }


### PR DESCRIPTION
This PR pre-populates a unique named JobId during statement execution when jobful mode is active, and registers it to the cancellation list before the SDK wait blocks. This prevents thread hangs during manual query cancellation.