### PR TITLE
fix(bqjdbc): fix Long to java.sql.Time coercion

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
+++ b/java-bigquery/google-cloud-bigquery-jdbc/.gitignore
@@ -2,6 +2,7 @@ drivers/**
 target-it/**
 *logs*/**
 **/ITBigQueryJDBCLocalTest.java
+**/BigQueryStatementE2EBenchmark.java
 
 tools/**/*.class
 tools/**/*.jfr

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -351,6 +351,8 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   }
 
   @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public BigDecimal getBigDecimal(int columnIndex, int scale) throws SQLException {
     LOG.finest("++enter++");
     try {
@@ -470,6 +472,8 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   }
 
   @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public InputStream getUnicodeStream(int columnIndex) throws SQLException {
     LOG.finest("++enter++");
     return getInputStream(getString(columnIndex), StandardCharsets.UTF_16LE);
@@ -567,6 +571,8 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   }
 
   @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public BigDecimal getBigDecimal(String columnLabel, int scale) throws SQLException {
     return getBigDecimal(getColumnIndex(columnLabel), scale);
   }
@@ -597,6 +603,8 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   }
 
   @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public InputStream getUnicodeStream(String columnLabel) throws SQLException {
     return getUnicodeStream(getColumnIndex(columnLabel));
   }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryCallableStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryCallableStatement.java
@@ -117,6 +117,8 @@ class BigQueryCallableStatement extends BigQueryPreparedStatement implements Cal
   }
 
   @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public BigDecimal getBigDecimal(int arg0, int arg1) throws SQLException {
     LOG.finest("++enter++");
     return getBigDecimal(arg0);

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryPreparedStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryPreparedStatement.java
@@ -233,6 +233,8 @@ class BigQueryPreparedStatement extends BigQueryStatement implements PreparedSta
   }
 
   @Override
+  @Deprecated
+  @SuppressWarnings("deprecation")
   public void setUnicodeStream(int parameterIndex, InputStream x, int length) {
     // TODO :NOT IMPLEMENTED
   }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
@@ -198,22 +198,12 @@ class BigQueryTypeCoercionUtility {
 
     @Override
     public Time coerce(Long value) {
-
-      int HH = (int) TimeUnit.MICROSECONDS.toHours(value);
-      int MM = (int) (TimeUnit.MICROSECONDS.toMinutes(value) % 60);
-      int SS = (int) (TimeUnit.MICROSECONDS.toSeconds(value) % 60);
-
-      // Note: BQ Time has a precision of up to six fractional digits (microsecond precision)
-      // but java.sql.Time do not. So data after seconds is not returned.
-      // Using Calendar for timezone-safe date rollover arithmetic instead of the deprecated Time
-      // constructor.
-      java.util.Calendar cal = java.util.Calendar.getInstance();
-      cal.clear();
-      cal.set(1970, 0, 1, 0, 0, 0);
-      cal.add(java.util.Calendar.HOUR, HH);
-      cal.add(java.util.Calendar.MINUTE, MM);
-      cal.add(java.util.Calendar.SECOND, SS);
-      return new Time(cal.getTimeInMillis());
+      // Convert UTC epoch microseconds to Instant
+      Instant instant = Instant.ofEpochMilli(value / 1000);
+      // Convert to LocalTime using the system default timezone to ensure correct wall-clock time
+      LocalTime localTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalTime();
+      // Return java.sql.Time with date component set to 1970-01-01 as mandated by JDBC spec
+      return Time.valueOf(localTime);
     }
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
@@ -200,7 +200,9 @@ class BigQueryTypeCoercionUtility {
       // Note: BQ Time has a precision of up to six fractional digits (microsecond precision)
       // but java.sql.Time only supports up to millisecond precision. So data after milliseconds is
       // truncated.
-      return new Time(value / 1000);
+      long millisOfDay = value / 1000;
+      long localMillis = TimeZoneCache.getLocalMillis(millisOfDay);
+      return new Time(localMillis);
     }
   }
 
@@ -209,7 +211,7 @@ class BigQueryTypeCoercionUtility {
     @Override
     public Timestamp coerce(Long value) {
       // Long value is in microseconds. All further calculations should account for the unit.
-      Instant instant = Instant.ofEpochMilli(value / 1000).plusNanos((value % 1000) * 1000);
+      Instant instant = Instant.EPOCH.plus(value, ChronoUnit.MICROS);
       // Timezone-agnostic conversion preserving exact point in time as mandated by JDBC spec
       return Timestamp.from(instant);
     }
@@ -252,7 +254,7 @@ class BigQueryTypeCoercionUtility {
         long millisOfDay = TimeUnit.NANOSECONDS.toMillis(localTime.toNanoOfDay());
         // Adjust by local timezone offset to ensure correct wall-clock representation with
         // millisecond precision
-        long localMillis = millisOfDay - java.util.TimeZone.getDefault().getOffset(millisOfDay);
+        long localMillis = TimeZoneCache.getLocalMillis(millisOfDay);
         return new Time(localMillis);
       } catch (java.time.format.DateTimeParseException e) {
         IllegalArgumentException ex =

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
@@ -205,7 +205,15 @@ class BigQueryTypeCoercionUtility {
 
       // Note: BQ Time has a precision of up to six fractional digits (microsecond precision)
       // but java.sql.Time do not. So data after seconds is not returned.
-      return new Time(HH, MM, SS);
+      // Using Calendar for timezone-safe date rollover arithmetic instead of the deprecated Time
+      // constructor.
+      java.util.Calendar cal = java.util.Calendar.getInstance();
+      cal.clear();
+      cal.set(1970, 0, 1, 0, 0, 0);
+      cal.add(java.util.Calendar.HOUR, HH);
+      cal.add(java.util.Calendar.MINUTE, MM);
+      cal.add(java.util.Calendar.SECOND, SS);
+      return new Time(cal.getTimeInMillis());
     }
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercionUtility.java
@@ -30,7 +30,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
@@ -198,12 +197,10 @@ class BigQueryTypeCoercionUtility {
 
     @Override
     public Time coerce(Long value) {
-      // Convert UTC epoch microseconds to Instant
-      Instant instant = Instant.ofEpochMilli(value / 1000);
-      // Convert to LocalTime using the system default timezone to ensure correct wall-clock time
-      LocalTime localTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault()).toLocalTime();
-      // Return java.sql.Time with date component set to 1970-01-01 as mandated by JDBC spec
-      return Time.valueOf(localTime);
+      // Note: BQ Time has a precision of up to six fractional digits (microsecond precision)
+      // but java.sql.Time only supports up to millisecond precision. So data after milliseconds is
+      // truncated.
+      return new Time(value / 1000);
     }
   }
 
@@ -213,9 +210,8 @@ class BigQueryTypeCoercionUtility {
     public Timestamp coerce(Long value) {
       // Long value is in microseconds. All further calculations should account for the unit.
       Instant instant = Instant.ofEpochMilli(value / 1000).plusNanos((value % 1000) * 1000);
-      // JDBC is defaulting to UTC because BQ UI defaults to UTC.
-      LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneId.of("UTC"));
-      return Timestamp.valueOf(localDateTime);
+      // Timezone-agnostic conversion preserving exact point in time as mandated by JDBC spec
+      return Timestamp.from(instant);
     }
   }
 
@@ -253,8 +249,11 @@ class BigQueryTypeCoercionUtility {
         LocalTime localTime = LocalTime.parse(strTime);
         // Convert LocalTime to milliseconds of the day. This correctly preserves millisecond
         // precision and truncates anything smaller
-        long millis = TimeUnit.NANOSECONDS.toMillis(localTime.toNanoOfDay());
-        return new Time(millis);
+        long millisOfDay = TimeUnit.NANOSECONDS.toMillis(localTime.toNanoOfDay());
+        // Adjust by local timezone offset to ensure correct wall-clock representation with
+        // millisecond precision
+        long localMillis = millisOfDay - java.util.TimeZone.getDefault().getOffset(millisOfDay);
+        return new Time(localMillis);
       } catch (java.time.format.DateTimeParseException e) {
         IllegalArgumentException ex =
             new IllegalArgumentException(
@@ -280,9 +279,8 @@ class BigQueryTypeCoercionUtility {
         // It's a TIMESTAMP numeric string.
         long microseconds = fieldValue.getTimestampValue();
         Instant instant = Instant.EPOCH.plus(microseconds, ChronoUnit.MICROS);
-        // JDBC is defaulting to UTC because BQ UI defaults to UTC.
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneId.of("UTC"));
-        return Timestamp.valueOf(localDateTime);
+        // Timezone-agnostic conversion preserving exact point in time as mandated by JDBC spec
+        return Timestamp.from(instant);
       }
     }
   }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/TimeZoneCache.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/TimeZoneCache.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery.jdbc;
+
+import com.google.api.core.InternalApi;
+import java.util.TimeZone;
+
+@InternalApi
+public class TimeZoneCache {
+  private static volatile TimeZone defaultTimeZone = TimeZone.getDefault();
+
+  public static void reset() {
+    defaultTimeZone = TimeZone.getDefault();
+  }
+
+  public static long getLocalMillis(long millisOfDay) {
+    return millisOfDay - defaultTimeZone.getOffset(millisOfDay);
+  }
+}

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
@@ -165,7 +165,7 @@ public class ArrowFormatTypeBigQueryCoercionUtilityTest {
   @Test
   public void longToTime() {
     assertThat(INSTANCE.coerceTo(Time.class, 1408452095220000L))
-        .isEqualTo(new Time(1408452095000L));
+        .isEqualTo(Time.valueOf(java.time.LocalTime.of(12, 41, 35)));
   }
 
   @Test

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
@@ -164,8 +164,28 @@ public class ArrowFormatTypeBigQueryCoercionUtilityTest {
 
   @Test
   public void longToTime() {
-    assertThat(INSTANCE.coerceTo(Time.class, 1408452095220000L))
-        .isEqualTo(new Time(1408452095220L));
+    long value = 1408452095220000L;
+    // 1408452095220000 microseconds is 1408452095220 milliseconds.
+    // Since the test runs under UTC timezone by TimeZoneRule, expected localMillis is
+    // 1408452095220L.
+    assertThat(INSTANCE.coerceTo(Time.class, value)).isEqualTo(new Time(1408452095220L));
+  }
+
+  @Test
+  public void longToTimeInNonUTCTimeZone() {
+    java.util.TimeZone originalTimeZone = java.util.TimeZone.getDefault();
+    try {
+      java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/Los_Angeles"));
+      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+      long value = 1408452095220000L;
+      // 1408452095220000 microseconds is 1408452095220 milliseconds.
+      // Under America/Los_Angeles (PDT, -7 hours offset in Aug 2014), the subtracted offset
+      // results in 1408452095220 - (-25200000) = 1408477295220L.
+      assertThat(INSTANCE.coerceTo(Time.class, value)).isEqualTo(new Time(1408477295220L));
+    } finally {
+      java.util.TimeZone.setDefault(originalTimeZone);
+      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+    }
   }
 
   @Test

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
@@ -165,7 +165,7 @@ public class ArrowFormatTypeBigQueryCoercionUtilityTest {
   @Test
   public void longToTime() {
     assertThat(INSTANCE.coerceTo(Time.class, 1408452095220000L))
-        .isEqualTo(Time.valueOf(java.time.LocalTime.of(12, 41, 35)));
+        .isEqualTo(new Time(1408452095220L));
   }
 
   @Test

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.util.TimeZone;
 import org.apache.arrow.vector.PeriodDuration;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
@@ -173,18 +174,18 @@ public class ArrowFormatTypeBigQueryCoercionUtilityTest {
 
   @Test
   public void longToTimeInNonUTCTimeZone() {
-    java.util.TimeZone originalTimeZone = java.util.TimeZone.getDefault();
+    TimeZone originalTimeZone = TimeZone.getDefault();
     try {
-      java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/Los_Angeles"));
-      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+      TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+      TimeZoneCache.reset();
       long value = 1408452095220000L;
       // 1408452095220000 microseconds is 1408452095220 milliseconds.
       // Under America/Los_Angeles (PDT, -7 hours offset in Aug 2014), the subtracted offset
       // results in 1408452095220 - (-25200000) = 1408477295220L.
       assertThat(INSTANCE.coerceTo(Time.class, value)).isEqualTo(new Time(1408477295220L));
     } finally {
-      java.util.TimeZone.setDefault(originalTimeZone);
-      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+      TimeZone.setDefault(originalTimeZone);
+      TimeZoneCache.reset();
     }
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
@@ -59,6 +59,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.Text;
@@ -176,16 +177,10 @@ public class BigQueryArrowArrayOfPrimitivesTest {
                 Long.valueOf("40461820227"),
                 Long.valueOf("40462820227")),
             new Time[] {
-              new Time(java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(aTime.toNanoOfDay())),
-              new Time(
-                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
-                      aTime.plusSeconds(1).toNanoOfDay())),
-              new Time(
-                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
-                      aTime.plusSeconds(2).toNanoOfDay())),
-              new Time(
-                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
-                      aTime.plusSeconds(3).toNanoOfDay()))
+              new Time(TimeUnit.NANOSECONDS.toMillis(aTime.toNanoOfDay())),
+              new Time(TimeUnit.NANOSECONDS.toMillis(aTime.plusSeconds(1).toNanoOfDay())),
+              new Time(TimeUnit.NANOSECONDS.toMillis(aTime.plusSeconds(2).toNanoOfDay())),
+              new Time(TimeUnit.NANOSECONDS.toMillis(aTime.plusSeconds(3).toNanoOfDay()))
             },
             Types.TIME
           },

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
@@ -75,7 +75,7 @@ public class BigQueryArrowArrayOfPrimitivesTest {
     timeZoneRule.enforce();
     LocalDateTime aTimeStamp = LocalDateTime.of(2023, MARCH, 30, 11, 14, 19, 820227000);
     LocalDate aDate = LocalDate.of(2023, MARCH, 30);
-    LocalTime aTime = LocalTime.of(11, 14, 19, 820227);
+    LocalTime aTime = LocalTime.of(11, 14, 19, 820227000);
     return Arrays.asList(
         new Object[][] {
           {
@@ -176,10 +176,16 @@ public class BigQueryArrowArrayOfPrimitivesTest {
                 Long.valueOf("40461820227"),
                 Long.valueOf("40462820227")),
             new Time[] {
-              Time.valueOf(aTime),
-              Time.valueOf(aTime.plusSeconds(1)),
-              Time.valueOf(aTime.plusSeconds(2)),
-              Time.valueOf(aTime.plusSeconds(3))
+              new Time(java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(aTime.toNanoOfDay())),
+              new Time(
+                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                      aTime.plusSeconds(1).toNanoOfDay())),
+              new Time(
+                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                      aTime.plusSeconds(2).toNanoOfDay())),
+              new Time(
+                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                      aTime.plusSeconds(3).toNanoOfDay()))
             },
             Types.TIME
           },

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
@@ -106,7 +106,9 @@ public class BigQueryArrowStructTest {
                     "one",
                     Timestamp.valueOf(LocalDateTime.of(2023, MARCH, 30, 11, 14, 19, 820227000)),
                     Date.valueOf(LocalDate.of(2023, MARCH, 30)),
-                    Time.valueOf(LocalTime.of(11, 14, 19, 820227)),
+                    new Time(
+                        java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                            LocalTime.of(11, 14, 19, 820227000).toNanoOfDay())),
                     Timestamp.valueOf("2023-03-30 11:14:19.820227"),
                     "POINT(-122 47)",
                     "one".getBytes())
@@ -117,7 +119,7 @@ public class BigQueryArrowStructTest {
   public void structOfArrays() throws SQLException {
     LocalDateTime aTimeStamp = LocalDateTime.of(2023, MARCH, 30, 11, 14, 19, 820227000);
     LocalDate aDate = LocalDate.of(2023, MARCH, 30);
-    LocalTime aTime = LocalTime.of(11, 14, 19, 820227);
+    LocalTime aTime = LocalTime.of(11, 14, 19, 820227000);
     List<Tuple<Field, JsonStringArrayList<Object>>> schemaAndValues =
         Arrays.asList(
             arrowArraySchemaAndValue(INT64, 10L, 20L),
@@ -165,7 +167,13 @@ public class BigQueryArrowStructTest {
     assertThat(((Array) attributes[7]).getArray())
         .isEqualTo(new Date[] {Date.valueOf(aDate), Date.valueOf(aDate.plusDays(1))});
     assertThat(((Array) attributes[8]).getArray())
-        .isEqualTo(new Time[] {Time.valueOf(aTime), Time.valueOf(aTime.plusSeconds(1))});
+        .isEqualTo(
+            new Time[] {
+              new Time(java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(aTime.toNanoOfDay())),
+              new Time(
+                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                      aTime.plusSeconds(1).toNanoOfDay()))
+            });
     assertThat(((Array) attributes[9]).getArray()) // DATETIME
         .isEqualTo(
             new Timestamp[] {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
@@ -58,6 +58,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.arrow.vector.util.JsonStringArrayList;
@@ -107,7 +108,7 @@ public class BigQueryArrowStructTest {
                     Timestamp.valueOf(LocalDateTime.of(2023, MARCH, 30, 11, 14, 19, 820227000)),
                     Date.valueOf(LocalDate.of(2023, MARCH, 30)),
                     new Time(
-                        java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                        TimeUnit.NANOSECONDS.toMillis(
                             LocalTime.of(11, 14, 19, 820227000).toNanoOfDay())),
                     Timestamp.valueOf("2023-03-30 11:14:19.820227"),
                     "POINT(-122 47)",
@@ -169,10 +170,8 @@ public class BigQueryArrowStructTest {
     assertThat(((Array) attributes[8]).getArray())
         .isEqualTo(
             new Time[] {
-              new Time(java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(aTime.toNanoOfDay())),
-              new Time(
-                  java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
-                      aTime.plusSeconds(1).toNanoOfDay()))
+              new Time(TimeUnit.NANOSECONDS.toMillis(aTime.toNanoOfDay())),
+              new Time(TimeUnit.NANOSECONDS.toMillis(aTime.plusSeconds(1).toNanoOfDay()))
             });
     assertThat(((Array) attributes[9]).getArray()) // DATETIME
         .isEqualTo(

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercerBuilderTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryTypeCoercerBuilderTest.java
@@ -21,7 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.cloud.bigquery.jdbc.TestType.Text;
 import org.junit.jupiter.api.Test;
 
-public class BigQueryBigQueryTypeCoercerBuilderTest {
+public class BigQueryTypeCoercerBuilderTest {
 
   @Test
   public void shouldBeAbleToConvertCustomTypes() {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/FieldValueTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/FieldValueTypeBigQueryCoercionUtilityTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.bigquery.FieldValue;
 import com.google.cloud.bigquery.FieldValueList;
 import com.google.cloud.bigquery.Range;
 import com.google.cloud.bigquery.exception.BigQueryJdbcCoercionException;
+import com.google.cloud.bigquery.jdbc.rules.TimeZoneRule;
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -38,10 +39,12 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class FieldValueTypeBigQueryCoercionUtilityTest {
+  @RegisterExtension public final TimeZoneRule timeZoneRule = new TimeZoneRule("UTC");
+
   private static final FieldValue STRING_VALUE = FieldValue.of(PRIMITIVE, "sample-string");
   private static final FieldValue INTEGER_VALUE = FieldValue.of(PRIMITIVE, "345");
   private static final FieldValue FLOAT_VALUE = FieldValue.of(PRIMITIVE, "345.21");
@@ -315,11 +318,27 @@ public class FieldValueTypeBigQueryCoercionUtilityTest {
   public void fieldValueToTime() {
     LocalTime expectedTime = LocalTime.of(23, 59, 59);
     assertThat(INSTANCE.coerceTo(Time.class, TIME_VALUE)).isEqualTo(Time.valueOf(expectedTime));
-    LocalTime expectedTimeWithNanos = LocalTime.parse("23:59:59.99999");
-    long millisOfDay = TimeUnit.NANOSECONDS.toMillis(expectedTimeWithNanos.toNanoOfDay());
-    long localMillis = millisOfDay - java.util.TimeZone.getDefault().getOffset(millisOfDay);
+    // expectedTimeWithNanos has 999 milliseconds, giving 86399999 ms of day.
+    // Since the test runs under UTC timezone by TimeZoneRule, expected localMillis is 86399999L.
     assertThat(INSTANCE.coerceTo(Time.class, TIME_WITH_NANOSECOND_VALUE))
-        .isEqualTo(new Time(localMillis));
+        .isEqualTo(new Time(86399999L));
+  }
+
+  @Test
+  public void fieldValueToTimeInNonUTCTimeZone() {
+    java.util.TimeZone originalTimeZone = java.util.TimeZone.getDefault();
+    try {
+      java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/Los_Angeles"));
+      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+      // 23:59:59.99999 yields 86399999 milliseconds.
+      // Under America/Los_Angeles on 1970-01-01 (PST, -8 hours offset),
+      // the subtracted offset results in 86399999 - (-28800000) = 115199999L.
+      assertThat(INSTANCE.coerceTo(Time.class, TIME_WITH_NANOSECOND_VALUE))
+          .isEqualTo(new Time(115199999L));
+    } finally {
+      java.util.TimeZone.setDefault(originalTimeZone);
+      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+    }
   }
 
   @Test

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/FieldValueTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/FieldValueTypeBigQueryCoercionUtilityTest.java
@@ -36,9 +36,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -299,9 +297,8 @@ public class FieldValueTypeBigQueryCoercionUtilityTest {
   @Test
   public void fieldValueToTimestamp() {
     Instant instant = Instant.EPOCH.plus(TIMESTAMP_VALUE.getTimestampValue(), ChronoUnit.MICROS);
-    LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneId.of("UTC"));
     assertThat(INSTANCE.coerceTo(Timestamp.class, TIMESTAMP_VALUE))
-        .isEqualTo(Timestamp.valueOf(localDateTime));
+        .isEqualTo(Timestamp.from(instant));
   }
 
   @Test
@@ -317,11 +314,12 @@ public class FieldValueTypeBigQueryCoercionUtilityTest {
   @Test
   public void fieldValueToTime() {
     LocalTime expectedTime = LocalTime.of(23, 59, 59);
-    assertThat(INSTANCE.coerceTo(Time.class, TIME_VALUE))
-        .isEqualTo(new Time(TimeUnit.NANOSECONDS.toMillis(expectedTime.toNanoOfDay())));
+    assertThat(INSTANCE.coerceTo(Time.class, TIME_VALUE)).isEqualTo(Time.valueOf(expectedTime));
     LocalTime expectedTimeWithNanos = LocalTime.parse("23:59:59.99999");
+    long millisOfDay = TimeUnit.NANOSECONDS.toMillis(expectedTimeWithNanos.toNanoOfDay());
+    long localMillis = millisOfDay - java.util.TimeZone.getDefault().getOffset(millisOfDay);
     assertThat(INSTANCE.coerceTo(Time.class, TIME_WITH_NANOSECOND_VALUE))
-        .isEqualTo(new Time(TimeUnit.NANOSECONDS.toMillis(expectedTimeWithNanos.toNanoOfDay())));
+        .isEqualTo(new Time(localMillis));
   }
 
   @Test

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/FieldValueTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/FieldValueTypeBigQueryCoercionUtilityTest.java
@@ -39,6 +39,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.TimeZone;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -326,18 +327,18 @@ public class FieldValueTypeBigQueryCoercionUtilityTest {
 
   @Test
   public void fieldValueToTimeInNonUTCTimeZone() {
-    java.util.TimeZone originalTimeZone = java.util.TimeZone.getDefault();
+    TimeZone originalTimeZone = TimeZone.getDefault();
     try {
-      java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/Los_Angeles"));
-      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+      java.util.TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+      TimeZoneCache.reset();
       // 23:59:59.99999 yields 86399999 milliseconds.
       // Under America/Los_Angeles on 1970-01-01 (PST, -8 hours offset),
       // the subtracted offset results in 86399999 - (-28800000) = 115199999L.
       assertThat(INSTANCE.coerceTo(Time.class, TIME_WITH_NANOSECOND_VALUE))
           .isEqualTo(new Time(115199999L));
     } finally {
-      java.util.TimeZone.setDefault(originalTimeZone);
-      com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+      TimeZone.setDefault(originalTimeZone);
+      TimeZoneCache.reset();
     }
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/rules/TimeZoneRule.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/rules/TimeZoneRule.java
@@ -37,11 +37,13 @@ public class TimeZoneRule
   public void beforeAll(ExtensionContext context) {
     defaultTimeZone = TimeZone.getDefault();
     TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
+    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
   }
 
   @Override
   public void afterAll(ExtensionContext context) {
     TimeZone.setDefault(defaultTimeZone);
+    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
   }
 
   @Override
@@ -50,6 +52,7 @@ public class TimeZoneRule
       defaultTimeZone = TimeZone.getDefault();
     }
     TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
+    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
   }
 
   @Override
@@ -57,10 +60,12 @@ public class TimeZoneRule
     if (defaultTimeZone != null) {
       TimeZone.setDefault(defaultTimeZone);
     }
+    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
   }
 
   /** Public method to enforce the rule manually */
   public void enforce() {
     TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
+    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/rules/TimeZoneRule.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/rules/TimeZoneRule.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigquery.jdbc.rules;
 
+import com.google.cloud.bigquery.jdbc.TimeZoneCache;
 import java.util.TimeZone;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -37,13 +38,13 @@ public class TimeZoneRule
   public void beforeAll(ExtensionContext context) {
     defaultTimeZone = TimeZone.getDefault();
     TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
-    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+    TimeZoneCache.reset();
   }
 
   @Override
   public void afterAll(ExtensionContext context) {
     TimeZone.setDefault(defaultTimeZone);
-    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+    TimeZoneCache.reset();
   }
 
   @Override
@@ -52,7 +53,7 @@ public class TimeZoneRule
       defaultTimeZone = TimeZone.getDefault();
     }
     TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
-    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+    TimeZoneCache.reset();
   }
 
   @Override
@@ -60,12 +61,12 @@ public class TimeZoneRule
     if (defaultTimeZone != null) {
       TimeZone.setDefault(defaultTimeZone);
     }
-    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+    TimeZoneCache.reset();
   }
 
   /** Public method to enforce the rule manually */
   public void enforce() {
     TimeZone.setDefault(TimeZone.getTimeZone(timeZoneId));
-    com.google.cloud.bigquery.jdbc.TimeZoneCache.reset();
+    TimeZoneCache.reset();
   }
 }


### PR DESCRIPTION
b/510853631

chore(bqjdbc): suppress deprecation warnings

- **Silenced Deprecation Warnings:** Added @Deprecated and @SuppressWarnings("deprecation") annotations to all mandated overridden methods in BigQueryBaseResultSet, BigQueryPreparedStatement, and BigQueryCallableStatement to satisfy the standard JDBC interface contract warning-free.
- **Unified Arrow Coercion (LongToTime):** Refactored the Arrow microsecond parser to use new Time(value / 1000) to achieve a zero-overhead, warning-free conversion that fully preserves sub-second millisecond precision.
- **Fixed JSON Coercion Wall-Clock Shifts (FieldValueToTime):** Introduced local timezone offset compensation arithmetic (millisOfDay - TimeZone.getDefault().getOffset()) to ensure the retrieved timezone-agnostic time-of-day matches the stored database value exactly, regardless of the client machine's timezone.
- **Fixed Timestamp Shifting (FieldValueToTimestamp & LongToTimestamp):** Standardized both numeric timestamp parsers to use the timezone-agnostic Timestamp.from(instant) standard, preserving the exact UTC point in time and eliminating dual timezone shifts in non-UTC system timezones.
- **Modernized the Test Suite:** Restructured and updated the expected assertions across multiple unit test classes (ArrowFormatType, FieldValueType, BigQueryArrowArrayOfPrimitives, BigQueryArrowStruct) to enforce these timezone-robust, high-precision, and compliant results.