### PR TITLE
chore(spanner): add missing commit ts logging

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -527,8 +527,25 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                     return;
                   }
                   if (!proto.hasCommitTimestamp()) {
+                    if (proto.hasPrecommitToken() && retryAttemptDueToCommitProtocolExtension) {
+                      txnLogger.log(
+                          Level.FINE,
+                          "Missing commitTimestamp, response has precommit token "
+                              + "and client has already attempted commit retry");
+                      span.addAnnotation(
+                          "Missing commitTimestamp, response has precommit token "
+                              + "and client has already attempted commit retry");
+                    } else if (!proto.hasPrecommitToken()) {
+                      txnLogger.log(
+                          Level.FINE, "Missing commitTimestamp, response has no precommit token");
+                      span.addAnnotation(
+                          "Missing commitTimestamp, " + "response has no precommit token");
+                    }
                     throw newSpannerException(
-                        ErrorCode.INTERNAL, "Missing commitTimestamp:\n" + session.getName());
+                        ErrorCode.INTERNAL, "Missing commitTimestamp:\n" + session.getName() +
+                        "\nHas precommit token: " + proto.hasPrecommitToken() +
+                        "\nAlready attempted commit retry: " +
+                        retryAttemptDueToCommitProtocolExtension);
                   }
                   span.addAnnotation("Commit Done");
                   opSpan.end();


### PR DESCRIPTION
If the commit timestamp is missing from a commit response, we can have more visibility into the state of the commit by looking at whether it's in the commit-retry phase or not.