### PR TITLE
fix(generator): align template and post-processor formatting

### DIFF
--- a/java-health/owlbot.py
+++ b/java-health/owlbot.py
@@ -33,6 +33,5 @@ java.common_templates(
         "java.header",
         "license-checks.xml",
         "renovate.json",
-        ".gitignore",
-    ],
-)
+        ".gitignore"
+])

--- a/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.py.j2
+++ b/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.py.j2
@@ -24,7 +24,10 @@ java.common_templates(
     monorepo=True,{% if template_excludes %}
     excludes=[
     {%- for exclude in template_excludes %}
-        "{{ exclude }}",
+        "{{ exclude }}"{% if not loop.last %},{% endif %}
     {%- endfor %}
-    ],{% endif %}
-){% endif %}
+])
+{%- else %}
+)
+{%- endif %}
+{%- endif %}

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/owlbot-golden.py
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/owlbot-golden.py
@@ -33,6 +33,5 @@ java.common_templates(
         "java.header",
         "license-checks.xml",
         "renovate.json",
-        ".gitignore",
-    ],
-)
+        ".gitignore"
+])


### PR DESCRIPTION
This PR aligns the `owlbot.py.j2` template with the formatting expected by `update_owlbot_postprocessor_config.sh` (no trailing comma on the last element and `])` closing tag), and synchronizes the existing `owlbot.py` files.