### PR TITLE
ci:update token in create_additional_release_tag.yaml

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}
+        token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
     - name: Set up Git
       run: |
         git config --local user.email "action@github.com"


### PR DESCRIPTION
CLOUD_JAVA_BOT_TOKEN has been replaced with CLOUD_JAVA_BOT_GITHUB_TOKEN