### PR TITLE
ci(versions): skip existing-versions-check for showcase and non-released modules

### DIFF
--- a/generation/check_existing_release_versions.sh
+++ b/generation/check_existing_release_versions.sh
@@ -44,7 +44,7 @@ function find_existing_version_pom() {
 return_code=0
 
 for pom_file in $(find . -maxdepth 3 -name pom.xml|sort --dictionary-order); do
-  if [[ "${pom_file}" == *java-samples* ]]; then
+  if [[ "${pom_file}" == *java-samples* || "${pom_file}" == *showcase* || "${pom_file}" == *coverage-report* || "${pom_file}" == *gapic-generator-java-root* ]]; then
       continue
   fi
   find_existing_version_pom "${pom_file}"

--- a/java-iam-policy/README.md
+++ b/java-iam-policy/README.md
@@ -42,20 +42,20 @@ If you are using Maven without the BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-iam-policy</artifactId>
-  <version>1.88.0</version>
+  <version>1.89.0</version>
 </dependency>
 ```
 
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-iam-policy:1.88.0'
+implementation 'com.google.cloud:google-iam-policy:1.89.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-iam-policy" % "1.88.0"
+libraryDependencies += "com.google.cloud" % "google-iam-policy" % "1.89.0"
 ```
 
 ## Authentication
@@ -175,7 +175,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [javadocs]: https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/history
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-iam-policy.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-iam-policy/1.88.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-iam-policy/1.89.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles


### PR DESCRIPTION
This PR updates `check_existing_release_versions.sh` to completely skip showcase, coverage-report, and gapic-generator-java-root POM files. These are non-released internal/test modules that contain SNAPSHOT versions, so they should be excluded from the duplicate versions check.