### PR TITLE
chore(iam-policy): remove proto path that is not copied from generation config

### DIFF
--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1335,8 +1335,6 @@ libraries:
   excluded_poms: proto-google-iam-v1-bom,google-iam-policy,proto-google-iam-v1
   excluded_dependencies: google-iam-policy
   GAPICs:
-  - proto_path: google/iam/v1
-  - proto_path: google/iam/v1beta
   - proto_path: google/iam/v2
   - proto_path: google/iam/v2beta
   - proto_path: google/iam/v3

--- a/java-iam-policy/README.md
+++ b/java-iam-policy/README.md
@@ -42,20 +42,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-iam-policy</artifactId>
-  <version>1.88.0</version>
+  <version>1.89.0</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-iam-policy:1.88.0'
+implementation 'com.google.cloud:google-iam-policy:1.89.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-iam-policy" % "1.88.0"
+libraryDependencies += "com.google.cloud" % "google-iam-policy" % "1.89.0"
 ```
 
 ## Authentication
@@ -175,7 +175,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [javadocs]: https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/history
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-iam-policy.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-iam-policy/1.88.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-iam-policy/1.89.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/java-iam-policy/README.md
+++ b/java-iam-policy/README.md
@@ -42,20 +42,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-iam-policy</artifactId>
-  <version>1.89.0</version>
+  <version>1.88.0</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-iam-policy:1.89.0'
+implementation 'com.google.cloud:google-iam-policy:1.88.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-iam-policy" % "1.89.0"
+libraryDependencies += "com.google.cloud" % "google-iam-policy" % "1.88.0"
 ```
 
 ## Authentication
@@ -175,7 +175,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [javadocs]: https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/history
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-iam-policy.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-iam-policy/1.89.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-iam-policy/1.88.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
+++ b/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
@@ -121,6 +121,14 @@ python hermetic_build/common/cli/get_changed_libraries.py create \
   --current-generation-config-path="${generation_config}"\
   --force-regenerate-all="${force_regenerate_all}" | tee "${changed_libraries_file}"
 changed_libraries="$(cat "${changed_libraries_file}")"
+# Force run for iam-policy
+if [[ -z "${changed_libraries}" ]]; then
+  changed_libraries="iam-policy"
+else
+  if [[ ! "${changed_libraries}" =~ "iam-policy" ]]; then
+    changed_libraries="iam-policy,${changed_libraries}"
+  fi
+fi
 echo "Changed libraries are: ${changed_libraries:-"No changed library"}."
 
 # run hermetic code generation docker image.

--- a/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
+++ b/sdk-platform-java/.github/scripts/hermetic_library_generation.sh
@@ -121,14 +121,6 @@ python hermetic_build/common/cli/get_changed_libraries.py create \
   --current-generation-config-path="${generation_config}"\
   --force-regenerate-all="${force_regenerate_all}" | tee "${changed_libraries_file}"
 changed_libraries="$(cat "${changed_libraries_file}")"
-# Force run for iam-policy
-if [[ -z "${changed_libraries}" ]]; then
-  changed_libraries="iam-policy"
-else
-  if [[ ! "${changed_libraries}" =~ "iam-policy" ]]; then
-    changed_libraries="iam-policy,${changed_libraries}"
-  fi
-fi
 echo "Changed libraries are: ${changed_libraries:-"No changed library"}."
 
 # run hermetic code generation docker image.


### PR DESCRIPTION
These proto path are configured in generation_config.yaml, but not copied in [.OwlBot-hermetic.yaml](https://github.com/googleapis/google-cloud-java/blob/main/java-iam-policy/.OwlBot-hermetic.yaml). Expect that this change should not lead to code changes after generate workflow runs.

For #13024
For https://github.com/googleapis/librarian/issues/5730