### PR TITLE
build: adapt samples build configurations for monorepo

### DIFF
--- a/java-bigquery/.cloudbuild/samples_build.yaml
+++ b/java-bigquery/.cloudbuild/samples_build.yaml
@@ -20,6 +20,7 @@ steps:
   ]
   env:
   - 'JOB_TYPE=samples'
+  - 'BUILD_SUBDIR=java-bigquery'
   - 'BIGQUERY_PROJECT_ID=cloud-java-ci-sample'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'GCS_BUCKET=java-samples-bigquery'

--- a/java-bigquerystorage/.cloudbuild/samples_build.yaml
+++ b/java-bigquerystorage/.cloudbuild/samples_build.yaml
@@ -20,6 +20,7 @@ steps:
   ]
   env:
   - 'JOB_TYPE=samples'
+  - 'BUILD_SUBDIR=java-bigquerystorage'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'BIGTABLE_TESTING_INSTANCE=instance'
 - name: gcr.io/cloud-devrel-public-resources/java8

--- a/java-datastore/.cloudbuild/samples_build.yaml
+++ b/java-datastore/.cloudbuild/samples_build.yaml
@@ -20,6 +20,7 @@ steps:
   ]
   env:
   - 'JOB_TYPE=samples'
+  - 'BUILD_SUBDIR=java-datastore'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'KOKORO_GITHUB_PULL_REQUEST_NUMBER=$_PR_NUMBER'
 - name: gcr.io/cloud-devrel-public-resources/java11

--- a/java-logging/.cloudbuild/samples_build.yaml
+++ b/java-logging/.cloudbuild/samples_build.yaml
@@ -19,6 +19,7 @@ steps:
     '.kokoro/build.sh'
   ]
   env:
+  - 'BUILD_SUBDIR=java-logging'
   - 'JOB_TYPE=samples'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
 - name: gcr.io/cloud-devrel-public-resources/java8

--- a/java-storage/.cloudbuild/samples_build.yaml
+++ b/java-storage/.cloudbuild/samples_build.yaml
@@ -20,6 +20,7 @@ steps:
   ]
   env:
   - 'JOB_TYPE=samples'
+  - 'BUILD_SUBDIR=java-storage'
   - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
   - 'GOOGLE_CLOUD_PROJECT_NUMBER=615621127317'
   - 'IT_SERVICE_ACCOUNT_EMAIL=samples@cloud-java-ci-sample.iam.gserviceaccount.com'


### PR DESCRIPTION
Adapts samples build configurations for already-migrated libraries in the monorepo by injecting the mandatory `BUILD_SUBDIR` environment variable.

- Fixes `samples_build.yaml` files in already-migrated directories: `java-bigquery`, `java-bigquerystorage`, `java-datastore`, `java-logging`, and `java-storage`.

This ensures that samples build runs execute within their correct subdirectories in the monorepo environment. Note that the automation helper script and migration integration have been moved to the central tooling branch.

Towards #12983