### PR TITLE
chore: Create a LTS branch for Datastore 2.x version

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -46,3 +46,8 @@ branches:
       onDemand: true
       local: true
       localCloneDepth: 200
+    - branch: datastore-2.x
+      releaseType: java-backport
+      onDemand: true
+      local: true
+      localCloneDepth: 200

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -139,18 +139,17 @@ branchProtectionRules:
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: false
     requiredStatusCheckContexts:
-      - units (8)
-      - units (11)
-      - units (17)
+      - split-units (java-datastore, 8)
+      - split-units (java-datastore, 11)
+      - split-units (java-datastore, 17)
+      - split-units (java-datastore, 21)
+      - split-units (java-datastore, 25)
+      - split-clirr (java-datastore)
       - cla/google
       - lint
       - 'Kokoro - Test: Integration'
-      - 'Kokoro - Test: GraalVM Native Image A'
-      - 'Kokoro - Test: GraalVM Native Image B'
-      - 'Kokoro - Test: GraalVM Native Image C'
-      - header-check
-      - library_generation
-      - unmanaged_dependency_check
+      - 'Kokoro - Test: Datastore Integration'
+      - 'Kokoro - Test: Datastore GraalVM Native Image'
 permissionRules:
   - team: yoshi-admins
     permission: admin

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -133,6 +133,24 @@ branchProtectionRules:
       - header-check
       - library_generation
       - unmanaged_dependency_check
+  - pattern: datastore-2.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - units (8)
+      - units (11)
+      - units (17)
+      - cla/google
+      - lint
+      - 'Kokoro - Test: Integration'
+      - 'Kokoro - Test: GraalVM Native Image A'
+      - 'Kokoro - Test: GraalVM Native Image B'
+      - 'Kokoro - Test: GraalVM Native Image C'
+      - header-check
+      - library_generation
+      - unmanaged_dependency_check
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
Copied the settings from the existing LTS configs