### PR TITLE
feat(bqjdbc): implement OTel SDK and exporting traces and logs to gcp

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
+++ b/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
@@ -314,6 +314,11 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry.contrib</groupId>
+      <artifactId>opentelemetry-gcp-auth-extension</artifactId>
+      <version>1.56.0-alpha</version>
+    </dependency>
 
     <!--  Test Dependencies  -->
     <dependency>

--- a/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
+++ b/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
@@ -301,6 +301,19 @@
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-context</artifactId>
     </dependency>
+    <!-- OpenTelemetry SDK and Exporters (will be shaded via existing 'io' relocation) -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+    </dependency>
 
     <!--  Test Dependencies  -->
     <dependency>

--- a/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
+++ b/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-logging</artifactId>
-      <version>3.33.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
+      <version>3.32.0</version><!-- {x-version-update:google-cloud-logging:current} -->
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -145,8 +145,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   Long connectionPoolSize;
   Long listenerPoolSize;
   String partnerToken;
-  Boolean enableGcpTraceExporter;
-  Boolean enableGcpLogExporter;
+  boolean enableGcpTraceExporter;
+  boolean enableGcpLogExporter;
   OpenTelemetry customOpenTelemetry;
   private OpenTelemetry openTelemetry;
   Tracer tracer =
@@ -969,34 +969,32 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   }
 
   private OpenTelemetry getOpenTelemetryInstance() {
-    boolean isTraceEnabled = Boolean.TRUE.equals(this.enableGcpTraceExporter);
-    boolean isLogEnabled = Boolean.TRUE.equals(this.enableGcpLogExporter);
     boolean hasCustomOtel = this.customOpenTelemetry != null;
 
     String effectiveProjectId =
         (this.gcpTelemetryProjectId != null) ? this.gcpTelemetryProjectId : this.catalog;
     String effectiveCredentials = resolveEffectiveCredentials();
 
-    validateTraceConfiguration(isTraceEnabled, effectiveCredentials);
+    validateTraceConfiguration(this.enableGcpTraceExporter, effectiveCredentials);
 
     OpenTelemetry openTelemetry =
         BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-            isTraceEnabled,
-            isLogEnabled,
+            this.enableGcpTraceExporter,
+            this.enableGcpLogExporter,
             this.customOpenTelemetry,
             effectiveCredentials,
             effectiveProjectId);
 
     Logging localLoggingClient = null;
-    if (isLogEnabled && !hasCustomOtel) {
+    if (this.enableGcpLogExporter && !hasCustomOtel) {
       localLoggingClient =
           BigQueryJdbcOpenTelemetry.createLoggingClient(
               true, null, effectiveCredentials, effectiveProjectId, this.credentials);
     }
 
-    if (isLogEnabled || hasCustomOtel) {
+    if (this.enableGcpLogExporter || hasCustomOtel) {
       BigQueryJdbcOpenTelemetry.registerConnection(
-          this.connectionId, openTelemetry, localLoggingClient, isLogEnabled);
+          this.connectionId, openTelemetry, localLoggingClient, this.enableGcpLogExporter);
     }
 
     return openTelemetry;

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -41,6 +41,7 @@ import com.google.cloud.bigquery.storage.v1.BigQueryReadSettings;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import com.google.cloud.http.HttpTransportOptions;
+import com.google.cloud.logging.Logging;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import java.io.IOException;
@@ -147,6 +148,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   Boolean enableGcpTraceExporter;
   Boolean enableGcpLogExporter;
   OpenTelemetry customOpenTelemetry;
+  private OpenTelemetry openTelemetry;
   Tracer tracer =
       OpenTelemetry.noop().getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME);
   DatabaseMetaData databaseMetaData;
@@ -281,6 +283,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
       this.enableGcpTraceExporter = ds.getEnableGcpTraceExporter();
       this.enableGcpLogExporter = ds.getEnableGcpLogExporter();
       this.customOpenTelemetry = ds.getCustomOpenTelemetry();
+      this.openTelemetry = getOpenTelemetryInstance();
       this.bigQuery = getBigQueryConnection();
     }
   }
@@ -966,29 +969,56 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   }
 
   private OpenTelemetry getOpenTelemetryInstance() {
+    boolean isTraceEnabled = Boolean.TRUE.equals(this.enableGcpTraceExporter);
+    boolean isLogEnabled = Boolean.TRUE.equals(this.enableGcpLogExporter);
+    boolean hasCustomOtel = this.customOpenTelemetry != null;
+
     String effectiveProjectId =
         (this.gcpTelemetryProjectId != null) ? this.gcpTelemetryProjectId : this.catalog;
+    String effectiveCredentials = resolveEffectiveCredentials();
 
-    String effectiveCredentials = this.gcpTelemetryCredentials;
-    String authTypeStr = this.overrideProperties.get("OAuthType");
+    validateTraceConfiguration(isTraceEnabled, effectiveCredentials);
 
-    if (effectiveCredentials == null && "0".equals(authTypeStr)) {
-      effectiveCredentials = this.overrideProperties.get("OAuthPvtKey");
+    OpenTelemetry openTelemetry =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(
+            isTraceEnabled,
+            isLogEnabled,
+            this.customOpenTelemetry,
+            effectiveCredentials,
+            effectiveProjectId);
+
+    Logging localLoggingClient = null;
+    if (isLogEnabled && !hasCustomOtel) {
+      localLoggingClient =
+          BigQueryJdbcOpenTelemetry.createLoggingClient(
+              true, null, effectiveCredentials, effectiveProjectId, this.credentials);
     }
 
-    if (Boolean.TRUE.equals(this.enableGcpTraceExporter) && effectiveCredentials == null) {
+    if (isLogEnabled || hasCustomOtel) {
+      BigQueryJdbcOpenTelemetry.registerConnection(
+          this.connectionId, openTelemetry, localLoggingClient, isLogEnabled);
+    }
+
+    return openTelemetry;
+  }
+
+  private String resolveEffectiveCredentials() {
+    String creds = this.gcpTelemetryCredentials;
+    String authTypeStr = this.overrideProperties.get("OAuthType");
+    if (creds == null && "0".equals(authTypeStr)) {
+      return this.overrideProperties.get("OAuthPvtKey");
+    }
+    return creds;
+  }
+
+  private void validateTraceConfiguration(boolean isTraceEnabled, String effectiveCredentials) {
+    if (isTraceEnabled && effectiveCredentials == null) {
+      String authTypeStr = this.overrideProperties.get("OAuthType");
       if (!"0".equals(authTypeStr) && !"3".equals(authTypeStr)) {
         throw new BigQueryJdbcRuntimeException(
             "Exporting traces to Google Cloud is only supported when using Application Default Credentials (ADC) or Service Account authentication.");
       }
     }
-
-    return BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-        Boolean.TRUE.equals(this.enableGcpTraceExporter),
-        Boolean.TRUE.equals(this.enableGcpLogExporter),
-        this.customOpenTelemetry,
-        effectiveCredentials,
-        effectiveProjectId);
   }
 
   private BigQuery getBigQueryConnection() {
@@ -1027,15 +1057,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     if (this.httpTransportOptions != null) {
       bigQueryOptions.setTransportOptions(this.httpTransportOptions);
     }
-    OpenTelemetry openTelemetry = getOpenTelemetryInstance();
-
-    if (Boolean.TRUE.equals(this.enableGcpLogExporter) || this.customOpenTelemetry != null) {
-      BigQueryJdbcOpenTelemetry.registerConnection(
-          this.connectionId, openTelemetry, null, this.enableGcpLogExporter);
-    }
-
     if (Boolean.TRUE.equals(this.enableGcpTraceExporter) || this.customOpenTelemetry != null) {
-      this.tracer = BigQueryJdbcOpenTelemetry.getTracer(openTelemetry);
+      this.tracer = BigQueryJdbcOpenTelemetry.getTracer(this.openTelemetry);
       bigQueryOptions.setOpenTelemetryTracer(this.tracer);
     }
 
@@ -1087,9 +1110,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     bigQueryReadSettings.setTransportChannelProvider(activeProvider);
 
-    OpenTelemetry openTelemetry = getOpenTelemetryInstance();
     if (Boolean.TRUE.equals(this.enableGcpTraceExporter) || this.customOpenTelemetry != null) {
-      bigQueryReadSettings.setOpenTelemetryTracerProvider(openTelemetry.getTracerProvider());
+      bigQueryReadSettings.setOpenTelemetryTracerProvider(this.openTelemetry.getTracerProvider());
     }
 
     return BigQueryReadClient.create(bigQueryReadSettings.build());

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -88,6 +88,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   int transactionIsolation;
   List<SQLWarning> sqlWarnings;
   String catalog;
+  String gcpTelemetryCredentials;
+  String gcpTelemetryProjectId;
   int holdability;
   long retryTimeoutInSeconds;
   Duration retryTimeoutDuration;
@@ -169,6 +171,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
       this.labels = ds.getLabels() != null ? ds.getLabels() : new java.util.HashMap<>();
       this.maxBytesBilled = ds.getMaximumBytesBilled();
+      this.gcpTelemetryCredentials = ds.getGcpTelemetryCredentials();
+      this.gcpTelemetryProjectId = ds.getGcpTelemetryProjectId();
       this.retryTimeoutInSeconds = ds.getTimeout();
       this.retryTimeoutDuration = Duration.ofMillis(retryTimeoutInSeconds * 1000L);
       this.retryInitialDelayInSeconds = ds.getRetryInitialDelay();
@@ -1000,14 +1004,18 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     OpenTelemetry openTelemetry =
         BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-            this.enableGcpTraceExporter, this.enableGcpLogExporter, this.customOpenTelemetry);
+            this.enableGcpTraceExporter,
+            this.enableGcpLogExporter,
+            this.customOpenTelemetry,
+            this.gcpTelemetryCredentials,
+            this.gcpTelemetryProjectId);
 
-    if (this.enableGcpLogExporter || this.customOpenTelemetry != null) {
+    if (Boolean.TRUE.equals(this.enableGcpLogExporter) || this.customOpenTelemetry != null) {
       BigQueryJdbcOpenTelemetry.registerConnection(
           this.connectionId, openTelemetry, null, this.enableGcpLogExporter);
     }
 
-    if (this.enableGcpTraceExporter || this.customOpenTelemetry != null) {
+    if (Boolean.TRUE.equals(this.enableGcpTraceExporter) || this.customOpenTelemetry != null) {
       this.tracer = BigQueryJdbcOpenTelemetry.getTracer(openTelemetry);
       bigQueryOptions.setOpenTelemetryTracer(this.tracer);
     }
@@ -1062,8 +1070,12 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     OpenTelemetry openTelemetry =
         BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-            this.enableGcpTraceExporter, this.enableGcpLogExporter, this.customOpenTelemetry);
-    if (this.enableGcpTraceExporter || this.customOpenTelemetry != null) {
+            this.enableGcpTraceExporter,
+            this.enableGcpLogExporter,
+            this.customOpenTelemetry,
+            this.gcpTelemetryCredentials,
+            this.gcpTelemetryProjectId);
+    if (Boolean.TRUE.equals(this.enableGcpTraceExporter) || this.customOpenTelemetry != null) {
       bigQueryReadSettings.setOpenTelemetryTracerProvider(openTelemetry.getTracerProvider());
     }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1004,8 +1004,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     OpenTelemetry openTelemetry =
         BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-            this.enableGcpTraceExporter,
-            this.enableGcpLogExporter,
+            Boolean.TRUE.equals(this.enableGcpTraceExporter),
+            Boolean.TRUE.equals(this.enableGcpLogExporter),
             this.customOpenTelemetry,
             this.gcpTelemetryCredentials,
             this.gcpTelemetryProjectId);
@@ -1070,8 +1070,8 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     OpenTelemetry openTelemetry =
         BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-            this.enableGcpTraceExporter,
-            this.enableGcpLogExporter,
+            Boolean.TRUE.equals(this.enableGcpTraceExporter),
+            Boolean.TRUE.equals(this.enableGcpLogExporter),
             this.customOpenTelemetry,
             this.gcpTelemetryCredentials,
             this.gcpTelemetryProjectId);

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -965,6 +965,32 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     this.openStatements.remove(statement);
   }
 
+  private OpenTelemetry getOpenTelemetryInstance() {
+    String effectiveProjectId =
+        (this.gcpTelemetryProjectId != null) ? this.gcpTelemetryProjectId : this.catalog;
+
+    String effectiveCredentials = this.gcpTelemetryCredentials;
+    String authTypeStr = this.overrideProperties.get("OAuthType");
+
+    if (effectiveCredentials == null && "0".equals(authTypeStr)) {
+      effectiveCredentials = this.overrideProperties.get("OAuthPvtKey");
+    }
+
+    if (Boolean.TRUE.equals(this.enableGcpTraceExporter) && effectiveCredentials == null) {
+      if (!"0".equals(authTypeStr) && !"3".equals(authTypeStr)) {
+        throw new BigQueryJdbcRuntimeException(
+            "Exporting traces to Google Cloud is only supported when using Application Default Credentials (ADC) or Service Account authentication.");
+      }
+    }
+
+    return BigQueryJdbcOpenTelemetry.getOpenTelemetry(
+        Boolean.TRUE.equals(this.enableGcpTraceExporter),
+        Boolean.TRUE.equals(this.enableGcpLogExporter),
+        this.customOpenTelemetry,
+        effectiveCredentials,
+        effectiveProjectId);
+  }
+
   private BigQuery getBigQueryConnection() {
     BigQueryOptions.Builder bigQueryOptions = BigQueryOptions.newBuilder();
     if (this.retryTimeoutInSeconds > 0L
@@ -1001,14 +1027,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     if (this.httpTransportOptions != null) {
       bigQueryOptions.setTransportOptions(this.httpTransportOptions);
     }
-
-    OpenTelemetry openTelemetry =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-            Boolean.TRUE.equals(this.enableGcpTraceExporter),
-            Boolean.TRUE.equals(this.enableGcpLogExporter),
-            this.customOpenTelemetry,
-            this.gcpTelemetryCredentials,
-            this.gcpTelemetryProjectId);
+    OpenTelemetry openTelemetry = getOpenTelemetryInstance();
 
     if (Boolean.TRUE.equals(this.enableGcpLogExporter) || this.customOpenTelemetry != null) {
       BigQueryJdbcOpenTelemetry.registerConnection(
@@ -1068,13 +1087,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     bigQueryReadSettings.setTransportChannelProvider(activeProvider);
 
-    OpenTelemetry openTelemetry =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(
-            Boolean.TRUE.equals(this.enableGcpTraceExporter),
-            Boolean.TRUE.equals(this.enableGcpLogExporter),
-            this.customOpenTelemetry,
-            this.gcpTelemetryCredentials,
-            this.gcpTelemetryProjectId);
+    OpenTelemetry openTelemetry = getOpenTelemetryInstance();
     if (Boolean.TRUE.equals(this.enableGcpTraceExporter) || this.customOpenTelemetry != null) {
       bigQueryReadSettings.setOpenTelemetryTracerProvider(openTelemetry.getTracerProvider());
     }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1004,17 +1004,21 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
   private String resolveEffectiveCredentials() {
     String creds = this.gcpTelemetryCredentials;
-    String authTypeStr = this.overrideProperties.get("OAuthType");
-    if (creds == null && "0".equals(authTypeStr)) {
-      return this.overrideProperties.get("OAuthPvtKey");
+    String authTypeStr = this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME);
+    if (creds == null
+        && BigQueryJdbcOAuthUtility.AuthType.GOOGLE_SERVICE_ACCOUNT.name().equals(authTypeStr)) {
+      return this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_PVT_KEY_PROPERTY_NAME);
     }
     return creds;
   }
 
   private void validateTraceConfiguration(boolean isTraceEnabled, String effectiveCredentials) {
     if (isTraceEnabled && effectiveCredentials == null) {
-      String authTypeStr = this.overrideProperties.get("OAuthType");
-      if (!"0".equals(authTypeStr) && !"3".equals(authTypeStr)) {
+      String authTypeStr = this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME);
+      if (!BigQueryJdbcOAuthUtility.AuthType.GOOGLE_SERVICE_ACCOUNT.name().equals(authTypeStr)
+          && !BigQueryJdbcOAuthUtility.AuthType.APPLICATION_DEFAULT_CREDENTIALS
+              .name()
+              .equals(authTypeStr)) {
         throw new BigQueryJdbcRuntimeException(
             "Exporting traces to Google Cloud is only supported when using Application Default Credentials (ADC) or Service Account authentication.");
       }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOAuthUtility.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOAuthUtility.java
@@ -307,7 +307,7 @@ final class BigQueryJdbcOAuthUtility {
     }
   }
 
-  private static boolean isJson(byte[] value) {
+  static boolean isJson(byte[] value) {
     try {
       // This is done this way to ensure strict Json parsing
       // https://github.com/google/gson/issues/1208#issuecomment-2120764686

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -45,7 +45,7 @@ public class BigQueryJdbcOpenTelemetry {
   private static final String EXPORTER_NONE = "none";
   private static final String EXPORTER_OTLP = "otlp";
 
-  private static final ConcurrentHashMap<String, io.opentelemetry.sdk.OpenTelemetrySdk> sdkCache =
+  private static final ConcurrentHashMap<String, OpenTelemetrySdk> sdkCache =
       new ConcurrentHashMap<>();
 
   static class TelemetryConfig {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -17,6 +17,7 @@
 package com.google.cloud.bigquery.jdbc;
 
 import com.google.cloud.logging.Logging;
+import com.google.common.hash.Hashing;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -68,6 +69,14 @@ public class BigQueryJdbcOpenTelemetry {
 
   static {
     ensureGlobalHandlerAttached();
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  for (OpenTelemetrySdk sdk : sdkCache.values()) {
+                    sdk.close();
+                  }
+                }));
   }
 
   public static void ensureGlobalHandlerAttached() {
@@ -105,6 +114,17 @@ public class BigQueryJdbcOpenTelemetry {
     return connectionConfigs.values();
   }
 
+  private static String getCredentialsIdentifier(String credentials) {
+    if (credentials == null) {
+      return "";
+    }
+    byte[] credsBytes = credentials.getBytes(StandardCharsets.UTF_8);
+    if (BigQueryJdbcOAuthUtility.isJson(credsBytes)) {
+      return Hashing.sha256().hashString(credentials, StandardCharsets.UTF_8).toString();
+    }
+    return credentials;
+  }
+
   /**
    * Initializes or returns the OpenTelemetry instance based on hybrid logic. Prefer
    * customOpenTelemetry if provided; fallback to an auto-configured GCP exporter if requested.
@@ -126,7 +146,11 @@ public class BigQueryJdbcOpenTelemetry {
       String key =
           (gcpTelemetryProjectId != null ? gcpTelemetryProjectId : "")
               + ":"
-              + (gcpTelemetryCredentials != null ? gcpTelemetryCredentials : "");
+              + getCredentialsIdentifier(gcpTelemetryCredentials)
+              + ":"
+              + enableGcpTraceExporter
+              + ":"
+              + enableGcpLogExporter;
       return sdkCache.computeIfAbsent(
           key,
           k -> {
@@ -160,8 +184,6 @@ public class BigQueryJdbcOpenTelemetry {
                 AutoConfiguredOpenTelemetrySdk.builder().addPropertiesSupplier(() -> props).build();
 
             OpenTelemetrySdk sdk = autoConfigured.getOpenTelemetrySdk();
-
-            Runtime.getRuntime().addShutdownHook(new Thread(sdk::close));
 
             return sdk;
           });

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -16,7 +16,10 @@
 
 package com.google.cloud.bigquery.jdbc;
 
+import com.google.auth.Credentials;
+import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
 import com.google.cloud.logging.Logging;
+import com.google.cloud.logging.LoggingOptions;
 import com.google.common.hash.Hashing;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
@@ -139,7 +142,61 @@ public class BigQueryJdbcOpenTelemetry {
   }
 
   public static void unregisterConnection(String connectionId) {
-    connectionConfigs.remove(connectionId);
+    TelemetryConfig config = connectionConfigs.remove(connectionId);
+    if (config != null && config.loggingClient != null) {
+      try {
+        config.loggingClient.close();
+      } catch (Exception e) {
+        LOG.warning("Failed to close Logging client during unregister: %s", e.getMessage());
+      }
+    }
+  }
+
+  public static Logging createLoggingClient(
+      boolean enableGcpLogExporter,
+      OpenTelemetry customOpenTelemetry,
+      String effectiveCredentials,
+      String effectiveProjectId,
+      Credentials fallbackCredentials) {
+
+    if (enableGcpLogExporter && customOpenTelemetry == null) {
+      try {
+        Credentials credentials;
+        if (effectiveCredentials != null) {
+          credentials = resolveCredentialsFromString(effectiveCredentials);
+        } else {
+          credentials = fallbackCredentials;
+        }
+
+        LoggingOptions.Builder loggingOptionsBuilder =
+            LoggingOptions.newBuilder().setProjectId(effectiveProjectId);
+        if (credentials != null) {
+          loggingOptionsBuilder.setCredentials(credentials);
+        }
+        return loggingOptionsBuilder.build().getService();
+      } catch (Exception e) {
+        throw new BigQueryJdbcRuntimeException("Failed to initialize Logging client", e);
+      }
+    }
+    return null;
+  }
+
+  private static Credentials resolveCredentialsFromString(String credsString) {
+    Map<String, String> authProperties = new java.util.HashMap<>();
+    authProperties.put(BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME, "0"); // Service Account
+
+    byte[] credsBytes = credsString.getBytes(StandardCharsets.UTF_8);
+    if (BigQueryJdbcOAuthUtility.isJson(credsBytes)) {
+      authProperties.put(BigQueryJdbcUrlUtility.OAUTH_PVT_KEY_PROPERTY_NAME, credsString);
+    } else {
+      authProperties.put(BigQueryJdbcUrlUtility.OAUTH_PVT_KEY_PATH_PROPERTY_NAME, credsString);
+    }
+
+    return BigQueryJdbcOAuthUtility.getCredentials(
+        authProperties,
+        new java.util.HashMap<>(),
+        false,
+        BigQueryJdbcOpenTelemetry.class.getName());
   }
 
   public static TelemetryConfig getConnectionConfig(String connectionId) {
@@ -171,58 +228,58 @@ public class BigQueryJdbcOpenTelemetry {
       OpenTelemetry customOpenTelemetry,
       String gcpTelemetryCredentials,
       String gcpTelemetryProjectId) {
+
     if (customOpenTelemetry != null) {
       return customOpenTelemetry;
     }
 
     // NOTE: Currently, tracing only fully supports Application Default Credentials (ADC).
     // Once b/503721589 is completed, Service Account (SA) will work as well.
-
-    if (enableGcpTraceExporter || enableGcpLogExporter) {
-      SdkCacheKey key =
-          new SdkCacheKey(
-              gcpTelemetryProjectId,
-              getCredentialsIdentifier(gcpTelemetryCredentials),
-              enableGcpTraceExporter);
-      return sdkCache.computeIfAbsent(
-          key,
-          k -> {
-            Map<String, String> props = new HashMap<>();
-            if (gcpTelemetryCredentials != null) {
-              byte[] credsBytes = gcpTelemetryCredentials.getBytes(StandardCharsets.UTF_8);
-              if (BigQueryJdbcOAuthUtility.isJson(credsBytes)) {
-                props.put(CREDENTIALS_JSON, gcpTelemetryCredentials);
-              } else {
-                props.put(CREDENTIALS_PATH, gcpTelemetryCredentials);
-              }
-            }
-
-            if (enableGcpTraceExporter) {
-              props.put(OTEL_TRACES_EXPORTER, EXPORTER_OTLP);
-              props.put(OTEL_EXPORTER_OTLP_ENDPOINT, OTLP_ENDPOINT_VALUE);
-            } else {
-              props.put(OTEL_TRACES_EXPORTER, EXPORTER_NONE);
-            }
-
-            // Logs are handled directly via GCP logging
-            props.put(OTEL_LOGS_EXPORTER, EXPORTER_NONE);
-            // Metrics are deferred to a future phase
-            props.put(OTEL_METRICS_EXPORTER, EXPORTER_NONE);
-
-            if (gcpTelemetryProjectId != null) {
-              props.put(GOOGLE_CLOUD_PROJECT, gcpTelemetryProjectId);
-            }
-
-            AutoConfiguredOpenTelemetrySdk autoConfigured =
-                AutoConfiguredOpenTelemetrySdk.builder().addPropertiesSupplier(() -> props).build();
-
-            OpenTelemetrySdk sdk = autoConfigured.getOpenTelemetrySdk();
-
-            return sdk;
-          });
+    if (!enableGcpTraceExporter && !enableGcpLogExporter) {
+      return OpenTelemetry.noop();
     }
 
-    return OpenTelemetry.noop();
+    SdkCacheKey key =
+        new SdkCacheKey(
+            gcpTelemetryProjectId,
+            getCredentialsIdentifier(gcpTelemetryCredentials),
+            enableGcpTraceExporter);
+    return sdkCache.computeIfAbsent(
+        key,
+        k -> {
+          Map<String, String> props = new HashMap<>();
+          if (gcpTelemetryCredentials != null) {
+            byte[] credsBytes = gcpTelemetryCredentials.getBytes(StandardCharsets.UTF_8);
+            if (BigQueryJdbcOAuthUtility.isJson(credsBytes)) {
+              props.put(CREDENTIALS_JSON, gcpTelemetryCredentials);
+            } else {
+              props.put(CREDENTIALS_PATH, gcpTelemetryCredentials);
+            }
+          }
+
+          if (enableGcpTraceExporter) {
+            props.put(OTEL_TRACES_EXPORTER, EXPORTER_OTLP);
+            props.put(OTEL_EXPORTER_OTLP_ENDPOINT, OTLP_ENDPOINT_VALUE);
+          } else {
+            props.put(OTEL_TRACES_EXPORTER, EXPORTER_NONE);
+          }
+
+          // Logs are handled directly via GCP logging
+          props.put(OTEL_LOGS_EXPORTER, EXPORTER_NONE);
+          // Metrics are deferred to a future phase
+          props.put(OTEL_METRICS_EXPORTER, EXPORTER_NONE);
+
+          if (gcpTelemetryProjectId != null) {
+            props.put(GOOGLE_CLOUD_PROJECT, gcpTelemetryProjectId);
+          }
+
+          AutoConfiguredOpenTelemetrySdk autoConfigured =
+              AutoConfiguredOpenTelemetrySdk.builder().addPropertiesSupplier(() -> props).build();
+
+          OpenTelemetrySdk sdk = autoConfigured.getOpenTelemetrySdk();
+
+          return sdk;
+        });
   }
 
   /** Gets a Tracer for the JDBC driver instrumentation scope. */

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
@@ -46,7 +47,38 @@ public class BigQueryJdbcOpenTelemetry {
   private static final String EXPORTER_NONE = "none";
   private static final String EXPORTER_OTLP = "otlp";
 
-  private static final ConcurrentHashMap<String, OpenTelemetrySdk> sdkCache =
+  private static final class SdkCacheKey {
+    private final String projectId;
+    private final String credentialsHashOrPath;
+    private final boolean enableTrace;
+    private final boolean enableLog;
+
+    SdkCacheKey(
+        String projectId, String credentialsHashOrPath, boolean enableTrace, boolean enableLog) {
+      this.projectId = projectId;
+      this.credentialsHashOrPath = credentialsHashOrPath;
+      this.enableTrace = enableTrace;
+      this.enableLog = enableLog;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SdkCacheKey that = (SdkCacheKey) o;
+      return enableTrace == that.enableTrace
+          && enableLog == that.enableLog
+          && Objects.equals(projectId, that.projectId)
+          && Objects.equals(credentialsHashOrPath, that.credentialsHashOrPath);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(projectId, credentialsHashOrPath, enableTrace, enableLog);
+    }
+  }
+
+  private static final ConcurrentHashMap<SdkCacheKey, OpenTelemetrySdk> sdkCache =
       new ConcurrentHashMap<>();
 
   static class TelemetryConfig {
@@ -143,14 +175,12 @@ public class BigQueryJdbcOpenTelemetry {
     // Once b/503721589 is completed, Service Account (SA) will work as well.
 
     if (enableGcpTraceExporter || enableGcpLogExporter) {
-      String key =
-          (gcpTelemetryProjectId != null ? gcpTelemetryProjectId : "")
-              + ":"
-              + getCredentialsIdentifier(gcpTelemetryCredentials)
-              + ":"
-              + enableGcpTraceExporter
-              + ":"
-              + enableGcpLogExporter;
+      SdkCacheKey key =
+          new SdkCacheKey(
+              gcpTelemetryProjectId,
+              getCredentialsIdentifier(gcpTelemetryCredentials),
+              enableGcpTraceExporter,
+              enableGcpLogExporter);
       return sdkCache.computeIfAbsent(
           key,
           k -> {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -159,26 +159,27 @@ public class BigQueryJdbcOpenTelemetry {
       String effectiveProjectId,
       Credentials fallbackCredentials) {
 
-    if (enableGcpLogExporter && customOpenTelemetry == null) {
-      try {
-        Credentials credentials;
-        if (effectiveCredentials != null) {
-          credentials = resolveCredentialsFromString(effectiveCredentials);
-        } else {
-          credentials = fallbackCredentials;
-        }
-
-        LoggingOptions.Builder loggingOptionsBuilder =
-            LoggingOptions.newBuilder().setProjectId(effectiveProjectId);
-        if (credentials != null) {
-          loggingOptionsBuilder.setCredentials(credentials);
-        }
-        return loggingOptionsBuilder.build().getService();
-      } catch (Exception e) {
-        throw new BigQueryJdbcRuntimeException("Failed to initialize Logging client", e);
-      }
+    if (!enableGcpLogExporter || customOpenTelemetry != null) {
+      return null;
     }
-    return null;
+
+    try {
+      Credentials credentials;
+      if (effectiveCredentials != null) {
+        credentials = resolveCredentialsFromString(effectiveCredentials);
+      } else {
+        credentials = fallbackCredentials;
+      }
+
+      LoggingOptions.Builder loggingOptionsBuilder =
+          LoggingOptions.newBuilder().setProjectId(effectiveProjectId);
+      if (credentials != null) {
+        loggingOptionsBuilder.setCredentials(credentials);
+      }
+      return loggingOptionsBuilder.build().getService();
+    } catch (Exception e) {
+      throw new BigQueryJdbcRuntimeException("Failed to initialize Logging client", e);
+    }
   }
 
   private static Credentials resolveCredentialsFromString(String credsString) {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -46,19 +46,18 @@ public class BigQueryJdbcOpenTelemetry {
   private static final String OTLP_ENDPOINT_VALUE = "https://telemetry.googleapis.com:443";
   private static final String EXPORTER_NONE = "none";
   private static final String EXPORTER_OTLP = "otlp";
+  private static final BigQueryJdbcCustomLogger LOG =
+      new BigQueryJdbcCustomLogger("BigQueryJdbcOpenTelemetry");
 
   private static final class SdkCacheKey {
     private final String projectId;
     private final String credentialsHashOrPath;
     private final boolean enableTrace;
-    private final boolean enableLog;
 
-    SdkCacheKey(
-        String projectId, String credentialsHashOrPath, boolean enableTrace, boolean enableLog) {
+    SdkCacheKey(String projectId, String credentialsHashOrPath, boolean enableTrace) {
       this.projectId = projectId;
       this.credentialsHashOrPath = credentialsHashOrPath;
       this.enableTrace = enableTrace;
-      this.enableLog = enableLog;
     }
 
     @Override
@@ -67,14 +66,13 @@ public class BigQueryJdbcOpenTelemetry {
       if (o == null || getClass() != o.getClass()) return false;
       SdkCacheKey that = (SdkCacheKey) o;
       return enableTrace == that.enableTrace
-          && enableLog == that.enableLog
           && Objects.equals(projectId, that.projectId)
           && Objects.equals(credentialsHashOrPath, that.credentialsHashOrPath);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(projectId, credentialsHashOrPath, enableTrace, enableLog);
+      return Objects.hash(projectId, credentialsHashOrPath, enableTrace);
     }
   }
 
@@ -106,7 +104,13 @@ public class BigQueryJdbcOpenTelemetry {
             new Thread(
                 () -> {
                   for (OpenTelemetrySdk sdk : sdkCache.values()) {
-                    sdk.close();
+                    try {
+                      sdk.close();
+                    } catch (Exception e) {
+                      // Ignore failures during shutdown to ensure all SDKs are attempted to be
+                      // closed. Logging is avoided here because the logging system might have
+                      // already been shut down by the JVM.
+                    }
                   }
                 }));
   }
@@ -179,8 +183,7 @@ public class BigQueryJdbcOpenTelemetry {
           new SdkCacheKey(
               gcpTelemetryProjectId,
               getCredentialsIdentifier(gcpTelemetryCredentials),
-              enableGcpTraceExporter,
-              enableGcpLogExporter);
+              enableGcpTraceExporter);
       return sdkCache.computeIfAbsent(
           key,
           k -> {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -19,7 +19,12 @@ package com.google.cloud.bigquery.jdbc;
 import com.google.cloud.logging.Logging;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
@@ -29,6 +34,19 @@ public class BigQueryJdbcOpenTelemetry {
   static final String INSTRUMENTATION_SCOPE_NAME = "com.google.cloud.bigquery.jdbc";
   static final String BIGQUERY_NAMESPACE = "com.google.cloud.bigquery";
   public static final String CONNECTION_ID_BAGGAGE_KEY = "jdbc.connection_id";
+  private static final String OTEL_TRACES_EXPORTER = "otel.traces.exporter";
+  private static final String OTEL_EXPORTER_OTLP_ENDPOINT = "otel.exporter.otlp.endpoint";
+  private static final String OTEL_LOGS_EXPORTER = "otel.logs.exporter";
+  private static final String OTEL_METRICS_EXPORTER = "otel.metrics.exporter";
+  private static final String GOOGLE_CLOUD_PROJECT = "google.cloud.project";
+  private static final String CREDENTIALS_JSON = "google.cloud.credentials.json";
+  private static final String CREDENTIALS_PATH = "google.cloud.credentials.path";
+  private static final String OTLP_ENDPOINT_VALUE = "https://telemetry.googleapis.com:443";
+  private static final String EXPORTER_NONE = "none";
+  private static final String EXPORTER_OTLP = "otlp";
+
+  private static final ConcurrentHashMap<String, io.opentelemetry.sdk.OpenTelemetrySdk> sdkCache =
+      new ConcurrentHashMap<>();
 
   static class TelemetryConfig {
     final OpenTelemetry openTelemetry;
@@ -36,10 +54,10 @@ public class BigQueryJdbcOpenTelemetry {
     final boolean useDirectGcpLogging;
 
     TelemetryConfig(
-        OpenTelemetry openTelemetry, Logging loggingClient, boolean useDirectGcpLogging) {
+        OpenTelemetry openTelemetry, Logging loggingClient, Boolean useDirectGcpLogging) {
       this.openTelemetry = openTelemetry;
       this.loggingClient = loggingClient;
-      this.useDirectGcpLogging = useDirectGcpLogging;
+      this.useDirectGcpLogging = useDirectGcpLogging != null ? useDirectGcpLogging : false;
     }
   }
 
@@ -70,7 +88,7 @@ public class BigQueryJdbcOpenTelemetry {
       String connectionId,
       OpenTelemetry openTelemetry,
       Logging loggingClient,
-      boolean useDirectGcpLogging) {
+      Boolean useDirectGcpLogging) {
     connectionConfigs.put(
         connectionId, new TelemetryConfig(openTelemetry, loggingClient, useDirectGcpLogging));
   }
@@ -94,14 +112,59 @@ public class BigQueryJdbcOpenTelemetry {
   public static OpenTelemetry getOpenTelemetry(
       boolean enableGcpTraceExporter,
       boolean enableGcpLogExporter,
-      OpenTelemetry customOpenTelemetry) {
+      OpenTelemetry customOpenTelemetry,
+      String gcpTelemetryCredentials,
+      String gcpTelemetryProjectId) {
     if (customOpenTelemetry != null) {
       return customOpenTelemetry;
     }
 
+    // NOTE: Currently, tracing only fully supports Application Default Credentials (ADC).
+    // Once b/503721589 is completed, Service Account (SA) will work as well.
+
     if (enableGcpTraceExporter || enableGcpLogExporter) {
-      // TODO(b/491238299): Initialize and return GCP-specific auto-configured SDK
-      return OpenTelemetry.noop();
+      String key =
+          (gcpTelemetryProjectId != null ? gcpTelemetryProjectId : "")
+              + ":"
+              + (gcpTelemetryCredentials != null ? gcpTelemetryCredentials : "");
+      return sdkCache.computeIfAbsent(
+          key,
+          k -> {
+            Map<String, String> props = new HashMap<>();
+            if (gcpTelemetryCredentials != null) {
+              byte[] credsBytes = gcpTelemetryCredentials.getBytes(StandardCharsets.UTF_8);
+              if (BigQueryJdbcOAuthUtility.isJson(credsBytes)) {
+                props.put(CREDENTIALS_JSON, gcpTelemetryCredentials);
+              } else {
+                props.put(CREDENTIALS_PATH, gcpTelemetryCredentials);
+              }
+            }
+
+            if (enableGcpTraceExporter) {
+              props.put(OTEL_TRACES_EXPORTER, EXPORTER_OTLP);
+              props.put(OTEL_EXPORTER_OTLP_ENDPOINT, OTLP_ENDPOINT_VALUE);
+            } else {
+              props.put(OTEL_TRACES_EXPORTER, EXPORTER_NONE);
+            }
+
+            // Logs are handled directly via GCP logging
+            props.put(OTEL_LOGS_EXPORTER, EXPORTER_NONE);
+            // Metrics are deferred to a future phase
+            props.put(OTEL_METRICS_EXPORTER, EXPORTER_NONE);
+
+            if (gcpTelemetryProjectId != null) {
+              props.put(GOOGLE_CLOUD_PROJECT, gcpTelemetryProjectId);
+            }
+
+            AutoConfiguredOpenTelemetrySdk autoConfigured =
+                AutoConfiguredOpenTelemetrySdk.builder().addPropertiesSupplier(() -> props).build();
+
+            OpenTelemetrySdk sdk = autoConfigured.getOpenTelemetrySdk();
+
+            Runtime.getRuntime().addShutdownHook(new Thread(sdk::close));
+
+            return sdk;
+          });
     }
 
     return OpenTelemetry.noop();

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
@@ -98,6 +98,8 @@ final class BigQueryJdbcUrlUtility {
   static final String BIGQUERY_ENDPOINT_OVERRIDE_PROPERTY_NAME = "BIGQUERY";
   static final String STS_ENDPOINT_OVERRIDE_PROPERTY_NAME = "STS";
   static final String OAUTH_ACCESS_TOKEN_PROPERTY_NAME = "OAuthAccessToken";
+  static final String GCP_TELEMETRY_PROJECT_ID_PROPERTY_NAME = "gcpTelemetryProjectId";
+  static final String GCP_TELEMETRY_CREDENTIALS_PROPERTY_NAME = "gcpTelemetryCredentials";
   static final String OAUTH_ACCESS_TOKEN_READONLY_PROPERTY_NAME = "OAuthAccessTokenReadonly";
   static final String OAUTH_REFRESH_TOKEN_PROPERTY_NAME = "OAuthRefreshToken";
   static final String OAUTH_CLIENT_ID_PROPERTY_NAME = "OAuthClientId";
@@ -628,6 +630,14 @@ final class BigQueryJdbcUrlUtility {
                       .setDescription(
                           "Enables or disables GCP OpenTelemetry Log exporter. Disabled by default.")
                       .setDefaultValue(String.valueOf(DEFAULT_ENABLE_GCP_LOG_EXPORTER_VALUE))
+                      .build(),
+                  BigQueryConnectionProperty.newBuilder()
+                      .setName(GCP_TELEMETRY_CREDENTIALS_PROPERTY_NAME)
+                      .setDescription("Path or raw JSON of credentials for OTel exporter.")
+                      .build(),
+                  BigQueryConnectionProperty.newBuilder()
+                      .setName(GCP_TELEMETRY_PROJECT_ID_PROPERTY_NAME)
+                      .setDescription("GCP Project ID for OTel exporter.")
                       .build())));
 
   private static final List<String> NETWORK_PROPERTIES =

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
@@ -58,6 +58,8 @@ public class DataSource implements javax.sql.DataSource {
   private String logLevel;
   private Boolean enableSession;
   private String logPath;
+  private String gcpTelemetryProjectId;
+  private String gcpTelemetryCredentials;
   private Integer oAuthType;
   private String oAuthServiceAcctEmail;
   private String oAuthPvtKeyPath;
@@ -134,6 +136,12 @@ public class DataSource implements javax.sql.DataSource {
           .put(BigQueryJdbcUrlUtility.PROJECT_ID_PROPERTY_NAME, DataSource::setProjectId)
           .put(BigQueryJdbcUrlUtility.DEFAULT_DATASET_PROPERTY_NAME, DataSource::setDefaultDataset)
           .put(BigQueryJdbcUrlUtility.LOCATION_PROPERTY_NAME, DataSource::setLocation)
+          .put(
+              BigQueryJdbcUrlUtility.GCP_TELEMETRY_PROJECT_ID_PROPERTY_NAME,
+              DataSource::setGcpTelemetryProjectId)
+          .put(
+              BigQueryJdbcUrlUtility.GCP_TELEMETRY_CREDENTIALS_PROPERTY_NAME,
+              DataSource::setGcpTelemetryCredentials)
           .put(
               BigQueryJdbcUrlUtility.ENABLE_HTAPI_PROPERTY_NAME,
               (ds, val) ->
@@ -865,6 +873,22 @@ public class DataSource implements javax.sql.DataSource {
 
   public void setLogPath(String logPath) {
     this.logPath = logPath;
+  }
+
+  public String getGcpTelemetryProjectId() {
+    return gcpTelemetryProjectId;
+  }
+
+  public void setGcpTelemetryProjectId(String gcpTelemetryProjectId) {
+    this.gcpTelemetryProjectId = gcpTelemetryProjectId;
+  }
+
+  public String getGcpTelemetryCredentials() {
+    return gcpTelemetryCredentials;
+  }
+
+  public void setGcpTelemetryCredentials(String gcpTelemetryCredentials) {
+    this.gcpTelemetryCredentials = gcpTelemetryCredentials;
   }
 
   public String getUniverseDomain() {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
@@ -117,8 +117,10 @@ public class DataSource implements javax.sql.DataSource {
   private String privateServiceConnect;
   private Long connectionPoolSize;
   private Long listenerPoolSize;
-  private Boolean enableGcpTraceExporter;
-  private Boolean enableGcpLogExporter;
+  private boolean enableGcpTraceExporter =
+      BigQueryJdbcUrlUtility.DEFAULT_ENABLE_GCP_TRACE_EXPORTER_VALUE;
+  private boolean enableGcpLogExporter =
+      BigQueryJdbcUrlUtility.DEFAULT_ENABLE_GCP_LOG_EXPORTER_VALUE;
   private OpenTelemetry customOpenTelemetry;
 
   // Make sure the JDBC driver class is loaded.
@@ -656,12 +658,12 @@ public class DataSource implements javax.sql.DataSource {
           BigQueryJdbcUrlUtility.LISTENER_POOL_SIZE_PROPERTY_NAME,
           String.valueOf(this.listenerPoolSize));
     }
-    if (this.enableGcpTraceExporter != null) {
+    if (this.enableGcpTraceExporter) {
       connectionProperties.setProperty(
           BigQueryJdbcUrlUtility.ENABLE_GCP_TRACE_EXPORTER_PROPERTY_NAME,
           String.valueOf(this.enableGcpTraceExporter));
     }
-    if (this.enableGcpLogExporter != null) {
+    if (this.enableGcpLogExporter) {
       connectionProperties.setProperty(
           BigQueryJdbcUrlUtility.ENABLE_GCP_LOG_EXPORTER_PROPERTY_NAME,
           String.valueOf(this.enableGcpLogExporter));
@@ -787,23 +789,19 @@ public class DataSource implements javax.sql.DataSource {
     this.listenerPoolSize = listenerPoolSize;
   }
 
-  public Boolean getEnableGcpTraceExporter() {
-    return enableGcpTraceExporter != null
-        ? enableGcpTraceExporter
-        : BigQueryJdbcUrlUtility.DEFAULT_ENABLE_GCP_TRACE_EXPORTER_VALUE;
+  public boolean getEnableGcpTraceExporter() {
+    return enableGcpTraceExporter;
   }
 
-  public void setEnableGcpTraceExporter(Boolean enableGcpTraceExporter) {
+  public void setEnableGcpTraceExporter(boolean enableGcpTraceExporter) {
     this.enableGcpTraceExporter = enableGcpTraceExporter;
   }
 
-  public Boolean getEnableGcpLogExporter() {
-    return enableGcpLogExporter != null
-        ? enableGcpLogExporter
-        : BigQueryJdbcUrlUtility.DEFAULT_ENABLE_GCP_LOG_EXPORTER_VALUE;
+  public boolean getEnableGcpLogExporter() {
+    return enableGcpLogExporter;
   }
 
-  public void setEnableGcpLogExporter(Boolean enableGcpLogExporter) {
+  public void setEnableGcpLogExporter(boolean enableGcpLogExporter) {
     this.enableGcpLogExporter = enableGcpLogExporter;
   }
 

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/OpenTelemetryJulHandler.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/OpenTelemetryJulHandler.java
@@ -33,12 +33,14 @@ import java.util.Collections;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import java.util.regex.Pattern;
 
 /**
  * Custom logging handler that bridges java.util.logging records to OpenTelemetry or Google Cloud
  * Logging. Extracts TraceId, SpanId, and Connection UUID from context.
  */
 public class OpenTelemetryJulHandler extends Handler {
+  private static final Pattern UNSAFE_LOG_CHARACTERS = Pattern.compile("[^a-zA-Z0-9./_-]");
 
   public OpenTelemetryJulHandler() {}
 
@@ -88,6 +90,8 @@ public class OpenTelemetryJulHandler extends Handler {
     String logId = record.getLoggerName();
     if (logId == null) {
       logId = BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME;
+    } else {
+      logId = UNSAFE_LOG_CHARACTERS.matcher(logId).replaceAll("_");
     }
 
     LogEntry.Builder builder =

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/OpenTelemetryJulHandler.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/OpenTelemetryJulHandler.java
@@ -85,12 +85,16 @@ public class OpenTelemetryJulHandler extends Handler {
     String traceId = spanContext.isValid() ? spanContext.getTraceId() : null;
     String spanId = spanContext.isValid() ? spanContext.getSpanId() : null;
 
-    // TODO(b/491238299): May require refinement for structured logging or error handling
+    String logId = record.getLoggerName();
+    if (logId == null) {
+      logId = BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME;
+    }
 
     LogEntry.Builder builder =
         LogEntry.newBuilder(Payload.StringPayload.of(formatMessage(record)))
             .setSeverity(mapGcpSeverity(record.getLevel()))
-            .setTimestamp(record.getMillis());
+            .setTimestamp(record.getMillis())
+            .setLogName(logId);
 
     if (traceId != null) {
       builder.setTrace(traceId);
@@ -181,6 +185,6 @@ public class OpenTelemetryJulHandler extends Handler {
 
   @Override
   public void close() throws SecurityException {
-    // TODO(b/491238299): Implement with gcp exporter logic
+    flush();
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
@@ -59,7 +59,6 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
 import org.apache.arrow.vector.util.Text;
@@ -138,8 +137,7 @@ public class BigQueryArrowStructTest {
                 LocalDateTime.parse("2023-03-30T11:15:19.820227")),
             arrowArraySchemaAndValue(
                 GEOGRAPHY, new Text("POINT(-122 47)"), new Text("POINT(-122 48)")),
-            arrowArraySchemaAndValue(
-                BYTES, Stream.of("one", "two").map(String::getBytes).toArray(byte[][]::new)));
+            arrowArraySchemaAndValue(BYTES, "one".getBytes(), "two".getBytes()));
 
     List<Field> orderedSchemas =
         schemaAndValues.stream().map(Tuple::x).collect(Collectors.toList());

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
@@ -82,12 +82,22 @@ public class BigQueryJdbcOpenTelemetryTest {
   }
 
   @Test
-  public void testGetOpenTelemetry_createsNewInstanceForDifferentFlags() {
+  public void testGetOpenTelemetry_createsNewInstanceForDifferentTraceFlag() {
     OpenTelemetry result1 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, true, null, null, "project1");
     OpenTelemetry result2 =
         BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, null, null, "project1");
 
     assertThat(result1).isNotSameInstanceAs(result2);
+  }
+
+  @Test
+  public void testGetOpenTelemetry_ignoresEnableLogFlagInCacheKey() {
+    OpenTelemetry result1 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, true, null, null, "project1");
+    OpenTelemetry result2 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+
+    assertThat(result1).isSameInstanceAs(result2);
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
@@ -29,7 +29,8 @@ public class BigQueryJdbcOpenTelemetryTest {
   public void testGetOpenTelemetry_withCustomSdk_returnsCustom() {
     OpenTelemetry mockCustomOtel = mock(OpenTelemetry.class);
 
-    OpenTelemetry result = BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, mockCustomOtel);
+    OpenTelemetry result =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, mockCustomOtel, null, null);
 
     assertThat(result).isSameInstanceAs(mockCustomOtel);
   }
@@ -39,14 +40,16 @@ public class BigQueryJdbcOpenTelemetryTest {
     OpenTelemetry mockCustomOtel = mock(OpenTelemetry.class);
 
     // Custom SDK always takes precedence over individual flags
-    OpenTelemetry result = BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, true, mockCustomOtel);
+    OpenTelemetry result =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, true, mockCustomOtel, null, null);
 
     assertThat(result).isSameInstanceAs(mockCustomOtel);
   }
 
   @Test
   public void testGetOpenTelemetry_noFlags_returnsNoop() {
-    OpenTelemetry result = BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, null);
+    OpenTelemetry result =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, null, null, null);
 
     assertThat(result).isSameInstanceAs(OpenTelemetry.noop());
   }
@@ -56,5 +59,25 @@ public class BigQueryJdbcOpenTelemetryTest {
     Tracer result = BigQueryJdbcOpenTelemetry.getTracer(OpenTelemetry.noop());
 
     assertThat(result).isNotNull();
+  }
+
+  @Test
+  public void testGetOpenTelemetry_cachesSdkInstances() {
+    OpenTelemetry result1 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+    OpenTelemetry result2 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+
+    assertThat(result1).isSameInstanceAs(result2);
+  }
+
+  @Test
+  public void testGetOpenTelemetry_createsNewInstanceForDifferentKey() {
+    OpenTelemetry result1 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+    OpenTelemetry result2 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project2");
+
+    assertThat(result1).isNotSameInstanceAs(result2);
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
@@ -80,4 +80,14 @@ public class BigQueryJdbcOpenTelemetryTest {
 
     assertThat(result1).isNotSameInstanceAs(result2);
   }
+
+  @Test
+  public void testGetOpenTelemetry_createsNewInstanceForDifferentFlags() {
+    OpenTelemetry result1 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+    OpenTelemetry result2 =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, null, null, "project1");
+
+    assertThat(result1).isNotSameInstanceAs(result2);
+  }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
@@ -19,11 +19,31 @@ package com.google.cloud.bigquery.jdbc;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class BigQueryJdbcOpenTelemetryTest {
+
+  private MockedStatic<GoogleCredentials> mockedCredentials;
+
+  @BeforeEach
+  public void setUp() {
+    mockedCredentials = Mockito.mockStatic(GoogleCredentials.class);
+    mockedCredentials
+        .when(GoogleCredentials::getApplicationDefault)
+        .thenReturn(mock(GoogleCredentials.class));
+  }
+
+  @AfterEach
+  public void tearDown() {
+    mockedCredentials.close();
+  }
 
   @Test
   public void testGetOpenTelemetry_withCustomSdk_returnsCustom() {


### PR DESCRIPTION
b/491238299
b/511147053

This PR completes the implementation of the OpenTelemetry SDK lifecycle and cross-project authentication for the BigQuery JDBC driver. It introduces thread-safe caching of heavy OTel SDK instances to support multi-project tracing without global side effects.

### Changes

#### `BigQueryJdbcOpenTelemetry.java`
- A `ConcurrentHashMap` caches `OpenTelemetrySdk` instances, keyed by a concatenated string of `ProjectId` and `Credentials`
- The `getOpenTelemetry()` method lazily loads and initializes the SDK only when requested and not present in the cache.
- A JVM shutdown hook closes each cached SDK to ensure pending traces are flushed on application exit.

#### `BigQueryJdbcUrlUtility.java`
- `gcpTelemetryCredentials` and `gcpTelemetryProjectId` are added to connection properties.

#### `BigQueryJdbcOAuthUtility.java`
- The `isJson()` helper method is changed from private to package-private to allow reuse in `BigQueryJdbcOpenTelemetry.`

#### `BigQueryConnection.java`
- Added new connection properties to be used
- Uses `Boolean.TRUE.equals()` when checking `enableGcpLogExporter` and `enableGcpTraceExporter` to safely handle cases where these properties are not specified `null` and avoid `NullPointerException` during auto-unboxing.

#### `BigQueryJdbcOpenTelemetryTest.java`
- New unit tests verify that SDK instances are correctly cached for identical keys and isolated for different keys.

#### `BigQueryArrowStructTest.java`
- A fix is applied to avoid varargs ambiguity in array creation, resolving a specific coercion failure in the structOfArrays test.