### PR TITLE
fix(bq): do not call 'getQueryResults' for stateful queries via 'query' api

### DIFF
--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -2104,7 +2104,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
 
         return queryRpc(projectId, content, options);
       }
-      return create(JobInfo.of(jobId, configuration), options).getQueryResults();
+      return create(JobInfo.of(jobId, configuration), options);
     } finally {
       if (querySpan != null) {
         querySpan.end();

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7517,7 +7517,7 @@ class ITBigQueryTest {
             .setJobCreationMode(JobCreationMode.JOB_CREATION_REQUIRED)
             .setUseQueryCache(false)
             .build();
-    long millis = System.currentTimeMillis();
+    millis = System.currentTimeMillis();
     result = bigQuery.queryWithTimeout(config, null, 1000L);
     millis = System.currentTimeMillis() - millis;
     assertTrue(result instanceof Job);

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7501,9 +7501,11 @@ class ITBigQueryTest {
     // Stateful query returns Job
     // Test scenario 3 to ensure job is created if Query is long running.
     // Explicitly disable cache to ensure it is long-running query;
-    config = QueryJobConfiguration.newBuilder(largeQuery)
-        .setJobCreationMode(JobCreationMode.JOB_CREATION_REQUIRED)
-        .setUseQueryCache(false).build();
+    config =
+        QueryJobConfiguration.newBuilder(largeQuery)
+            .setJobCreationMode(JobCreationMode.JOB_CREATION_REQUIRED)
+            .setUseQueryCache(false)
+            .build();
     long millis = System.currentTimeMillis();
     result = bigQuery.queryWithTimeout(config, null, 1000L);
     millis = System.currentTimeMillis() - millis;

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7487,19 +7487,30 @@ class ITBigQueryTest {
     }
 
     // Stateful query returns Job
-    // Test scenario 2 to ensure job is created if JobCreationMode is set, but for a small query
-    // it still returns results.
+    // Test scenario 2 to ensure job is created if Query is long running.
+    // Explicitly disable cache to ensure it is long-running query;
+    config =
+        QueryJobConfiguration.newBuilder(largeQuery).setUseQueryCache(false).build();
+    long millis = System.currentTimeMillis();
+    result = bigQuery.queryWithTimeout(config, null, 1000L);
+    millis = System.currentTimeMillis() - millis;
+    assertTrue(result instanceof Job);
+    // Cancel the job as we don't need results.
+    ((Job) result).cancel();
+    // Allow 2 seconds of timeout value to account for random delays
+    assertTrue(millis < 1_000_000 * 2);
+
+    // Stateful query returns Job
+    // Test scenario 3 to ensure job is created if JobCreationMode is set.
     config =
         QueryJobConfiguration.newBuilder(query)
             .setJobCreationMode(JobCreationMode.JOB_CREATION_REQUIRED)
             .build();
     result = bigQuery.queryWithTimeout(config, null, null);
-    assertTrue(result instanceof TableResult);
-    assertNotNull(((TableResult) result).getJobId());
-    assertNull(((TableResult) result).getQueryId());
+    assertTrue(result instanceof Job);
 
     // Stateful query returns Job
-    // Test scenario 3 to ensure job is created if Query is long running.
+    // Test scenario 4 to ensure job is created if Query is long running.
     // Explicitly disable cache to ensure it is long-running query;
     config =
         QueryJobConfiguration.newBuilder(largeQuery)

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7501,7 +7501,9 @@ class ITBigQueryTest {
     // Stateful query returns Job
     // Test scenario 3 to ensure job is created if Query is long running.
     // Explicitly disable cache to ensure it is long-running query;
-    config = QueryJobConfiguration.newBuilder(largeQuery).setUseQueryCache(false).build();
+    config = QueryJobConfiguration.newBuilder(largeQuery)
+        .setJobCreationMode(JobCreationMode.JOB_CREATION_REQUIRED)
+        .setUseQueryCache(false).build();
     long millis = System.currentTimeMillis();
     result = bigQuery.queryWithTimeout(config, null, 1000L);
     millis = System.currentTimeMillis() - millis;

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/it/ITBigQueryTest.java
@@ -7489,8 +7489,7 @@ class ITBigQueryTest {
     // Stateful query returns Job
     // Test scenario 2 to ensure job is created if Query is long running.
     // Explicitly disable cache to ensure it is long-running query;
-    config =
-        QueryJobConfiguration.newBuilder(largeQuery).setUseQueryCache(false).build();
+    config = QueryJobConfiguration.newBuilder(largeQuery).setUseQueryCache(false).build();
     long millis = System.currentTimeMillis();
     result = bigQuery.queryWithTimeout(config, null, 1000L);
     millis = System.currentTimeMillis() - millis;


### PR DESCRIPTION
`queryWithTimeout` is not supposed to call `getQueryResults` when job is forcefully created. Unit test was meant to cover this scenario, but it didn't set a JOB_CREATION_REQUIRED flag, so it was not using proper API. 

There are multiple issues with calling `getQueryResults` directly:
- timeout is not honored, long-running queries are non-cancellable if JobID is not provided
- `maxResults` per page to read results is not honored