### PR TITLE
deps(common-protos): use JUnit 5 artifact ID as per `${junit.verison}`

### DIFF
--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -90,8 +90,8 @@
       </dependency>
 
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>

--- a/java-common-protos/pom.xml
+++ b/java-common-protos/pom.xml
@@ -93,7 +93,8 @@
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Fixes observed failures in last nightly graalvm runs
 - [GraalVM B](https://fusion2.corp.google.com/invocations/9a9a32f7-0522-4864-989d-337d8c257e51/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fgoogle-cloud-java%2Fnightly%2Fgraalvm-sub-jobs%2Fnative-b%2Fgraalvm-native-16/log)
 - [GraalVM C](https://fusion2.corp.google.com/invocations/804394ff-293b-488a-9dfa-c84d6d02db2b/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fgoogle-cloud-java%2Fnightly%2Fgraalvm-sub-jobs%2Fnative-c%2Fgraalvm-native-16/log)

The failure is as follows:

```
07:21:37:407 [ERROR] Failed to execute goal on project proto-google-common-protos: Could not resolve dependencies for project com.google.api.grpc:proto-google-common-protos:jar:2.71.0-SNAPSHOT: The following artifacts could not be resolved: junit:junit:jar:5.11.4 (absent): Could not find artifact junit:junit:jar:5.11.4 in maven-central (https://repo1.maven.org/maven2) -> [Help 1]
```

Due to `junit:junit` being 4.x api. For 5.x we use the `junit:junit-bom`
