### PR TITLE
test(spanner): wrap backup schedule deletion in try-catch to prevent exception masking

### DIFF
--- a/java-spanner/samples/snippets/src/test/java/com/example/spanner/CreateFullBackupScheduleSampleIT.java
+++ b/java-spanner/samples/snippets/src/test/java/com/example/spanner/CreateFullBackupScheduleSampleIT.java
@@ -41,8 +41,17 @@ public class CreateFullBackupScheduleSampleIT extends SampleTestBaseV2 {
                 CreateFullBackupScheduleSample.createFullBackupSchedule(
                     projectId, instanceId, databaseId, backupScheduleId);
               } finally {
-                DeleteBackupScheduleSample.deleteBackupSchedule(
-                    projectId, instanceId, databaseId, backupScheduleId);
+                try {
+                  DeleteBackupScheduleSample.deleteBackupSchedule(
+                      projectId, instanceId, databaseId, backupScheduleId);
+                } catch (Exception e) {
+                  System.out.println(
+                      "Failed to delete backup schedule "
+                          + backupScheduleId
+                          + " due to "
+                          + e.getMessage()
+                          + ", skipping...");
+                }
               }
             });
     assertThat(out).contains(String.format("Created backup schedule: %s", backupScheduleName));

--- a/java-spanner/samples/snippets/src/test/java/com/example/spanner/CreateIncrementalBackupScheduleSampleIT.java
+++ b/java-spanner/samples/snippets/src/test/java/com/example/spanner/CreateIncrementalBackupScheduleSampleIT.java
@@ -41,8 +41,17 @@ public class CreateIncrementalBackupScheduleSampleIT extends SampleTestBaseV2 {
                 CreateIncrementalBackupScheduleSample.createIncrementalBackupSchedule(
                     projectId, multiRegionalInstanceId, databaseId, backupScheduleId);
               } finally {
-                DeleteBackupScheduleSample.deleteBackupSchedule(
-                    projectId, multiRegionalInstanceId, databaseId, backupScheduleId);
+                try {
+                  DeleteBackupScheduleSample.deleteBackupSchedule(
+                      projectId, multiRegionalInstanceId, databaseId, backupScheduleId);
+                } catch (Exception e) {
+                  System.out.println(
+                      "Failed to delete backup schedule "
+                          + backupScheduleId
+                          + " due to "
+                          + e.getMessage()
+                          + ", skipping...");
+                }
               }
             });
     assertThat(out)

--- a/java-spanner/samples/snippets/src/test/java/com/example/spanner/DeleteBackupScheduleSampleIT.java
+++ b/java-spanner/samples/snippets/src/test/java/com/example/spanner/DeleteBackupScheduleSampleIT.java
@@ -41,8 +41,17 @@ public class DeleteBackupScheduleSampleIT extends SampleTestBaseV2 {
                 CreateFullBackupScheduleSample.createFullBackupSchedule(
                     projectId, instanceId, databaseId, backupScheduleId);
               } finally {
-                DeleteBackupScheduleSample.deleteBackupSchedule(
-                    projectId, instanceId, databaseId, backupScheduleId);
+                try {
+                  DeleteBackupScheduleSample.deleteBackupSchedule(
+                      projectId, instanceId, databaseId, backupScheduleId);
+                } catch (Exception e) {
+                  System.out.println(
+                      "Failed to delete backup schedule "
+                          + backupScheduleId
+                          + " due to "
+                          + e.getMessage()
+                          + ", skipping...");
+                }
               }
             });
     assertThat(out).contains(String.format("Deleted backup schedule: %s", backupScheduleName));

--- a/java-spanner/samples/snippets/src/test/java/com/example/spanner/GetBackupScheduleSampleIT.java
+++ b/java-spanner/samples/snippets/src/test/java/com/example/spanner/GetBackupScheduleSampleIT.java
@@ -44,8 +44,17 @@ public class GetBackupScheduleSampleIT extends SampleTestBaseV2 {
                     projectId, instanceId,
                     databaseId, backupScheduleId);
               } finally {
-                DeleteBackupScheduleSample.deleteBackupSchedule(
-                    projectId, instanceId, databaseId, backupScheduleId);
+                try {
+                  DeleteBackupScheduleSample.deleteBackupSchedule(
+                      projectId, instanceId, databaseId, backupScheduleId);
+                } catch (Exception e) {
+                  System.out.println(
+                      "Failed to delete backup schedule "
+                          + backupScheduleId
+                          + " due to "
+                          + e.getMessage()
+                          + ", skipping...");
+                }
               }
             });
     assertThat(out).contains(String.format("Backup schedule: %s", backupScheduleName));

--- a/java-spanner/samples/snippets/src/test/java/com/example/spanner/ListBackupSchedulesSampleIT.java
+++ b/java-spanner/samples/snippets/src/test/java/com/example/spanner/ListBackupSchedulesSampleIT.java
@@ -49,10 +49,28 @@ public class ListBackupSchedulesSampleIT extends SampleTestBaseV2 {
                     projectId, instanceId, databaseId, backupScheduleId2);
                 ListBackupSchedulesSample.listBackupSchedules(projectId, instanceId, databaseId);
               } finally {
-                DeleteBackupScheduleSample.deleteBackupSchedule(
-                    projectId, instanceId, databaseId, backupScheduleId1);
-                DeleteBackupScheduleSample.deleteBackupSchedule(
-                    projectId, instanceId, databaseId, backupScheduleId2);
+                try {
+                  DeleteBackupScheduleSample.deleteBackupSchedule(
+                      projectId, instanceId, databaseId, backupScheduleId1);
+                } catch (Exception e) {
+                  System.out.println(
+                      "Failed to delete backup schedule "
+                          + backupScheduleId1
+                          + " due to "
+                          + e.getMessage()
+                          + ", skipping...");
+                }
+                try {
+                  DeleteBackupScheduleSample.deleteBackupSchedule(
+                      projectId, instanceId, databaseId, backupScheduleId2);
+                } catch (Exception e) {
+                  System.out.println(
+                      "Failed to delete backup schedule "
+                          + backupScheduleId2
+                          + " due to "
+                          + e.getMessage()
+                          + ", skipping...");
+                }
               }
             });
     assertThat(out).contains(String.format("Backup schedule: %s", backupScheduleName1));

--- a/java-spanner/samples/snippets/src/test/java/com/example/spanner/UpdateBackupScheduleSampleIT.java
+++ b/java-spanner/samples/snippets/src/test/java/com/example/spanner/UpdateBackupScheduleSampleIT.java
@@ -43,8 +43,17 @@ public class UpdateBackupScheduleSampleIT extends SampleTestBaseV2 {
                 UpdateBackupScheduleSample.updateBackupSchedule(
                     projectId, instanceId, databaseId, backupScheduleId);
               } finally {
-                DeleteBackupScheduleSample.deleteBackupSchedule(
-                    projectId, instanceId, databaseId, backupScheduleId);
+                try {
+                  DeleteBackupScheduleSample.deleteBackupSchedule(
+                      projectId, instanceId, databaseId, backupScheduleId);
+                } catch (Exception e) {
+                  System.out.println(
+                      "Failed to delete backup schedule "
+                          + backupScheduleId
+                          + " due to "
+                          + e.getMessage()
+                          + ", skipping...");
+                }
               }
             });
     assertThat(out).contains(String.format("Updated backup schedule: %s", backupScheduleName));


### PR DESCRIPTION
When a backup schedule creation fails (e.g., due to quota limits or rate throttling), the finally block attempts to delete the resource. Previously, deleteBackupSchedule threw a NotFoundException for uncreated resources, which suppressed the original failure from the try block.

Wrapping the cleanup calls in try-catch ensures that:
- The original exception explaining why the test failed is preserved and correctly reported.
- In tests with multiple resources, a failure to delete the first resource does not abort cleanup of subsequent resources.