### PR TITLE
fix(hermetic): exclude showcase modules from versions.txt

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/src/fix_poms.py
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/src/fix_poms.py
@@ -606,10 +606,16 @@ def main(versions_file, monorepo):
                 version=main_module.version,
                 release_version=main_module.release_version,
             )
+
+    modules_to_write = []
+    for m in existing_modules.values():
+        if "showcase" not in m.artifact_id:
+            modules_to_write.append(m)
+
     templates.render(
         template_name="versions.txt.j2",
         output_name=versions_file,
-        modules=existing_modules.values(),
+        modules=modules_to_write,
     )
 
 


### PR DESCRIPTION
This PR updates `fix_poms.py` to completely exclude showcase-related modules (such as `gapic-showcase`, `gapic-showcase-parent`, etc.) from `versions.txt`.

fixes: https://github.com/googleapis/google-cloud-java/issues/12914