### PR TITLE
chore(gitignore): exclude java code packages from global python env patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,13 +40,11 @@ ENV/
 env.bak/
 venv.bak/
 
-# Protect Java package folders from global Python virtualenv env/ and ENV/ blanket collisions
+# Protect Java package folders from global Python virtualenv env/ blanket collisions
 !**/src/main/java/**/env/
 !**/src/test/java/**/env/
 !**/src/main/proto/**/env/
 !**/src/test/proto/**/env/
-!**/src/main/java/**/ENV/
-!**/src/test/java/**/ENV/
 
 # Unit test / coverage reports
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,13 @@ ENV/
 env.bak/
 venv.bak/
 
+# Protect Java package folders from global Python virtualenv env/ and ENV/ blanket collisions
+!**/src/main/java/**/env/
+!**/src/test/java/**/env/
+!**/src/main/proto/**/env/
+!**/src/test/proto/**/env/
+!**/src/main/java/**/ENV/
+!**/src/test/java/**/ENV/
 
 # Unit test / coverage reports
 .coverage


### PR DESCRIPTION
This will be needed for java-bigtable.
Example: `java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/test_helpers/env/PrefixGenerator.java`