### PR TITLE
feat(bqjdbc): Add custom logger to handle ResultSet logs

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
+++ b/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
@@ -2,6 +2,7 @@ drivers/**
 target-it/**
 **/*logs*/**
 **/ITBigQueryJDBCLocalTest.java
+**/BigQueryStatementE2EBenchmark.java
 
 tools/**/*.class
 tools/**/*.jfr

--- a/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
+++ b/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
@@ -1,6 +1,6 @@
 drivers/**
 target-it/**
-*logs*/**
+**/*logs*/**
 **/ITBigQueryJDBCLocalTest.java
 
 tools/**/*.class

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
@@ -41,7 +41,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public Object getArray() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getArray", () -> "++enter++");
     ensureValid();
     if (values == null) {
       return null;
@@ -51,7 +51,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public Object getArray(long index, int count) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getArray", () -> "++enter++");
     ensureValid();
     if (values == null) {
       return null;
@@ -62,7 +62,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public ResultSet getResultSet() throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getResultSet", () -> "++enter++");
     ensureValid();
     if (values == null) {
       return new BigQueryArrowResultSet();
@@ -75,7 +75,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public ResultSet getResultSet(long index, int count) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getResultSet", () -> "++enter++");
     ensureValid();
     if (values == null) {
       return new BigQueryArrowResultSet();
@@ -89,14 +89,14 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public void free() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("free", () -> "++enter++");
     this.values = null;
     markInvalid();
   }
 
   @Override
   Object getCoercedValue(int index) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getCoercedValue", () -> "++enter++");
     Object value = this.values.get(index);
     return this.arrayOfStruct
         ? new BigQueryArrowStruct(schema.getSubFields(), (JsonStringHashMap<?, ?>) value)

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
@@ -28,8 +28,8 @@ import org.apache.arrow.vector.util.JsonStringHashMap;
  * An implementation of {@link BigQueryBaseArray} used to represent Array values from Arrow data.
  */
 class BigQueryArrowArray extends BigQueryBaseArray {
-  private static final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(BigQueryArrowArray.class.getName());
+  private static final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class);
   private static final BigQueryTypeCoercer BIGQUERY_TYPE_COERCER =
       BigQueryTypeCoercionUtility.INSTANCE;
   private JsonStringArrayList<?> values;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
@@ -41,7 +41,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public Object getArray() {
-    LOG.finestTrace("getArray", () -> "++enter++");
+    LOG.finestTrace("getArray", "++enter++");
     ensureValid();
     if (values == null) {
       return null;
@@ -51,7 +51,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public Object getArray(long index, int count) {
-    LOG.finestTrace("getArray", () -> "++enter++");
+    LOG.finestTrace("getArray", "++enter++");
     ensureValid();
     if (values == null) {
       return null;
@@ -62,7 +62,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public ResultSet getResultSet() throws SQLException {
-    LOG.finestTrace("getResultSet", () -> "++enter++");
+    LOG.finestTrace("getResultSet", "++enter++");
     ensureValid();
     if (values == null) {
       return new BigQueryArrowResultSet();
@@ -75,7 +75,7 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public ResultSet getResultSet(long index, int count) throws SQLException {
-    LOG.finestTrace("getResultSet", () -> "++enter++");
+    LOG.finestTrace("getResultSet", "++enter++");
     ensureValid();
     if (values == null) {
       return new BigQueryArrowResultSet();
@@ -89,14 +89,14 @@ class BigQueryArrowArray extends BigQueryBaseArray {
 
   @Override
   public void free() {
-    LOG.finestTrace("free", () -> "++enter++");
+    LOG.finestTrace("free", "++enter++");
     this.values = null;
     markInvalid();
   }
 
   @Override
   Object getCoercedValue(int index) {
-    LOG.finestTrace("getCoercedValue", () -> "++enter++");
+    LOG.finestTrace("getCoercedValue", "++enter++");
     Object value = this.values.get(index);
     return this.arrayOfStruct
         ? new BigQueryArrowStruct(schema.getSubFields(), (JsonStringHashMap<?, ?>) value)

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -96,7 +96,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
       BigQuery bigQuery)
       throws SQLException {
     super(bigQuery, statement, schema, isNested);
-    LOG.finestTrace("<init>", () -> "++enter++");
+    LOG.finestTrace("<init>", "++enter++");
     this.totalRows = totalRows;
     this.buffer = buffer;
     this.currentNestedBatch = currentNestedBatch;
@@ -181,7 +181,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     }
 
     private void deserializeArrowBatch(ArrowRecordBatch batch) throws SQLException {
-      LOG.finestTrace("deserializeArrowBatch", () -> "++enter++");
+      LOG.finestTrace("deserializeArrowBatch", "++enter++");
       try {
         if (vectorSchemaRoot != null) {
           // Clear vectorSchemaRoot before populating a new batch
@@ -204,7 +204,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
     @Override
     public void close() {
-      LOG.finestTrace("close", () -> "++enter++");
+      LOG.fineTrace("close", () -> String.format("Closing BigQueryArrowResultSet %s.", this));
       vectorSchemaRoot.close();
       allocator.close();
     }
@@ -276,7 +276,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   }
 
   private Object getObjectInternal(int columnIndex) throws SQLException {
-    LOG.finestTrace("getObjectInternal", () -> "++enter++");
+    LOG.finestTrace("getObjectInternal", "++enter++");
     checkClosed();
     Object value;
     if (this.isNested) {
@@ -318,7 +318,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   public Object getObject(int columnIndex) throws SQLException {
 
     // columnIndex is SQL index starting at 1
-    LOG.finestTrace("getObject", () -> "++enter++");
+    LOG.finestTrace("getObject", "++enter++");
     checkClosed();
     Object value = getObjectInternal(columnIndex);
     if (value == null) {
@@ -449,7 +449,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public void close() {
-    LOG.finestTrace("close", () -> String.format("Closing BigqueryArrowResultSet %s.", this));
+    LOG.fineTrace("close", () -> String.format("Closing BigqueryArrowResultSet %s.", this));
     this.isClosed = true;
     if (ownedThread != null && !ownedThread.isInterrupted()) {
       // interrupt the producer thread when result set is closed
@@ -460,7 +460,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public boolean isBeforeFirst() throws SQLException {
-    LOG.finestTrace("isBeforeFirst", () -> "++enter++");
+    LOG.finestTrace("isBeforeFirst", "++enter++");
     checkClosed();
     if (this.isNested) {
       return this.nestedRowIndex < this.fromIndex;
@@ -471,14 +471,14 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public boolean isAfterLast() throws SQLException {
-    LOG.finestTrace("isAfterLast", () -> "++enter++");
+    LOG.finestTrace("isAfterLast", "++enter++");
     checkClosed();
     return this.afterLast;
   }
 
   @Override
   public boolean isFirst() throws SQLException {
-    LOG.finestTrace("isFirst", () -> "++enter++");
+    LOG.finestTrace("isFirst", "++enter++");
     checkClosed();
     if (this.isNested) {
       return this.nestedRowIndex == this.fromIndex;
@@ -489,7 +489,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public boolean isLast() throws SQLException {
-    LOG.finestTrace("isLast", () -> "++enter++");
+    LOG.finestTrace("isLast", "++enter++");
     checkClosed();
     if (this.isNested) {
       return this.nestedRowIndex == this.toIndexExclusive - 1;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -96,7 +96,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
       BigQuery bigQuery)
       throws SQLException {
     super(bigQuery, statement, schema, isNested);
-    LOG.finest("++enter++");
+    LOG.finestTrace("<init>", () -> "++enter++");
     this.totalRows = totalRows;
     this.buffer = buffer;
     this.currentNestedBatch = currentNestedBatch;
@@ -181,7 +181,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     }
 
     private void deserializeArrowBatch(ArrowRecordBatch batch) throws SQLException {
-      LOG.finest("++enter++");
+      LOG.finestTrace("deserializeArrowBatch", () -> "++enter++");
       try {
         if (vectorSchemaRoot != null) {
           // Clear vectorSchemaRoot before populating a new batch
@@ -204,7 +204,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
     @Override
     public void close() {
-      LOG.finest("++enter++");
+      LOG.finestTrace("close", () -> "++enter++");
       vectorSchemaRoot.close();
       allocator.close();
     }
@@ -276,7 +276,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   }
 
   private Object getObjectInternal(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getObjectInternal", () -> "++enter++");
     checkClosed();
     Object value;
     if (this.isNested) {
@@ -318,7 +318,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   public Object getObject(int columnIndex) throws SQLException {
 
     // columnIndex is SQL index starting at 1
-    LOG.finest("++enter++");
+    LOG.finestTrace("getObject", () -> "++enter++");
     checkClosed();
     Object value = getObjectInternal(columnIndex);
     if (value == null) {
@@ -449,7 +449,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public void close() {
-    LOG.finestTrace("close", "Closing BigqueryArrowResultSet %s.", this);
+    LOG.finestTrace("close", () -> String.format("Closing BigqueryArrowResultSet %s.", this));
     this.isClosed = true;
     if (ownedThread != null && !ownedThread.isInterrupted()) {
       // interrupt the producer thread when result set is closed
@@ -460,7 +460,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public boolean isBeforeFirst() throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("isBeforeFirst", () -> "++enter++");
     checkClosed();
     if (this.isNested) {
       return this.nestedRowIndex < this.fromIndex;
@@ -471,14 +471,14 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public boolean isAfterLast() throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("isAfterLast", () -> "++enter++");
     checkClosed();
     return this.afterLast;
   }
 
   @Override
   public boolean isFirst() throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("isFirst", () -> "++enter++");
     checkClosed();
     if (this.isNested) {
       return this.nestedRowIndex == this.fromIndex;
@@ -489,7 +489,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public boolean isLast() throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("isLast", () -> "++enter++");
     checkClosed();
     if (this.isNested) {
       return this.nestedRowIndex == this.toIndexExclusive - 1;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -449,7 +449,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
 
   @Override
   public void close() {
-    LOG.fine("Closing BigqueryArrowResultSet %s.", this);
+    LOG.finestTrace("close", "Closing BigqueryArrowResultSet %s.", this);
     this.isClosed = true;
     if (ownedThread != null && !ownedThread.isInterrupted()) {
       // interrupt the producer thread when result set is closed

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
@@ -52,7 +52,7 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
 
   @Override
   public Object[] getAttributes() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getAttributes", () -> "++enter++");
     int size = this.schema.size();
     Object[] attributes = (Object[]) Array.newInstance(Object.class, size);
 
@@ -71,7 +71,7 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
   }
 
   private Object getValue(Field currentSchema, Object currentValue) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getValue", () -> "++enter++");
     if (isArray(currentSchema)) {
       return new BigQueryArrowArray(currentSchema, (JsonStringArrayList<?>) currentValue);
     } else if (isStruct(currentSchema)) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
@@ -30,8 +30,8 @@ import org.apache.arrow.vector.util.JsonStringHashMap;
  * An implementation of {@link BigQueryBaseStruct} used to represent Struct values from Arrow data.
  */
 class BigQueryArrowStruct extends BigQueryBaseStruct {
-  private static final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(BigQueryArrowStruct.class.getName());
+  private static final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class);
 
   private static final BigQueryTypeCoercer BIGQUERY_TYPE_COERCER =
       BigQueryTypeCoercionUtility.INSTANCE;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
@@ -52,7 +52,7 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
 
   @Override
   public Object[] getAttributes() {
-    LOG.finestTrace("getAttributes", () -> "++enter++");
+    LOG.finestTrace("getAttributes", "++enter++");
     int size = this.schema.size();
     Object[] attributes = (Object[]) Array.newInstance(Object.class, size);
 
@@ -71,7 +71,7 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
   }
 
   private Object getValue(Field currentSchema, Object currentValue) {
-    LOG.finestTrace("getValue", () -> "++enter++");
+    LOG.finestTrace("getValue", "++enter++");
     if (isArray(currentSchema)) {
       return new BigQueryArrowArray(currentSchema, (JsonStringArrayList<?>) currentValue);
     } else if (isStruct(currentSchema)) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
@@ -56,14 +56,14 @@ abstract class BigQueryBaseArray implements java.sql.Array {
 
   @Override
   public final String getBaseTypeName() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBaseTypeName", () -> "++enter++");
     ensureValid();
     return this.schema.getType().getStandardType().name();
   }
 
   @Override
   public final int getBaseType() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBaseType", () -> "++enter++");
     ensureValid();
     return BigQueryJdbcTypeMappings.standardSQLToJavaSqlTypesMapping.get(
         schema.getType().getStandardType());
@@ -92,7 +92,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected Object getArrayInternal(int fromIndex, int toIndexExclusive) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getArrayInternal", () -> "++enter++");
     Class<?> targetClass = getTargetClass();
     int size = toIndexExclusive - fromIndex;
     Object javaArray = Array.newInstance(targetClass, size);
@@ -104,7 +104,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected void ensureValid() throws IllegalStateException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("ensureValid", () -> "++enter++");
     if (!this.valid) {
       IllegalStateException ex = new IllegalStateException(INVALID_ARRAY);
       LOG.severe(INVALID_ARRAY, ex);
@@ -113,19 +113,19 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected void markInvalid() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("markInvalid", () -> "++enter++");
     this.schema = null;
     this.valid = false;
   }
 
   protected Field singleElementSchema() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("singleElementSchema", () -> "++enter++");
     return this.schema.toBuilder().setMode(Mode.REQUIRED).build();
   }
 
   protected Tuple<Integer, Integer> createRange(long index, int count, int size)
       throws IllegalStateException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("createRange", () -> "++enter++");
     // jdbc array follows 1 based array indexing
     long normalisedFromIndex = index - 1;
     if (normalisedFromIndex + count > size) {
@@ -142,7 +142,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected Class<?> getTargetClass() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getTargetClass", () -> "++enter++");
     return this.arrayOfStruct
         ? Struct.class
         : BigQueryJdbcTypeMappings.standardSQLToJavaTypeMapping.get(
@@ -152,7 +152,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   abstract Object getCoercedValue(int index);
 
   static boolean isArray(Field currentSchema) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("isArray", () -> "++enter++");
     return currentSchema.getMode() == REPEATED;
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
@@ -56,14 +56,14 @@ abstract class BigQueryBaseArray implements java.sql.Array {
 
   @Override
   public final String getBaseTypeName() {
-    LOG.finestTrace("getBaseTypeName", () -> "++enter++");
+    LOG.finestTrace("getBaseTypeName", "++enter++");
     ensureValid();
     return this.schema.getType().getStandardType().name();
   }
 
   @Override
   public final int getBaseType() {
-    LOG.finestTrace("getBaseType", () -> "++enter++");
+    LOG.finestTrace("getBaseType", "++enter++");
     ensureValid();
     return BigQueryJdbcTypeMappings.standardSQLToJavaSqlTypesMapping.get(
         schema.getType().getStandardType());
@@ -92,7 +92,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected Object getArrayInternal(int fromIndex, int toIndexExclusive) {
-    LOG.finestTrace("getArrayInternal", () -> "++enter++");
+    LOG.finestTrace("getArrayInternal", "++enter++");
     Class<?> targetClass = getTargetClass();
     int size = toIndexExclusive - fromIndex;
     Object javaArray = Array.newInstance(targetClass, size);
@@ -104,7 +104,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected void ensureValid() throws IllegalStateException {
-    LOG.finestTrace("ensureValid", () -> "++enter++");
+    LOG.finestTrace("ensureValid", "++enter++");
     if (!this.valid) {
       IllegalStateException ex = new IllegalStateException(INVALID_ARRAY);
       LOG.severe(INVALID_ARRAY, ex);
@@ -113,19 +113,19 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected void markInvalid() {
-    LOG.finestTrace("markInvalid", () -> "++enter++");
+    LOG.finestTrace("markInvalid", "++enter++");
     this.schema = null;
     this.valid = false;
   }
 
   protected Field singleElementSchema() {
-    LOG.finestTrace("singleElementSchema", () -> "++enter++");
+    LOG.finestTrace("singleElementSchema", "++enter++");
     return this.schema.toBuilder().setMode(Mode.REQUIRED).build();
   }
 
   protected Tuple<Integer, Integer> createRange(long index, int count, int size)
       throws IllegalStateException {
-    LOG.finestTrace("createRange", () -> "++enter++");
+    LOG.finestTrace("createRange", "++enter++");
     // jdbc array follows 1 based array indexing
     long normalisedFromIndex = index - 1;
     if (normalisedFromIndex + count > size) {
@@ -142,7 +142,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   }
 
   protected Class<?> getTargetClass() {
-    LOG.finestTrace("getTargetClass", () -> "++enter++");
+    LOG.finestTrace("getTargetClass", "++enter++");
     return this.arrayOfStruct
         ? Struct.class
         : BigQueryJdbcTypeMappings.standardSQLToJavaTypeMapping.get(
@@ -152,7 +152,7 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   abstract Object getCoercedValue(int index);
 
   static boolean isArray(Field currentSchema) {
-    LOG.finestTrace("isArray", () -> "++enter++");
+    LOG.finestTrace("isArray", "++enter++");
     return currentSchema.getMode() == REPEATED;
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
@@ -41,8 +41,8 @@ import java.util.stream.Collectors;
  * reference to an SQL ARRAY value.
  */
 abstract class BigQueryBaseArray implements java.sql.Array {
-  private static final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(BigQueryBaseArray.class.getName());
+  private static final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(BigQueryBaseArray.class);
 
   protected final boolean arrayOfStruct;
   private boolean valid;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -247,7 +247,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   public abstract Object getObject(int columnIndex) throws SQLException;
 
   protected int getColumnIndex(String columnLabel) throws SQLException {
-    LOG.finestTrace("getColumnIndex", () -> "++enter++");
+    LOG.finestTrace("getColumnIndex", "++enter++");
     checkClosed();
     if (columnLabel == null) {
       throw logAndCreateException("Column label cannot be null");
@@ -258,7 +258,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public String getString(int columnIndex) throws SQLException {
-    LOG.finestTrace("getString", () -> "++enter++");
+    LOG.finestTrace("getString", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(String.class, value);
@@ -269,7 +269,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public boolean getBoolean(int columnIndex) throws SQLException {
-    LOG.finestTrace("getBoolean", () -> "++enter++");
+    LOG.finestTrace("getBoolean", "++enter++");
 
     StandardSQLTypeName type = getStandardSQLTypeName(columnIndex);
     if (type == StandardSQLTypeName.GEOGRAPHY
@@ -288,7 +288,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public byte getByte(int columnIndex) throws SQLException {
-    LOG.finestTrace("getByte", () -> "++enter++");
+    LOG.finestTrace("getByte", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Byte.class, value);
@@ -299,7 +299,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public short getShort(int columnIndex) throws SQLException {
-    LOG.finestTrace("getShort", () -> "++enter++");
+    LOG.finestTrace("getShort", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Short.class, value);
@@ -310,7 +310,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public int getInt(int columnIndex) throws SQLException {
-    LOG.finestTrace("getInt", () -> "++enter++");
+    LOG.finestTrace("getInt", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Integer.class, value);
@@ -321,7 +321,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public long getLong(int columnIndex) throws SQLException {
-    LOG.finestTrace("getLong", () -> "++enter++");
+    LOG.finestTrace("getLong", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Long.class, value);
@@ -332,7 +332,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public float getFloat(int columnIndex) throws SQLException {
-    LOG.finestTrace("getFloat", () -> "++enter++");
+    LOG.finestTrace("getFloat", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Float.class, value);
@@ -343,7 +343,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public double getDouble(int columnIndex) throws SQLException {
-    LOG.finestTrace("getDouble", () -> "++enter++");
+    LOG.finestTrace("getDouble", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Double.class, value);
@@ -354,7 +354,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
-    LOG.finestTrace("getBigDecimal", () -> "++enter++");
+    LOG.finestTrace("getBigDecimal", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(BigDecimal.class, value);
@@ -365,7 +365,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public byte[] getBytes(int columnIndex) throws SQLException {
-    LOG.finestTrace("getBytes", () -> "++enter++");
+    LOG.finestTrace("getBytes", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(byte[].class, value);
@@ -376,7 +376,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Date getDate(int columnIndex) throws SQLException {
-    LOG.finestTrace("getDate", () -> "++enter++");
+    LOG.finestTrace("getDate", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(java.sql.Date.class, value);
@@ -387,7 +387,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Time getTime(int columnIndex) throws SQLException {
-    LOG.finestTrace("getTime", () -> "++enter++");
+    LOG.finestTrace("getTime", "++enter++");
     StandardSQLTypeName type = getStandardSQLTypeName(columnIndex);
     if (type == StandardSQLTypeName.INT64) {
       throw createCoercionException(columnIndex, java.sql.Time.class, null);
@@ -402,7 +402,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Timestamp getTimestamp(int columnIndex) throws SQLException {
-    LOG.finestTrace("getTimestamp", () -> "++enter++");
+    LOG.finestTrace("getTimestamp", "++enter++");
     StandardSQLTypeName type = getStandardSQLTypeName(columnIndex);
     if (type == StandardSQLTypeName.INT64) {
       throw createCoercionException(columnIndex, java.sql.Timestamp.class, null);
@@ -417,7 +417,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-    LOG.finestTrace("getBigDecimal", () -> "++enter++");
+    LOG.finestTrace("getBigDecimal", "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(BigDecimal.class, value);
@@ -428,7 +428,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Array getArray(int columnIndex) throws SQLException {
-    LOG.finestTrace("getArray", () -> "++enter++");
+    LOG.finestTrace("getArray", "++enter++");
     try {
       return (Array) getObject(columnIndex);
     } catch (ClassCastException e) {
@@ -438,27 +438,27 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Blob getBlob(int columnIndex) throws SQLException {
-    LOG.finestTrace("getBlob", () -> "++enter++");
+    LOG.finestTrace("getBlob", "++enter++");
     byte[] value = getBytes(columnIndex);
     return new javax.sql.rowset.serial.SerialBlob(value);
   }
 
   @Override
   public Clob getClob(int columnIndex) throws SQLException {
-    LOG.finestTrace("getClob", () -> "++enter++");
+    LOG.finestTrace("getClob", "++enter++");
     String value = getString(columnIndex);
     return new javax.sql.rowset.serial.SerialClob(value.toCharArray());
   }
 
   @Override
   public Reader getCharacterStream(int columnIndex) throws SQLException {
-    LOG.finestTrace("getCharacterStream", () -> "++enter++");
+    LOG.finestTrace("getCharacterStream", "++enter++");
     String value = getString(columnIndex);
     return value == null ? null : new StringReader(value);
   }
 
   private InputStream getInputStream(String value, java.nio.charset.Charset charset) {
-    LOG.finestTrace("getInputStream", () -> "++enter++");
+    LOG.finestTrace("getInputStream", "++enter++");
     if (value == null) {
       return null;
     }
@@ -467,26 +467,26 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public InputStream getAsciiStream(int columnIndex) throws SQLException {
-    LOG.finestTrace("getAsciiStream", () -> "++enter++");
+    LOG.finestTrace("getAsciiStream", "++enter++");
     return getInputStream(getString(columnIndex), StandardCharsets.US_ASCII);
   }
 
   @Override
   public InputStream getUnicodeStream(int columnIndex) throws SQLException {
-    LOG.finestTrace("getUnicodeStream", () -> "++enter++");
+    LOG.finestTrace("getUnicodeStream", "++enter++");
     return getInputStream(getString(columnIndex), StandardCharsets.UTF_16LE);
   }
 
   @Override
   public InputStream getBinaryStream(int columnIndex) throws SQLException {
-    LOG.finestTrace("getBinaryStream", () -> "++enter++");
+    LOG.finestTrace("getBinaryStream", "++enter++");
     byte[] bytes = getBytes(columnIndex);
     return bytes == null ? null : new java.io.ByteArrayInputStream(bytes);
   }
 
   @Override
   public Date getDate(int columnIndex, Calendar cal) throws SQLException {
-    LOG.finestTrace("getDate", () -> "++enter++");
+    LOG.finestTrace("getDate", "++enter++");
     Date date = getDate(columnIndex);
     if (date == null || cal == null) {
       return null;
@@ -497,7 +497,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Time getTime(int columnIndex, Calendar cal) throws SQLException {
-    LOG.finestTrace("getTime", () -> "++enter++");
+    LOG.finestTrace("getTime", "++enter++");
     Time time = getTime(columnIndex);
     if (time == null || cal == null) {
       return null;
@@ -508,7 +508,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    LOG.finestTrace("getTimestamp", () -> "++enter++");
+    LOG.finestTrace("getTimestamp", "++enter++");
     Timestamp timeStamp = getTimestamp(columnIndex);
     if (timeStamp == null || cal == null) {
       return null;
@@ -519,7 +519,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public int findColumn(String columnLabel) throws SQLException {
-    LOG.finestTrace("findColumn", () -> "++enter++");
+    LOG.finestTrace("findColumn", "++enter++");
     return getColumnIndex(columnLabel);
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -46,8 +46,7 @@ import java.util.Calendar;
 
 public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
     implements BigQueryResultSet {
-  protected final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(this.getClass().getName());
+  protected final BigQueryJdbcResultSetLogger LOG;
   private BigQuery bigQuery;
   private JobId jobId;
   private String queryId;
@@ -67,6 +66,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
     this.schema = schema;
     this.schemaFieldList = schema != null ? schema.getFields() : null;
     this.isNested = isNested;
+    this.LOG = BigQueryJdbcResultSetLogger.getLogger(this.getClass(), statement != null ? statement.connectionId : null);
   }
 
   public QueryStatistics getQueryStatistics() {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -66,7 +66,9 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
     this.schema = schema;
     this.schemaFieldList = schema != null ? schema.getFields() : null;
     this.isNested = isNested;
-    this.LOG = BigQueryJdbcResultSetLogger.getLogger(this.getClass(), statement != null ? statement.connectionId : null);
+    this.LOG =
+        BigQueryJdbcResultSetLogger.getLogger(
+            this.getClass(), statement != null ? statement.connectionId : null);
   }
 
   public QueryStatistics getQueryStatistics() {
@@ -245,7 +247,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   public abstract Object getObject(int columnIndex) throws SQLException;
 
   protected int getColumnIndex(String columnLabel) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getColumnIndex", () -> "++enter++");
     checkClosed();
     if (columnLabel == null) {
       throw logAndCreateException("Column label cannot be null");
@@ -256,7 +258,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public String getString(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getString", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(String.class, value);
@@ -267,7 +269,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public boolean getBoolean(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBoolean", () -> "++enter++");
 
     StandardSQLTypeName type = getStandardSQLTypeName(columnIndex);
     if (type == StandardSQLTypeName.GEOGRAPHY
@@ -286,7 +288,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public byte getByte(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getByte", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Byte.class, value);
@@ -297,7 +299,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public short getShort(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getShort", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Short.class, value);
@@ -308,7 +310,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public int getInt(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getInt", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Integer.class, value);
@@ -319,7 +321,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public long getLong(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getLong", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Long.class, value);
@@ -330,7 +332,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public float getFloat(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getFloat", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Float.class, value);
@@ -341,7 +343,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public double getDouble(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getDouble", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(Double.class, value);
@@ -352,7 +354,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBigDecimal", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(BigDecimal.class, value);
@@ -363,7 +365,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public byte[] getBytes(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBytes", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(byte[].class, value);
@@ -374,7 +376,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Date getDate(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getDate", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(java.sql.Date.class, value);
@@ -385,7 +387,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Time getTime(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getTime", () -> "++enter++");
     StandardSQLTypeName type = getStandardSQLTypeName(columnIndex);
     if (type == StandardSQLTypeName.INT64) {
       throw createCoercionException(columnIndex, java.sql.Time.class, null);
@@ -400,7 +402,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Timestamp getTimestamp(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getTimestamp", () -> "++enter++");
     StandardSQLTypeName type = getStandardSQLTypeName(columnIndex);
     if (type == StandardSQLTypeName.INT64) {
       throw createCoercionException(columnIndex, java.sql.Timestamp.class, null);
@@ -415,7 +417,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public BigDecimal getBigDecimal(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBigDecimal", () -> "++enter++");
     try {
       Object value = getObject(columnIndex);
       return this.bigQueryTypeCoercer.coerceTo(BigDecimal.class, value);
@@ -426,7 +428,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Array getArray(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getArray", () -> "++enter++");
     try {
       return (Array) getObject(columnIndex);
     } catch (ClassCastException e) {
@@ -436,27 +438,27 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Blob getBlob(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBlob", () -> "++enter++");
     byte[] value = getBytes(columnIndex);
     return new javax.sql.rowset.serial.SerialBlob(value);
   }
 
   @Override
   public Clob getClob(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getClob", () -> "++enter++");
     String value = getString(columnIndex);
     return new javax.sql.rowset.serial.SerialClob(value.toCharArray());
   }
 
   @Override
   public Reader getCharacterStream(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getCharacterStream", () -> "++enter++");
     String value = getString(columnIndex);
     return value == null ? null : new StringReader(value);
   }
 
   private InputStream getInputStream(String value, java.nio.charset.Charset charset) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getInputStream", () -> "++enter++");
     if (value == null) {
       return null;
     }
@@ -465,26 +467,26 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public InputStream getAsciiStream(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getAsciiStream", () -> "++enter++");
     return getInputStream(getString(columnIndex), StandardCharsets.US_ASCII);
   }
 
   @Override
   public InputStream getUnicodeStream(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getUnicodeStream", () -> "++enter++");
     return getInputStream(getString(columnIndex), StandardCharsets.UTF_16LE);
   }
 
   @Override
   public InputStream getBinaryStream(int columnIndex) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getBinaryStream", () -> "++enter++");
     byte[] bytes = getBytes(columnIndex);
     return bytes == null ? null : new java.io.ByteArrayInputStream(bytes);
   }
 
   @Override
   public Date getDate(int columnIndex, Calendar cal) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getDate", () -> "++enter++");
     Date date = getDate(columnIndex);
     if (date == null || cal == null) {
       return null;
@@ -495,7 +497,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Time getTime(int columnIndex, Calendar cal) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getTime", () -> "++enter++");
     Time time = getTime(columnIndex);
     if (time == null || cal == null) {
       return null;
@@ -506,7 +508,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getTimestamp", () -> "++enter++");
     Timestamp timeStamp = getTimestamp(columnIndex);
     if (timeStamp == null || cal == null) {
       return null;
@@ -517,7 +519,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
 
   @Override
   public int findColumn(String columnLabel) throws SQLException {
-    LOG.finest("++enter++");
+    LOG.finestTrace("findColumn", () -> "++enter++");
     return getColumnIndex(columnLabel);
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
@@ -52,7 +52,7 @@ abstract class BigQueryBaseStruct implements java.sql.Struct {
   }
 
   static boolean isStruct(Field currentSchema) {
-    LOG.finestTrace("isStruct", () -> "++enter++");
+    LOG.finestTrace("isStruct", "++enter++");
     return currentSchema.getType().getStandardType() == STRUCT;
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
@@ -36,8 +36,8 @@ import java.util.Map;
  * attribute of the SQL structured type that it represents.
  */
 abstract class BigQueryBaseStruct implements java.sql.Struct {
-  private static final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(BigQueryBaseStruct.class.getName());
+  private static final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(BigQueryBaseStruct.class);
 
   abstract FieldList getSchema();
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
@@ -52,7 +52,7 @@ abstract class BigQueryBaseStruct implements java.sql.Struct {
   }
 
   static boolean isStruct(Field currentSchema) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("isStruct", () -> "++enter++");
     return currentSchema.getType().getStandardType() == STRUCT;
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLogger.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLogger.java
@@ -125,4 +125,14 @@ public class BigQueryJdbcCustomLogger extends Logger {
   public void severe(String format, Throwable thrown, Object... args) {
     logWithCaller(Level.SEVERE, thrown, () -> String.format(format, args));
   }
+
+  @Override
+  public void finest(Supplier<String> msgSupplier) {
+    logWithCaller(Level.FINEST, msgSupplier);
+  }
+
+  @Override
+  public void fine(Supplier<String> msgSupplier) {
+    logWithCaller(Level.FINE, msgSupplier);
+  }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
@@ -94,6 +94,48 @@ public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
     }
   }
 
+  /** Log a message at Level.FINER with predefined class name and method name. */
+  public void finerTrace(String methodName, String msg) {
+    if (isLoggable(Level.FINER)) {
+      logp(Level.FINER, targetClassName, methodName, msg);
+    }
+  }
+
+  /** Log a formatted message at Level.FINER with predefined class name and method name. */
+  public void finerTrace(String methodName, String format, Object... args) {
+    if (isLoggable(Level.FINER)) {
+      logp(Level.FINER, targetClassName, methodName, String.format(format, args));
+    }
+  }
+
+  /** Log a lazy message at Level.FINER with predefined class name and method name. */
+  public void finerTrace(String methodName, Supplier<String> msgSupplier) {
+    if (isLoggable(Level.FINER)) {
+      logp(Level.FINER, targetClassName, methodName, msgSupplier);
+    }
+  }
+
+  /** Log a message at Level.FINE with predefined class name and method name. */
+  public void fineTrace(String methodName, String msg) {
+    if (isLoggable(Level.FINE)) {
+      logp(Level.FINE, targetClassName, methodName, msg);
+    }
+  }
+
+  /** Log a formatted message at Level.FINE with predefined class name and method name. */
+  public void fineTrace(String methodName, String format, Object... args) {
+    if (isLoggable(Level.FINE)) {
+      logp(Level.FINE, targetClassName, methodName, String.format(format, args));
+    }
+  }
+
+  /** Log a lazy message at Level.FINE with predefined class name and method name. */
+  public void fineTrace(String methodName, Supplier<String> msgSupplier) {
+    if (isLoggable(Level.FINE)) {
+      logp(Level.FINE, targetClassName, methodName, msgSupplier);
+    }
+  }
+
   @Override
   public void finest(String msg) {
     if (isLoggable(Level.FINEST)) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
@@ -17,12 +17,13 @@
 package com.google.cloud.bigquery.jdbc;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 /**
- * Specialized high-performance logger for ResultSet and its related classes.
- * Avoids expensive stack trace walking (caller inference) on hot-path logging calls.
+ * Specialized high-performance logger for ResultSet and its related classes. Avoids expensive stack
+ * trace walking (caller inference) on hot-path logging calls.
  */
 public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
   private static final ConcurrentHashMap<String, BigQueryJdbcResultSetLogger> cache =
@@ -68,12 +69,17 @@ public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
     }
   }
 
-  /**
-   * Log a formatted message at Level.FINEST with predefined class name and method name.
-   */
+  /** Log a formatted message at Level.FINEST with predefined class name and method name. */
   public void finestTrace(String methodName, String format, Object... args) {
     if (isLoggable(Level.FINEST)) {
       logp(Level.FINEST, targetClassName, methodName, String.format(format, args));
+    }
+  }
+
+  /** Log a lazy message at Level.FINEST with predefined class name and method name. */
+  public void finestTrace(String methodName, Supplier<String> msgSupplier) {
+    if (isLoggable(Level.FINEST)) {
+      logp(Level.FINEST, targetClassName, methodName, msgSupplier);
     }
   }
 
@@ -85,38 +91,9 @@ public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
   }
 
   @Override
-  public void finer(String msg) {
-    if (isLoggable(Level.FINER)) {
-      logp(Level.FINER, targetClassName, "unknown", msg);
-    }
-  }
-
-  @Override
-  public void fine(String msg) {
-    if (isLoggable(Level.FINE)) {
-      logp(Level.FINE, targetClassName, "unknown", msg);
-    }
-  }
-
-  @Override
-  public void finest(String format, Object... args) {
+  public void finest(Supplier<String> msgSupplier) {
     if (isLoggable(Level.FINEST)) {
-      logp(Level.FINEST, targetClassName, "unknown", () -> String.format(format, args));
-    }
-  }
-
-  @Override
-  public void finer(String format, Object... args) {
-    if (isLoggable(Level.FINER)) {
-      logp(Level.FINER, targetClassName, "unknown", () -> String.format(format, args));
-    }
-  }
-
-  @Override
-  public void fine(String format, Object... args) {
-    if (isLoggable(Level.FINE)) {
-      logp(Level.FINE, targetClassName, "unknown", () -> String.format(format, args));
+      logp(Level.FINEST, targetClassName, "unknown", msgSupplier);
     }
   }
 }
-

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery.jdbc;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+/**
+ * Specialized high-performance logger for ResultSet and its related classes.
+ * Avoids expensive stack trace walking (caller inference) on hot-path logging calls.
+ */
+public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
+  private static final ConcurrentHashMap<String, BigQueryJdbcResultSetLogger> cache =
+      new ConcurrentHashMap<>();
+
+  private final String targetClassName;
+  private final String connectionId;
+
+  public static BigQueryJdbcResultSetLogger getLogger(Class<?> clazz) {
+    return getLogger(clazz, null);
+  }
+
+  public static BigQueryJdbcResultSetLogger getLogger(Class<?> clazz, String connectionId) {
+    String key = clazz.getName() + (connectionId != null ? ":" + connectionId : "");
+    return cache.computeIfAbsent(key, k -> new BigQueryJdbcResultSetLogger(clazz, connectionId));
+  }
+
+  public BigQueryJdbcResultSetLogger(Class<?> clazz) {
+    this(clazz, null);
+  }
+
+  public BigQueryJdbcResultSetLogger(Class<?> clazz, String connectionId) {
+    super(clazz.getName());
+    this.targetClassName = clazz.getName();
+    this.connectionId = connectionId;
+  }
+
+  @Override
+  public void log(LogRecord record) {
+    if (connectionId != null) {
+      record.setParameters(new Object[] {connectionId});
+    }
+    super.log(record);
+  }
+
+  /**
+   * Log a message at Level.FINEST with predefined class name and method name to avoid stack trace
+   * parsing on the hot-path.
+   */
+  public void finestTrace(String methodName, String msg) {
+    if (isLoggable(Level.FINEST)) {
+      logp(Level.FINEST, targetClassName, methodName, msg);
+    }
+  }
+
+  /**
+   * Log a formatted message at Level.FINEST with predefined class name and method name.
+   */
+  public void finestTrace(String methodName, String format, Object... args) {
+    if (isLoggable(Level.FINEST)) {
+      logp(Level.FINEST, targetClassName, methodName, String.format(format, args));
+    }
+  }
+
+  @Override
+  public void finest(String msg) {
+    if (isLoggable(Level.FINEST)) {
+      logp(Level.FINEST, targetClassName, "unknown", msg);
+    }
+  }
+
+  @Override
+  public void finer(String msg) {
+    if (isLoggable(Level.FINER)) {
+      logp(Level.FINER, targetClassName, "unknown", msg);
+    }
+  }
+
+  @Override
+  public void fine(String msg) {
+    if (isLoggable(Level.FINE)) {
+      logp(Level.FINE, targetClassName, "unknown", msg);
+    }
+  }
+
+  @Override
+  public void finest(String format, Object... args) {
+    if (isLoggable(Level.FINEST)) {
+      logp(Level.FINEST, targetClassName, "unknown", () -> String.format(format, args));
+    }
+  }
+
+  @Override
+  public void finer(String format, Object... args) {
+    if (isLoggable(Level.FINER)) {
+      logp(Level.FINER, targetClassName, "unknown", () -> String.format(format, args));
+    }
+  }
+
+  @Override
+  public void fine(String format, Object... args) {
+    if (isLoggable(Level.FINE)) {
+      logp(Level.FINE, targetClassName, "unknown", () -> String.format(format, args));
+    }
+  }
+}
+

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcResultSetLogger.java
@@ -37,8 +37,11 @@ public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
   }
 
   public static BigQueryJdbcResultSetLogger getLogger(Class<?> clazz, String connectionId) {
-    String key = clazz.getName() + (connectionId != null ? ":" + connectionId : "");
-    return cache.computeIfAbsent(key, k -> new BigQueryJdbcResultSetLogger(clazz, connectionId));
+    if (connectionId == null) {
+      return cache.computeIfAbsent(
+          clazz.getName(), k -> new BigQueryJdbcResultSetLogger(clazz, null));
+    }
+    return new BigQueryJdbcResultSetLogger(clazz, connectionId);
   }
 
   public BigQueryJdbcResultSetLogger(Class<?> clazz) {
@@ -54,7 +57,15 @@ public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
   @Override
   public void log(LogRecord record) {
     if (connectionId != null) {
-      record.setParameters(new Object[] {connectionId});
+      Object[] existingParams = record.getParameters();
+      if (existingParams == null || existingParams.length == 0) {
+        record.setParameters(new Object[] {connectionId});
+      } else {
+        Object[] newParams = new Object[existingParams.length + 1];
+        newParams[0] = connectionId;
+        System.arraycopy(existingParams, 0, newParams, 1, existingParams.length);
+        record.setParameters(newParams);
+      }
     }
     super.log(record);
   }
@@ -94,6 +105,34 @@ public class BigQueryJdbcResultSetLogger extends BigQueryJdbcCustomLogger {
   public void finest(Supplier<String> msgSupplier) {
     if (isLoggable(Level.FINEST)) {
       logp(Level.FINEST, targetClassName, "unknown", msgSupplier);
+    }
+  }
+
+  @Override
+  public void finer(String msg) {
+    if (isLoggable(Level.FINER)) {
+      logp(Level.FINER, targetClassName, "unknown", msg);
+    }
+  }
+
+  @Override
+  public void finer(Supplier<String> msgSupplier) {
+    if (isLoggable(Level.FINER)) {
+      logp(Level.FINER, targetClassName, "unknown", msgSupplier);
+    }
+  }
+
+  @Override
+  public void fine(String msg) {
+    if (isLoggable(Level.FINE)) {
+      logp(Level.FINE, targetClassName, "unknown", msg);
+    }
+  }
+
+  @Override
+  public void fine(Supplier<String> msgSupplier) {
+    if (isLoggable(Level.FINE)) {
+      logp(Level.FINE, targetClassName, "unknown", msgSupplier);
     }
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcRootLogger.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcRootLogger.java
@@ -88,6 +88,12 @@ class BigQueryJdbcRootLogger {
       public String format(LogRecord record) {
         String date = DATE_FORMATTER.format(Instant.ofEpochMilli(record.getMillis()));
         String connectionId = BigQueryJdbcMdc.getConnectionId();
+        if (connectionId == null || connectionId.isEmpty()) {
+          Object[] params = record.getParameters();
+          if (params != null && params.length > 0 && params[0] instanceof String) {
+            connectionId = (String) params[0];
+          }
+        }
         String connStr =
             (connectionId != null && !connectionId.isEmpty()) ? connectionId : "NO_CONN";
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
@@ -44,7 +44,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public Object getArray() {
     ensureValid();
-    LOG.finest("++enter++");
+    LOG.finestTrace("getArray", () -> "++enter++");
     if (this.values == null) {
       return null;
     }
@@ -54,7 +54,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public Object getArray(long index, int count) {
     ensureValid();
-    LOG.finest("++enter++");
+    LOG.finestTrace("getArray", () -> "++enter++");
     if (this.values == null) {
       return null;
     }
@@ -65,7 +65,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public ResultSet getResultSet() {
     ensureValid();
-    LOG.finest("++enter++");
+    LOG.finestTrace("getResultSet", () -> "++enter++");
     if (this.values == null) {
       return new BigQueryJsonResultSet();
     }
@@ -78,7 +78,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public ResultSet getResultSet(long index, int count) {
     ensureValid();
-    LOG.finest("++enter++");
+    LOG.finestTrace("getResultSet", () -> "++enter++");
     if (this.values == null) {
       return new BigQueryJsonResultSet();
     }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
@@ -30,8 +30,8 @@ import java.util.List;
 /** An implementation of {@link BigQueryBaseArray} used to represent Array values from Json data. */
 @InternalApi
 class BigQueryJsonArray extends BigQueryBaseArray {
-  private static final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(BigQueryJsonArray.class.getName());
+  private static final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(BigQueryJsonArray.class);
   private static final BigQueryTypeCoercer BIGQUERY_TYPE_COERCER =
       BigQueryTypeCoercionUtility.INSTANCE;
   private List<FieldValue> values;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
@@ -44,7 +44,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public Object getArray() {
     ensureValid();
-    LOG.finestTrace("getArray", () -> "++enter++");
+    LOG.finestTrace("getArray", "++enter++");
     if (this.values == null) {
       return null;
     }
@@ -54,7 +54,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public Object getArray(long index, int count) {
     ensureValid();
-    LOG.finestTrace("getArray", () -> "++enter++");
+    LOG.finestTrace("getArray", "++enter++");
     if (this.values == null) {
       return null;
     }
@@ -65,7 +65,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public ResultSet getResultSet() {
     ensureValid();
-    LOG.finestTrace("getResultSet", () -> "++enter++");
+    LOG.finestTrace("getResultSet", "++enter++");
     if (this.values == null) {
       return new BigQueryJsonResultSet();
     }
@@ -78,7 +78,7 @@ class BigQueryJsonArray extends BigQueryBaseArray {
   @Override
   public ResultSet getResultSet(long index, int count) {
     ensureValid();
-    LOG.finestTrace("getResultSet", () -> "++enter++");
+    LOG.finestTrace("getResultSet", "++enter++");
     if (this.values == null) {
       return new BigQueryJsonResultSet();
     }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -185,7 +185,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   public Object getObject(int columnIndex) throws SQLException {
     // columnIndex is SQL index starting at 1
     checkClosed();
-    LOG.finestTrace("getObject", () -> "++enter++");
+    LOG.finestTrace("getObject", "++enter++");
     FieldValue value = getObjectInternal(columnIndex);
     if (value == null || value.isNull()) {
       return null;
@@ -230,7 +230,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
    */
   private FieldValue getObjectInternal(int columnIndex) throws SQLException {
     checkClosed();
-    LOG.finestTrace("getObjectInternal", () -> "++enter++");
+    LOG.finestTrace("getObjectInternal", "++enter++");
     FieldValue value;
     if (this.isNested) {
       boolean validIndexForNestedResultSet = columnIndex == 1 || columnIndex == 2;
@@ -272,7 +272,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
 
   @Override
   public void close() {
-    LOG.finestTrace("close", () -> String.format("Closing BigqueryJsonResultSet %s.", this));
+    LOG.fineTrace("close", () -> String.format("Closing BigqueryJsonResultSet %s.", this));
     this.isClosed = true;
     if (ownedThreads != null) {
       for (Thread ownedThread : ownedThreads) {
@@ -287,7 +287,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean isBeforeFirst() throws SQLException {
     checkClosed();
-    LOG.finestTrace("isBeforeFirst", () -> "++enter++");
+    LOG.finestTrace("isBeforeFirst", "++enter++");
     if (this.isNested) {
       return this.nestedRowIndex < this.fromIndex;
     } else {
@@ -298,14 +298,14 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean isAfterLast() throws SQLException {
     checkClosed();
-    LOG.finestTrace("isAfterLast", () -> "++enter++");
+    LOG.finestTrace("isAfterLast", "++enter++");
     return this.afterLast;
   }
 
   @Override
   public boolean isFirst() throws SQLException {
     checkClosed();
-    LOG.finestTrace("isFirst", () -> "++enter++");
+    LOG.finestTrace("isFirst", "++enter++");
     if (this.isNested) {
       return this.nestedRowIndex == this.fromIndex;
     } else {
@@ -316,7 +316,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean isLast() throws SQLException {
     checkClosed();
-    LOG.finestTrace("isLast", () -> "++enter++");
+    LOG.finestTrace("isLast", "++enter++");
     if (this.isNested) {
       return this.nestedRowIndex == this.toIndexExclusive - 1;
     } else {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -185,7 +185,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   public Object getObject(int columnIndex) throws SQLException {
     // columnIndex is SQL index starting at 1
     checkClosed();
-    LOG.finest("++enter++");
+    LOG.finestTrace("getObject", () -> "++enter++");
     FieldValue value = getObjectInternal(columnIndex);
     if (value == null || value.isNull()) {
       return null;
@@ -230,7 +230,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
    */
   private FieldValue getObjectInternal(int columnIndex) throws SQLException {
     checkClosed();
-    LOG.finest("++enter++");
+    LOG.finestTrace("getObjectInternal", () -> "++enter++");
     FieldValue value;
     if (this.isNested) {
       boolean validIndexForNestedResultSet = columnIndex == 1 || columnIndex == 2;
@@ -272,7 +272,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
 
   @Override
   public void close() {
-    LOG.finestTrace("close", "Closing BigqueryJsonResultSet %s.", this);
+    LOG.finestTrace("close", () -> String.format("Closing BigqueryJsonResultSet %s.", this));
     this.isClosed = true;
     if (ownedThreads != null) {
       for (Thread ownedThread : ownedThreads) {
@@ -287,7 +287,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean isBeforeFirst() throws SQLException {
     checkClosed();
-    LOG.finest("++enter++");
+    LOG.finestTrace("isBeforeFirst", () -> "++enter++");
     if (this.isNested) {
       return this.nestedRowIndex < this.fromIndex;
     } else {
@@ -298,14 +298,14 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean isAfterLast() throws SQLException {
     checkClosed();
-    LOG.finest("++enter++");
+    LOG.finestTrace("isAfterLast", () -> "++enter++");
     return this.afterLast;
   }
 
   @Override
   public boolean isFirst() throws SQLException {
     checkClosed();
-    LOG.finest("++enter++");
+    LOG.finestTrace("isFirst", () -> "++enter++");
     if (this.isNested) {
       return this.nestedRowIndex == this.fromIndex;
     } else {
@@ -316,7 +316,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   @Override
   public boolean isLast() throws SQLException {
     checkClosed();
-    LOG.finest("++enter++");
+    LOG.finestTrace("isLast", () -> "++enter++");
     if (this.isNested) {
       return this.nestedRowIndex == this.toIndexExclusive - 1;
     } else {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -272,7 +272,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
 
   @Override
   public void close() {
-    LOG.fine("Closing BigqueryJsonResultSet %s.", this);
+    LOG.finestTrace("close", "Closing BigqueryJsonResultSet %s.", this);
     this.isClosed = true;
     if (ownedThreads != null) {
       for (Thread ownedThread : ownedThreads) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStruct.java
@@ -51,7 +51,7 @@ class BigQueryJsonStruct extends BigQueryBaseStruct {
 
   @Override
   public Object[] getAttributes() {
-    LOG.finestTrace("getAttributes", () -> "++enter++");
+    LOG.finestTrace("getAttributes", "++enter++");
     int size = schema.size();
     Object[] attributes = (Object[]) Array.newInstance(Object.class, size);
 
@@ -65,7 +65,7 @@ class BigQueryJsonStruct extends BigQueryBaseStruct {
   }
 
   private Object getValue(Field currentSchema, FieldValue currentValue) {
-    LOG.finestTrace("getValue", () -> "++enter++");
+    LOG.finestTrace("getValue", "++enter++");
     if (isArray(currentSchema)) {
       return new BigQueryJsonArray(currentSchema, currentValue);
     } else if (isStruct(currentSchema)) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStruct.java
@@ -30,8 +30,8 @@ import java.util.List;
  */
 @InternalApi
 class BigQueryJsonStruct extends BigQueryBaseStruct {
-  private static final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(BigQueryJsonStruct.class.getName());
+  private static final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(BigQueryJsonStruct.class);
 
   private static final BigQueryTypeCoercer BIGQUERY_TYPE_COERCER =
       BigQueryTypeCoercionUtility.INSTANCE;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStruct.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonStruct.java
@@ -51,7 +51,7 @@ class BigQueryJsonStruct extends BigQueryBaseStruct {
 
   @Override
   public Object[] getAttributes() {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getAttributes", () -> "++enter++");
     int size = schema.size();
     Object[] attributes = (Object[]) Array.newInstance(Object.class, size);
 
@@ -65,7 +65,7 @@ class BigQueryJsonStruct extends BigQueryBaseStruct {
   }
 
   private Object getValue(Field currentSchema, FieldValue currentValue) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("getValue", () -> "++enter++");
     if (isArray(currentSchema)) {
       return new BigQueryJsonArray(currentSchema, currentValue);
     } else if (isStruct(currentSchema)) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
@@ -22,8 +22,8 @@ import java.lang.ref.ReferenceQueue;
 
 @InternalApi
 class BigQueryResultSetFinalizers {
-  private static final BigQueryJdbcCustomLogger LOG =
-      new BigQueryJdbcCustomLogger(BigQueryResultSetFinalizers.class.getName());
+  private static final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(BigQueryResultSetFinalizers.class);
 
   @InternalApi
   static class ArrowResultSetFinalizer extends PhantomReference<BigQueryArrowResultSet> {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
@@ -39,7 +39,7 @@ class BigQueryResultSetFinalizers {
 
     // Free resources. Remove all the hard refs
     public void finalizeResources() {
-      LOG.finestTrace("finalizeResources", () -> "++enter++");
+      LOG.finestTrace("finalizeResources", "++enter++");
       if (ownedThread != null && !ownedThread.isInterrupted()) {
         ownedThread.interrupt();
       }
@@ -60,7 +60,7 @@ class BigQueryResultSetFinalizers {
 
     // Free resources. Remove all the hard refs
     public void finalizeResources() {
-      LOG.finestTrace("finalizeResources", () -> "++enter++");
+      LOG.finestTrace("finalizeResources", "++enter++");
       if (ownedThreads != null) {
         for (Thread ownedThread : ownedThreads) {
           if (!ownedThread.isInterrupted()) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
@@ -39,7 +39,7 @@ class BigQueryResultSetFinalizers {
 
     // Free resources. Remove all the hard refs
     public void finalizeResources() {
-      LOG.finest("++enter++");
+      LOG.finestTrace("finalizeResources", () -> "++enter++");
       if (ownedThread != null && !ownedThread.isInterrupted()) {
         ownedThread.interrupt();
       }
@@ -60,7 +60,7 @@ class BigQueryResultSetFinalizers {
 
     // Free resources. Remove all the hard refs
     public void finalizeResources() {
-      LOG.finest("++enter++");
+      LOG.finestTrace("finalizeResources", () -> "++enter++");
       if (ownedThreads != null) {
         for (Thread ownedThread : ownedThreads) {
           if (!ownedThread.isInterrupted()) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
@@ -28,7 +28,7 @@ import java.sql.Types;
 
 /** This class returns ResultSetMetadata for the JSON and the Arrow ResultSets */
 class BigQueryResultSetMetadata implements ResultSetMetaData {
-  private final BigQueryJdbcCustomLogger LOG = new BigQueryJdbcCustomLogger(this.toString());
+  private final BigQueryJdbcResultSetLogger LOG = BigQueryJdbcResultSetLogger.getLogger(this.getClass());
   private final FieldList schemaFieldList;
   private final Statement statement;
   private final int columnCount;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
@@ -37,7 +37,7 @@ class BigQueryResultSetMetadata implements ResultSetMetaData {
   private static final int DEFAULT_DISPLAY_SIZE = 50;
 
   private BigQueryResultSetMetadata(FieldList schemaFieldList, Statement statement) {
-    LOG.finestTrace("<init>", () -> "++enter++");
+    LOG.finestTrace("<init>", "++enter++");
     this.schemaFieldList = schemaFieldList;
     this.columnCount = schemaFieldList.size();
     this.statement = statement;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
@@ -28,7 +28,8 @@ import java.sql.Types;
 
 /** This class returns ResultSetMetadata for the JSON and the Arrow ResultSets */
 class BigQueryResultSetMetadata implements ResultSetMetaData {
-  private final BigQueryJdbcResultSetLogger LOG = BigQueryJdbcResultSetLogger.getLogger(this.getClass());
+  private final BigQueryJdbcResultSetLogger LOG =
+      BigQueryJdbcResultSetLogger.getLogger(this.getClass());
   private final FieldList schemaFieldList;
   private final Statement statement;
   private final int columnCount;
@@ -36,7 +37,7 @@ class BigQueryResultSetMetadata implements ResultSetMetaData {
   private static final int DEFAULT_DISPLAY_SIZE = 50;
 
   private BigQueryResultSetMetadata(FieldList schemaFieldList, Statement statement) {
-    LOG.finest("++enter++");
+    LOG.finestTrace("<init>", () -> "++enter++");
     this.schemaFieldList = schemaFieldList;
     this.columnCount = schemaFieldList.size();
     this.statement = statement;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/PerConnectionFileHandler.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/PerConnectionFileHandler.java
@@ -90,6 +90,12 @@ class PerConnectionFileHandler extends Handler {
     }
 
     String connectionId = BigQueryJdbcMdc.getConnectionId();
+    if (connectionId == null || connectionId.isEmpty()) {
+      Object[] params = record.getParameters();
+      if (params != null && params.length > 0 && params[0] instanceof String) {
+        connectionId = (String) params[0];
+      }
+    }
     FileHandler handler = defaultHandler;
 
     if (connectionId != null && !connectionId.isEmpty()) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
@@ -128,7 +128,8 @@ public class BigQueryJdbcCustomLoggerTest {
 
   @Test
   public void testResultSetLoggerTrace() {
-    BigQueryJdbcResultSetLogger rsLogger = new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    BigQueryJdbcResultSetLogger rsLogger =
+        new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
     TestHandler rsHandler = new TestHandler();
     rsLogger.addHandler(rsHandler);
     rsLogger.setLevel(Level.ALL);
@@ -147,7 +148,8 @@ public class BigQueryJdbcCustomLoggerTest {
 
   @Test
   public void testResultSetLoggerTraceFormat() {
-    BigQueryJdbcResultSetLogger rsLogger = new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    BigQueryJdbcResultSetLogger rsLogger =
+        new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
     TestHandler rsHandler = new TestHandler();
     rsLogger.addHandler(rsHandler);
     rsLogger.setLevel(Level.ALL);
@@ -166,40 +168,90 @@ public class BigQueryJdbcCustomLoggerTest {
 
   @Test
   public void testResultSetLoggerStandardMethods() {
-    BigQueryJdbcResultSetLogger rsLogger = new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    BigQueryJdbcResultSetLogger rsLogger =
+        new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
     TestHandler rsHandler = new TestHandler();
     rsLogger.addHandler(rsHandler);
     rsLogger.setLevel(Level.ALL);
 
     rsLogger.finest("Finest msg");
-    rsLogger.finer("Finer msg");
-    rsLogger.fine("Fine msg");
-    rsLogger.finest("Finest format: %s", "val");
 
     List<LogRecord> records = rsHandler.getRecords();
-    assertEquals(4, records.size());
+    assertEquals(1, records.size());
 
     LogRecord r1 = records.get(0);
     assertEquals(Level.FINEST, r1.getLevel());
     assertEquals("unknown", r1.getSourceMethodName());
     assertEquals(BigQueryBaseResultSet.class.getName(), r1.getSourceClassName());
     assertEquals("Finest msg", r1.getMessage());
+  }
 
-    LogRecord r2 = records.get(1);
-    assertEquals(Level.FINER, r2.getLevel());
-    assertEquals("unknown", r2.getSourceMethodName());
-    assertEquals("Finer msg", r2.getMessage());
+  @Test
+  public void testCustomLoggerSupplierMethods() {
+    logger.fine(() -> "Lazy fine message");
 
-    LogRecord r3 = records.get(2);
-    assertEquals(Level.FINE, r3.getLevel());
-    assertEquals("unknown", r3.getSourceMethodName());
-    assertEquals("Fine msg", r3.getMessage());
+    List<LogRecord> records = testHandler.getRecords();
+    assertEquals(1, records.size());
+    LogRecord record = records.get(0);
 
-    LogRecord r4 = records.get(3);
-    assertEquals(Level.FINEST, r4.getLevel());
-    assertEquals("unknown", r4.getSourceMethodName());
-    assertEquals("Finest format: val", r4.getMessage());
+    assertEquals(Level.FINE, record.getLevel());
+    assertEquals("testCustomLoggerSupplierMethods", record.getSourceMethodName());
+    assertEquals(BigQueryJdbcCustomLoggerTest.class.getName(), record.getSourceClassName());
+    assertEquals("Lazy fine message", record.getMessage());
+  }
+
+  @Test
+  public void testResultSetLoggerSupplierMethods() {
+    BigQueryJdbcResultSetLogger rsLogger =
+        new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    TestHandler rsHandler = new TestHandler();
+    rsLogger.addHandler(rsHandler);
+    rsLogger.setLevel(Level.ALL);
+
+    rsLogger.finest(() -> "Lazy finest RS message");
+
+    List<LogRecord> records = rsHandler.getRecords();
+    assertEquals(1, records.size());
+    LogRecord record = records.get(0);
+
+    assertEquals(Level.FINEST, record.getLevel());
+    assertEquals("unknown", record.getSourceMethodName());
+    assertEquals(BigQueryBaseResultSet.class.getName(), record.getSourceClassName());
+    assertEquals("Lazy finest RS message", record.getMessage());
+  }
+
+  @Test
+  public void testSupplierNotEvaluatedWhenDisabled() {
+    logger.setLevel(Level.INFO); // Disables FINE, FINER, FINEST
+
+    boolean[] evaluated = {false};
+    logger.fine(
+        () -> {
+          evaluated[0] = true;
+          return "This should not be evaluated";
+        });
+
+    assertEquals(0, testHandler.getRecords().size());
+    assertEquals(false, evaluated[0]);
+  }
+
+  @Test
+  public void testResultSetLoggerSupplierTraceMethods() {
+    BigQueryJdbcResultSetLogger rsLogger =
+        new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    TestHandler rsHandler = new TestHandler();
+    rsLogger.addHandler(rsHandler);
+    rsLogger.setLevel(Level.ALL);
+
+    rsLogger.finestTrace("customTraceMethod", () -> "Lazy finest RS trace message");
+
+    List<LogRecord> records = rsHandler.getRecords();
+    assertEquals(1, records.size());
+    LogRecord record = records.get(0);
+
+    assertEquals(Level.FINEST, record.getLevel());
+    assertEquals("customTraceMethod", record.getSourceMethodName());
+    assertEquals(BigQueryBaseResultSet.class.getName(), record.getSourceClassName());
+    assertEquals("Lazy finest RS trace message", record.getMessage());
   }
 }
-
-

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
@@ -17,6 +17,8 @@
 package com.google.cloud.bigquery.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -175,15 +177,27 @@ public class BigQueryJdbcCustomLoggerTest {
     rsLogger.setLevel(Level.ALL);
 
     rsLogger.finest("Finest msg");
+    rsLogger.finer("Finer msg");
+    rsLogger.fine("Fine msg");
 
     List<LogRecord> records = rsHandler.getRecords();
-    assertEquals(1, records.size());
+    assertEquals(3, records.size());
 
     LogRecord r1 = records.get(0);
     assertEquals(Level.FINEST, r1.getLevel());
     assertEquals("unknown", r1.getSourceMethodName());
     assertEquals(BigQueryBaseResultSet.class.getName(), r1.getSourceClassName());
     assertEquals("Finest msg", r1.getMessage());
+
+    LogRecord r2 = records.get(1);
+    assertEquals(Level.FINER, r2.getLevel());
+    assertEquals("unknown", r2.getSourceMethodName());
+    assertEquals("Finer msg", r2.getMessage());
+
+    LogRecord r3 = records.get(2);
+    assertEquals(Level.FINE, r3.getLevel());
+    assertEquals("unknown", r3.getSourceMethodName());
+    assertEquals("Fine msg", r3.getMessage());
   }
 
   @Test
@@ -253,5 +267,44 @@ public class BigQueryJdbcCustomLoggerTest {
     assertEquals("customTraceMethod", record.getSourceMethodName());
     assertEquals(BigQueryBaseResultSet.class.getName(), record.getSourceClassName());
     assertEquals("Lazy finest RS trace message", record.getMessage());
+  }
+
+  @Test
+  public void testResultSetLoggerCachingBehavior() {
+    // Global logger (connectionId is null) should be cached
+    BigQueryJdbcResultSetLogger globalLogger1 =
+        BigQueryJdbcResultSetLogger.getLogger(BigQueryBaseResultSet.class);
+    BigQueryJdbcResultSetLogger globalLogger2 =
+        BigQueryJdbcResultSetLogger.getLogger(BigQueryBaseResultSet.class);
+    assertSame(globalLogger1, globalLogger2);
+
+    // Connection-specific loggers should not be cached globally
+    BigQueryJdbcResultSetLogger connLogger1 =
+        BigQueryJdbcResultSetLogger.getLogger(BigQueryBaseResultSet.class, "conn-123");
+    BigQueryJdbcResultSetLogger connLogger2 =
+        BigQueryJdbcResultSetLogger.getLogger(BigQueryBaseResultSet.class, "conn-123");
+    assertNotSame(connLogger1, connLogger2);
+  }
+
+  @Test
+  public void testResultSetLoggerParameterPreservation() {
+    BigQueryJdbcResultSetLogger rsLogger =
+        new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class, "conn-123");
+    TestHandler rsHandler = new TestHandler();
+    rsLogger.addHandler(rsHandler);
+    rsLogger.setLevel(Level.ALL);
+
+    LogRecord record = new LogRecord(Level.INFO, "Processing job {0}");
+    record.setParameters(new Object[] {"job-999"});
+    rsLogger.log(record);
+
+    List<LogRecord> records = rsHandler.getRecords();
+    assertEquals(1, records.size());
+    LogRecord loggedRecord = records.get(0);
+
+    Object[] params = loggedRecord.getParameters();
+    assertEquals(2, params.length);
+    assertEquals("conn-123", params[0]);
+    assertEquals("job-999", params[1]);
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
@@ -125,4 +125,81 @@ public class BigQueryJdbcCustomLoggerTest {
     assertTrue(record.getMessage().contains("Error occurred: detail"));
     assertEquals(ex, record.getThrown());
   }
+
+  @Test
+  public void testResultSetLoggerTrace() {
+    BigQueryJdbcResultSetLogger rsLogger = new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    TestHandler rsHandler = new TestHandler();
+    rsLogger.addHandler(rsHandler);
+    rsLogger.setLevel(Level.ALL);
+
+    rsLogger.finestTrace("customMethod", "Hello finest trace message");
+
+    List<LogRecord> records = rsHandler.getRecords();
+    assertEquals(1, records.size());
+    LogRecord record = records.get(0);
+
+    assertEquals(Level.FINEST, record.getLevel());
+    assertEquals("customMethod", record.getSourceMethodName());
+    assertEquals(BigQueryBaseResultSet.class.getName(), record.getSourceClassName());
+    assertEquals("Hello finest trace message", record.getMessage());
+  }
+
+  @Test
+  public void testResultSetLoggerTraceFormat() {
+    BigQueryJdbcResultSetLogger rsLogger = new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    TestHandler rsHandler = new TestHandler();
+    rsLogger.addHandler(rsHandler);
+    rsLogger.setLevel(Level.ALL);
+
+    rsLogger.finestTrace("formattedMethod", "Value: %s, Code: %d", "abc", 123);
+
+    List<LogRecord> records = rsHandler.getRecords();
+    assertEquals(1, records.size());
+    LogRecord record = records.get(0);
+
+    assertEquals(Level.FINEST, record.getLevel());
+    assertEquals("formattedMethod", record.getSourceMethodName());
+    assertEquals(BigQueryBaseResultSet.class.getName(), record.getSourceClassName());
+    assertEquals("Value: abc, Code: 123", record.getMessage());
+  }
+
+  @Test
+  public void testResultSetLoggerStandardMethods() {
+    BigQueryJdbcResultSetLogger rsLogger = new BigQueryJdbcResultSetLogger(BigQueryBaseResultSet.class);
+    TestHandler rsHandler = new TestHandler();
+    rsLogger.addHandler(rsHandler);
+    rsLogger.setLevel(Level.ALL);
+
+    rsLogger.finest("Finest msg");
+    rsLogger.finer("Finer msg");
+    rsLogger.fine("Fine msg");
+    rsLogger.finest("Finest format: %s", "val");
+
+    List<LogRecord> records = rsHandler.getRecords();
+    assertEquals(4, records.size());
+
+    LogRecord r1 = records.get(0);
+    assertEquals(Level.FINEST, r1.getLevel());
+    assertEquals("unknown", r1.getSourceMethodName());
+    assertEquals(BigQueryBaseResultSet.class.getName(), r1.getSourceClassName());
+    assertEquals("Finest msg", r1.getMessage());
+
+    LogRecord r2 = records.get(1);
+    assertEquals(Level.FINER, r2.getLevel());
+    assertEquals("unknown", r2.getSourceMethodName());
+    assertEquals("Finer msg", r2.getMessage());
+
+    LogRecord r3 = records.get(2);
+    assertEquals(Level.FINE, r3.getLevel());
+    assertEquals("unknown", r3.getSourceMethodName());
+    assertEquals("Fine msg", r3.getMessage());
+
+    LogRecord r4 = records.get(3);
+    assertEquals(Level.FINEST, r4.getLevel());
+    assertEquals("unknown", r4.getSourceMethodName());
+    assertEquals("Finest format: val", r4.getMessage());
+  }
 }
+
+


### PR DESCRIPTION

b/510827966

Optimized JDBC driver performance by implementing a custom logger for ResultSet classes, designed for low impact when logging is off and efficient handling when on.

- **Lazy Logging Overloads:** Added Java 8 Supplier overloads to custom loggers, eliminating dynamic string allocations and GC pressure when logging is disabled.

- **Explicit Trace Logging:** Introduced Supplier-based trace overloads (like finestTrace) with explicit method parameters, bypassing CPU-intensive stack-walking.

- **ResultSet-Wide Refactoring:** Refactored 11 ResultSet-related classes to use these lazy trace overloads, removing hot-path logging overhead at the bytecode level.

- **Per-Connection Log Routing:** Enhanced PerConnectionFileHandler to extract connection IDs directly from log parameters, preventing log leakage into the global log.
