### PR TITLE
feat(bqjdbc): Complete OpenTelemetry instrumentation and context propagation

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -43,7 +43,9 @@ import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.logging.Logging;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.CallableStatement;
@@ -149,6 +151,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   boolean enableGcpLogExporter;
   OpenTelemetry customOpenTelemetry;
   private OpenTelemetry openTelemetry;
+  private Context otelContext;
   Tracer tracer =
       OpenTelemetry.noop().getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME);
   DatabaseMetaData databaseMetaData;
@@ -161,6 +164,11 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
   BigQueryConnection(String url, DataSource ds) throws IOException {
     this.connectionId = UUID.randomUUID().toString();
+    Baggage baggage =
+        Baggage.builder()
+            .put(BigQueryJdbcOpenTelemetry.CONNECTION_ID_BAGGAGE_KEY, this.connectionId)
+            .build();
+    this.otelContext = Context.current().with(baggage);
     try (BigQueryJdbcMdc.MdcCloseable mdc = BigQueryJdbcMdc.registerInstance(this.connectionId)) {
       LOG.finest("++enter++");
 
@@ -1059,9 +1067,11 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     if (this.httpTransportOptions != null) {
       bigQueryOptions.setTransportOptions(this.httpTransportOptions);
     }
-    if (Boolean.TRUE.equals(this.enableGcpTraceExporter) || this.customOpenTelemetry != null) {
-      this.tracer = BigQueryJdbcOpenTelemetry.getTracer(this.openTelemetry);
-      bigQueryOptions.setOpenTelemetryTracer(this.tracer);
+    if (this.enableGcpTraceExporter || this.customOpenTelemetry != null) {
+      Tracer sdkTracer = this.openTelemetry.getTracer(BigQueryJdbcOpenTelemetry.BIGQUERY_NAMESPACE);
+      bigQueryOptions.setOpenTelemetryTracer(sdkTracer);
+      this.tracer =
+          this.openTelemetry.getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME);
     }
 
     BigQueryOptions options = bigQueryOptions.setHeaderProvider(this.headerProvider).build();
@@ -1112,7 +1122,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     bigQueryReadSettings.setTransportChannelProvider(activeProvider);
 
-    if (Boolean.TRUE.equals(this.enableGcpTraceExporter) || this.customOpenTelemetry != null) {
+    if (this.enableGcpTraceExporter || this.customOpenTelemetry != null) {
       bigQueryReadSettings.setOpenTelemetryTracerProvider(this.openTelemetry.getTracerProvider());
     }
 
@@ -1219,6 +1229,14 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
   public Tracer getTracer() {
     return this.tracer;
+  }
+
+  public Context getOtelContext() {
+    return this.otelContext;
+  }
+
+  public String getPartnerToken() {
+    return this.partnerToken;
   }
 
   public boolean isReadOnlyTokenUsed() {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -45,8 +45,6 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
-import io.opentelemetry.api.trace.StatusCode;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.io.BufferedReader;
@@ -864,7 +862,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                           procedureNamePattern,
                           procedureNameRegex,
                           LOG);
-              Future<List<Routine>> apiFuture = apiExecutor.submit(apiCallable);
+              Future<List<Routine>> apiFuture =
+                  apiExecutor.submit(Context.current().wrap(apiCallable));
               apiFutures.add(apiFuture);
             }
             LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingRoutines tasks.");
@@ -888,9 +887,13 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                       final Routine finalRoutine = routine;
                       Future<?> processFuture =
                           routineProcessorExecutor.submit(
-                              () ->
-                                  processProcedureInfo(
-                                      finalRoutine, collectedResults, localResultSchemaFields));
+                              Context.current()
+                                  .wrap(
+                                      () ->
+                                          processProcedureInfo(
+                                              finalRoutine,
+                                              collectedResults,
+                                              localResultSchemaFields)));
                       processingTaskFutures.add(processFuture);
                     } else {
                       LOG.finer("Skipping non-procedure routine: " + routine.getRoutineId());
@@ -1280,7 +1283,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                   procedureNamePattern,
                   procedureNameRegex,
                   logger);
-      listRoutineFutures.add(listRoutinesExecutor.submit(listCallable));
+      listRoutineFutures.add(listRoutinesExecutor.submit(Context.current().wrap(listCallable)));
     }
     logger.fine(
         "Submitted "
@@ -1357,7 +1360,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return null;
             }
           };
-      getRoutineFutures.add(getRoutineDetailsExecutor.submit(getCallable));
+      getRoutineFutures.add(getRoutineDetailsExecutor.submit(Context.current().wrap(getCallable)));
     }
     logger.fine("Submitted " + getRoutineFutures.size() + " getRoutine detail tasks.");
 
@@ -1407,9 +1410,14 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
           final Routine finalFullRoutine = fullRoutine;
           Future<?> processFuture =
               processArgsExecutor.submit(
-                  () ->
-                      processProcedureArguments(
-                          finalFullRoutine, columnNameRegex, collectedResults, resultSchemaFields));
+                  Context.current()
+                      .wrap(
+                          () ->
+                              processProcedureArguments(
+                                  finalFullRoutine,
+                                  columnNameRegex,
+                                  collectedResults,
+                                  resultSchemaFields)));
           outArgumentProcessingFutures.add(processFuture);
         } else {
           logger.warning(
@@ -4080,7 +4088,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                         functionNameRegex,
                         LOG);
                   };
-              Future<List<Routine>> apiFuture = apiExecutor.submit(apiCallable);
+              Future<List<Routine>> apiFuture =
+                  apiExecutor.submit(Context.current().wrap(apiCallable));
               apiFutures.add(apiFuture);
             }
             LOG.fine(
@@ -4515,7 +4524,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                   functionNamePattern,
                   functionNameRegex,
                   logger);
-      listRoutineFutures.add(listRoutinesExecutor.submit(listCallable));
+      listRoutineFutures.add(listRoutinesExecutor.submit(Context.current().wrap(listCallable)));
     }
     logger.fine(
         "Submitted "
@@ -5443,16 +5452,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   private <T> T withTracing(String spanName, TracedMetadataOperation<T> operation)
       throws SQLException {
-    Tracer tracer = this.connection.getTracer();
-    Span span = tracer.spanBuilder(spanName).startSpan();
-    try (Scope scope = span.makeCurrent()) {
-      return operation.run();
-    } catch (Exception ex) {
-      span.recordException(ex);
-      span.setStatus(StatusCode.ERROR, ex.getMessage());
-      throw ex;
-    } finally {
-      span.end();
-    }
+    return BigQueryJdbcOpenTelemetry.withTracing(
+        spanName, this.connection, null, () -> operation.run());
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -22,6 +22,7 @@ import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.common.hash.Hashing;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
@@ -306,9 +307,8 @@ public class BigQueryJdbcOpenTelemetry {
       String spanName, BigQueryConnection connection, String sql, Callable<T> operation)
       throws SQLException {
 
-    Context parentContext = connection.getOtelContext();
     Tracer tracer = connection.getTracer();
-    Span span = tracer.spanBuilder(spanName).setParent(parentContext).startSpan();
+    Span span = tracer.spanBuilder(spanName).startSpan();
 
     span.setAttribute(DB_SYSTEM_KEY, DB_SYSTEM_VALUE);
     span.setAttribute(DB_CONNECTION_ID_KEY, connection.getConnectionId());
@@ -323,14 +323,31 @@ public class BigQueryJdbcOpenTelemetry {
       span.setAttribute(DB_STATEMENT_KEY, sql);
     }
 
-    Context fullContext = parentContext.with(span);
+    String connectionId =
+        Baggage.fromContext(connection.getOtelContext()).getEntryValue(CONNECTION_ID_BAGGAGE_KEY);
+    Baggage updatedBaggage =
+        Baggage.fromContext(Context.current()).toBuilder()
+            .put(CONNECTION_ID_BAGGAGE_KEY, connectionId)
+            .build();
+
+    // Create full context with new span and updated baggage
+    Context fullContext = Context.current().with(span).with(updatedBaggage);
+
     try (Scope scope = fullContext.makeCurrent()) {
       return operation.call();
     } catch (Exception ex) {
       span.recordException(ex);
       span.setStatus(StatusCode.ERROR, ex.getMessage());
+
       if (ex instanceof SQLException) {
         throw (SQLException) ex;
+      }
+      if (ex instanceof RuntimeException) {
+        throw (RuntimeException) ex;
+      }
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+        throw new BigQueryJdbcRuntimeException("Operation interrupted", ex);
       }
       throw new BigQueryJdbcRuntimeException(ex);
     } finally {

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -24,6 +24,7 @@ import com.google.common.hash.Hashing;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
@@ -308,7 +309,7 @@ public class BigQueryJdbcOpenTelemetry {
       throws SQLException {
 
     Tracer tracer = connection.getTracer();
-    Span span = tracer.spanBuilder(spanName).startSpan();
+    Span span = tracer.spanBuilder(spanName).setSpanKind(SpanKind.CLIENT).startSpan();
 
     span.setAttribute(DB_SYSTEM_KEY, DB_SYSTEM_VALUE);
     span.setAttribute(DB_CONNECTION_ID_KEY, connection.getConnectionId());

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -323,11 +323,9 @@ public class BigQueryJdbcOpenTelemetry {
       span.setAttribute(DB_STATEMENT_KEY, sql);
     }
 
-    String connectionId =
-        Baggage.fromContext(connection.getOtelContext()).getEntryValue(CONNECTION_ID_BAGGAGE_KEY);
     Baggage updatedBaggage =
         Baggage.fromContext(Context.current()).toBuilder()
-            .put(CONNECTION_ID_BAGGAGE_KEY, connectionId)
+            .put(CONNECTION_ID_BAGGAGE_KEY, connection.getConnectionId())
             .build();
 
     // Create full context with new span and updated baggage

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -22,14 +22,20 @@ import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.common.hash.Hashing;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
@@ -39,6 +45,14 @@ public class BigQueryJdbcOpenTelemetry {
   static final String INSTRUMENTATION_SCOPE_NAME = "com.google.cloud.bigquery.jdbc";
   static final String BIGQUERY_NAMESPACE = "com.google.cloud.bigquery";
   public static final String CONNECTION_ID_BAGGAGE_KEY = "jdbc.connection_id";
+  public static final String DB_SYSTEM_KEY = "db.system";
+  public static final String DB_SYSTEM_VALUE = "bigquery";
+  public static final String DB_CONNECTION_ID_KEY = "db.connection_id";
+  public static final String DB_APPLICATION_KEY = "db.application";
+  public static final String DEFAULT_APPLICATION_NAME = "Google-BigQuery-JDBC-Driver";
+  public static final String DB_STATEMENT_KEY = "db.statement";
+  public static final String DB_STATEMENT_COUNT_KEY = "db.statement.count";
+  public static final String DB_BATCH_STATEMENTS_KEY = "db.batch.statements";
   private static final String OTEL_TRACES_EXPORTER = "otel.traces.exporter";
   private static final String OTEL_EXPORTER_OTLP_ENDPOINT = "otel.exporter.otlp.endpoint";
   private static final String OTEL_LOGS_EXPORTER = "otel.logs.exporter";
@@ -286,5 +300,41 @@ public class BigQueryJdbcOpenTelemetry {
   /** Gets a Tracer for the JDBC driver instrumentation scope. */
   public static Tracer getTracer(OpenTelemetry openTelemetry) {
     return openTelemetry.getTracer(INSTRUMENTATION_SCOPE_NAME);
+  }
+
+  public static <T> T withTracing(
+      String spanName, BigQueryConnection connection, String sql, Callable<T> operation)
+      throws SQLException {
+
+    Context parentContext = connection.getOtelContext();
+    Tracer tracer = connection.getTracer();
+    Span span = tracer.spanBuilder(spanName).setParent(parentContext).startSpan();
+
+    span.setAttribute(DB_SYSTEM_KEY, DB_SYSTEM_VALUE);
+    span.setAttribute(DB_CONNECTION_ID_KEY, connection.getConnectionId());
+
+    String appName = connection.getPartnerToken();
+    if (appName == null || appName.isEmpty()) {
+      appName = DEFAULT_APPLICATION_NAME;
+    }
+    span.setAttribute(DB_APPLICATION_KEY, appName);
+
+    if (sql != null) {
+      span.setAttribute(DB_STATEMENT_KEY, sql);
+    }
+
+    Context fullContext = parentContext.with(span);
+    try (Scope scope = fullContext.makeCurrent()) {
+      return operation.call();
+    } catch (Exception ex) {
+      span.recordException(ex);
+      span.setStatus(StatusCode.ERROR, ex.getMessage());
+      if (ex instanceof SQLException) {
+        throw (SQLException) ex;
+      }
+      throw new BigQueryJdbcRuntimeException(ex);
+    } finally {
+      span.end();
+    }
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryPreparedStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryPreparedStatement.java
@@ -91,6 +91,15 @@ class BigQueryPreparedStatement extends BigQueryStatement implements PreparedSta
   @Override
   public ResultSet executeQuery() throws SQLException {
     LOG.finest("++enter++");
+    checkClosed();
+    return BigQueryJdbcOpenTelemetry.withTracing(
+        "BigQueryPreparedStatement.executeQuery",
+        this.connection,
+        this.currentQuery,
+        () -> executeQueryImpl());
+  }
+
+  private ResultSet executeQueryImpl() throws SQLException {
     logQueryExecutionStart(this.currentQuery);
     try {
       QueryJobConfiguration.Builder jobConfiguration = getJobConfig(this.currentQuery);
@@ -106,6 +115,15 @@ class BigQueryPreparedStatement extends BigQueryStatement implements PreparedSta
   @Override
   public long executeLargeUpdate() throws SQLException {
     LOG.finest("++enter++");
+    checkClosed();
+    return BigQueryJdbcOpenTelemetry.withTracing(
+        "BigQueryPreparedStatement.executeLargeUpdate",
+        this.connection,
+        this.currentQuery,
+        () -> executeLargeUpdateImpl());
+  }
+
+  private long executeLargeUpdateImpl() throws SQLException {
     logQueryExecutionStart(this.currentQuery);
     try {
       QueryJobConfiguration.Builder jobConfiguration = getJobConfig(this.currentQuery);
@@ -127,6 +145,15 @@ class BigQueryPreparedStatement extends BigQueryStatement implements PreparedSta
   @Override
   public boolean execute() throws SQLException {
     LOG.finest("++enter++");
+    checkClosed();
+    return BigQueryJdbcOpenTelemetry.withTracing(
+        "BigQueryPreparedStatement.execute",
+        this.connection,
+        this.currentQuery,
+        () -> executeImpl());
+  }
+
+  private boolean executeImpl() throws SQLException {
     logQueryExecutionStart(this.currentQuery);
     try {
       QueryJobConfiguration.Builder jobConfiguration = getJobConfig(this.currentQuery);

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -244,12 +244,8 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   public ResultSet executeQuery(String sql) throws SQLException {
     LOG.finest("++enter++");
     checkClosed();
-    return withTracing(
-        "BigQueryStatement.executeQuery",
-        (span) -> {
-          span.setAttribute("db.statement", sql);
-          return executeQueryImpl(sql);
-        });
+    return BigQueryJdbcOpenTelemetry.withTracing(
+        "BigQueryStatement.executeQuery", this.connection, sql, () -> executeQueryImpl(sql));
   }
 
   private ResultSet executeQueryImpl(String sql) throws SQLException {
@@ -273,12 +269,11 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   public long executeLargeUpdate(String sql) throws SQLException {
     LOG.finest("++enter++");
     checkClosed();
-    return withTracing(
+    return BigQueryJdbcOpenTelemetry.withTracing(
         "BigQueryStatement.executeLargeUpdate",
-        (span) -> {
-          span.setAttribute("db.statement", sql);
-          return executeLargeUpdateImpl(sql);
-        });
+        this.connection,
+        sql,
+        () -> executeLargeUpdateImpl(sql));
   }
 
   private long executeLargeUpdateImpl(String sql) throws SQLException {
@@ -316,12 +311,8 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   public boolean execute(String sql) throws SQLException {
     LOG.finest("++enter++");
     checkClosed();
-    return withTracing(
-        "BigQueryStatement.execute",
-        (span) -> {
-          span.setAttribute("db.statement", sql);
-          return executeImpl(sql);
-        });
+    return BigQueryJdbcOpenTelemetry.withTracing(
+        "BigQueryStatement.execute", this.connection, sql, () -> executeImpl(sql));
   }
 
   private boolean executeImpl(String sql) throws SQLException {
@@ -1366,12 +1357,16 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   @Override
   public int[] executeBatch() throws SQLException {
     LOG.finest("++enter++");
-    return withTracing(
+    return BigQueryJdbcOpenTelemetry.withTracing(
         "BigQueryStatement.executeBatch",
-        (span) -> {
-          span.setAttribute("db.statement.count", this.batchQueries.size());
+        this.connection,
+        null,
+        () -> {
+          Span span = Span.current();
           span.setAttribute(
-              AttributeKey.stringArrayKey("db.batch.statements"),
+              BigQueryJdbcOpenTelemetry.DB_STATEMENT_COUNT_KEY, this.batchQueries.size());
+          span.setAttribute(
+              AttributeKey.stringArrayKey(BigQueryJdbcOpenTelemetry.DB_BATCH_STATEMENTS_KEY),
               new ArrayList<>(this.batchQueries));
 
           StringBuilder sb = new StringBuilder();
@@ -1554,25 +1549,6 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
 
   private void enqueueBufferEndOfStream(BlockingQueue<BigQueryFieldValueListWrapper> queue) {
     Uninterruptibles.putUninterruptibly(queue, BigQueryFieldValueListWrapper.of(null, null, true));
-  }
-
-  @FunctionalInterface
-  private interface TracedOperation<T> {
-    T run(Span span) throws SQLException;
-  }
-
-  private <T> T withTracing(String spanName, TracedOperation<T> operation) throws SQLException {
-    Tracer tracer = this.connection.getTracer();
-    Span span = tracer.spanBuilder(spanName).startSpan();
-    try (Scope scope = span.makeCurrent()) {
-      return operation.run(span);
-    } catch (SQLException | RuntimeException ex) {
-      span.recordException(ex);
-      span.setStatus(StatusCode.ERROR, ex.getMessage());
-      throw ex;
-    } finally {
-      span.end();
-    }
   }
 
   private void fetchNextPages(

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/OpenTelemetryJulHandler.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/OpenTelemetryJulHandler.java
@@ -56,11 +56,6 @@ public class OpenTelemetryJulHandler extends Handler {
           Baggage.fromContext(Context.current())
               .getEntryValue(BigQueryJdbcOpenTelemetry.CONNECTION_ID_BAGGAGE_KEY);
 
-      // Fallback to MDC if not in baggage (if MDC is available and used)
-      if (connectionId == null) {
-        connectionId = BigQueryJdbcMdc.getConnectionId();
-      }
-
       if (connectionId == null) {
         return;
       }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -30,9 +30,11 @@ import static org.mockito.Mockito.*;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.bigquery.*;
 import com.google.cloud.bigquery.BigQuery.RoutineListOption;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -81,11 +83,13 @@ public class BigQueryDatabaseMetaDataTest {
     when(bigQueryConnection.getConnectionUrl()).thenReturn("jdbc:bigquery://test-project");
     when(bigQueryConnection.getBigQuery()).thenReturn(bigqueryClient);
     when(bigQueryConnection.createStatement()).thenReturn(mockStatement);
+    when(bigQueryConnection.getConnectionId()).thenReturn("test-connection-id");
     when(bigQueryConnection.getTracer())
         .thenReturn(
             otelTesting
                 .getOpenTelemetry()
                 .getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME));
+    when(bigQueryConnection.getOtelContext()).thenReturn(Context.current());
 
     Page<Dataset> datasetPageMock = mock(Page.class);
     when(bigqueryClient.listDatasets(anyString(), any())).thenReturn(datasetPageMock);
@@ -3249,6 +3253,15 @@ public class BigQueryDatabaseMetaDataTest {
     SpanData span =
         OpenTelemetryTestUtility.findSpanByName(otelTesting.getSpans(), expectedSpanName);
     OpenTelemetryTestUtility.assertSpanStatus(span, StatusCode.UNSET);
+
+    OpenTelemetryTestUtility.assertSpanHasAttribute(
+        span,
+        AttributeKey.stringKey(BigQueryJdbcOpenTelemetry.DB_SYSTEM_KEY),
+        BigQueryJdbcOpenTelemetry.DB_SYSTEM_VALUE);
+    OpenTelemetryTestUtility.assertSpanHasAttribute(
+        span,
+        AttributeKey.stringKey(BigQueryJdbcOpenTelemetry.DB_CONNECTION_ID_KEY),
+        "test-connection-id");
   }
 
   @FunctionalInterface

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -31,6 +31,7 @@ import com.google.cloud.Tuple;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQuery.QueryResultsOption;
 import com.google.cloud.bigquery.BigQuery.TableDataListOption;
+import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
@@ -47,6 +48,7 @@ import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import com.google.cloud.bigquery.jdbc.BigQueryStatement.JobIdWrapper;
 import com.google.cloud.bigquery.spi.BigQueryRpcFactory;
 import com.google.cloud.bigquery.storage.v1.ArrowSchema;
@@ -55,6 +57,7 @@ import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
+import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
@@ -752,5 +755,71 @@ public class BigQueryStatementTest {
     // This should not throw ArithmeticException (/ by zero) and should evaluate safely
     boolean useReadApi = statement.useReadAPI(tableResult);
     assertThat(useReadApi).isTrue(); // ratio = 500 / 1 = 500 > 2 -> true
+  }
+
+  @Test
+  public void testExecute_registersException() throws Exception {
+    // Mock bigquery to throw a backend exception
+    BigQueryException expectedException = new BigQueryException(500, "Backend Error");
+    Mockito.doThrow(expectedException)
+        .when(bigquery)
+        .queryWithTimeout(Mockito.any(QueryJobConfiguration.class), Mockito.any(), Mockito.any());
+
+    BigQueryStatement spiedStatement = Mockito.spy(bigQueryStatement);
+
+    // Execute and expect the exception to be propagated to JDBC
+    Assertions.assertThrows(SQLException.class, () -> spiedStatement.executeQuery("SELECT 1"));
+
+    // Retrieve the exported span from OTel extension
+    List<SpanData> spans = otelTesting.getSpans();
+    SpanData span =
+        OpenTelemetryTestUtility.findSpanByName(spans, "BigQueryStatement.executeQuery");
+
+    // Assert that the span recorded the error correctly
+    OpenTelemetryTestUtility.assertSpanStatus(span, StatusCode.ERROR);
+    OpenTelemetryTestUtility.assertSpanHasException(span, BigQueryJdbcException.class);
+  }
+
+  @Test
+  public void testExecute_propagatesContextAndBaggage() throws Exception {
+    // Mock bigquery using thenAnswer to hook into the call and assert Context/Baggage
+    Mockito.doAnswer(
+            invocation -> {
+              // This code runs on the execution thread during the SDK call
+              String connectionIdBaggage =
+                  Baggage.current()
+                      .getEntryValue(BigQueryJdbcOpenTelemetry.CONNECTION_ID_BAGGAGE_KEY);
+              assertEquals("test-connection-id", connectionIdBaggage);
+
+              Span currentSpan = Span.current();
+              assertTrue(currentSpan.getSpanContext().isValid());
+
+              // Return a mock TableResult to allow the execution to proceed
+              TableResult tableResultMock = mock(TableResult.class);
+              doReturn(jobId).when(tableResultMock).getJobId();
+              doReturn(Schema.of()).when(tableResultMock).getSchema();
+              return tableResultMock;
+            })
+        .when(bigquery)
+        .queryWithTimeout(Mockito.any(QueryJobConfiguration.class), Mockito.any(), Mockito.any());
+
+    BigQueryStatement spiedStatement = Mockito.spy(bigQueryStatement);
+
+    // Setup connection mocks to allow the statement to execute successfully
+    doReturn(true).when(bigQueryConnection).getUseStatelessQueryMode();
+    Job dryRunJobMock = getJobMock(null, null, StatementType.SELECT);
+    doReturn(dryRunJobMock).when(bigquery).create(Mockito.any(JobInfo.class));
+
+    BigQueryJsonResultSet resultSetMock = mock(BigQueryJsonResultSet.class);
+    doReturn(resultSetMock)
+        .when(spiedStatement)
+        .processJsonResultSet(Mockito.any(TableResult.class));
+
+    // Execute query
+    spiedStatement.executeQuery("SELECT 1");
+
+    // Verify the SDK call actually occurred
+    verify(bigquery)
+        .queryWithTimeout(Mockito.any(QueryJobConfiguration.class), Mockito.any(), Mockito.any());
   }
 }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -59,6 +59,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -181,6 +182,7 @@ public class BigQueryStatementTest {
                 .getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME))
         .when(bigQueryConnection)
         .getTracer();
+    doReturn(Context.current()).when(bigQueryConnection).getOtelContext();
     rpcFactoryMock = mock(BigQueryRpcFactory.class);
     bigquery = mock(BigQuery.class);
     bigQueryConnection.bigQuery = bigquery;
@@ -188,6 +190,7 @@ public class BigQueryStatementTest {
     jobId = JobId.newBuilder().setJob(jobIdVal).build();
 
     doReturn(bigquery).when(bigQueryConnection).getBigQuery();
+    doReturn("test-connection-id").when(bigQueryConnection).getConnectionId();
     doReturn(10L).when(bigQueryConnection).getJobTimeoutInSeconds();
     doReturn(10L).when(bigQueryConnection).getMaxBytesBilled();
     doReturn(LABELS).when(bigQueryConnection).getLabels();
@@ -586,6 +589,15 @@ public class BigQueryStatementTest {
             span, (AttributeKey<Object>) entry.getKey(), entry.getValue());
       }
     }
+
+    OpenTelemetryTestUtility.assertSpanHasAttribute(
+        span,
+        AttributeKey.stringKey(BigQueryJdbcOpenTelemetry.DB_SYSTEM_KEY),
+        BigQueryJdbcOpenTelemetry.DB_SYSTEM_VALUE);
+    OpenTelemetryTestUtility.assertSpanHasAttribute(
+        span,
+        AttributeKey.stringKey(BigQueryJdbcOpenTelemetry.DB_CONNECTION_ID_KEY),
+        "test-connection-id");
   }
 
   Stream<Arguments> statementOperationProvider() {


### PR DESCRIPTION
b/496720140

## Changes

### Context Propagation & Session Tracking
*   **Baggage Injection**: Injected the generated Connection UUID into OpenTelemetry Baggage upon `BigQueryConnection` initialization to enable reliable log correlation.
*   **Log Handler Update**: Updated `OpenTelemetryJulHandler` to rely on Baggage for retrieving the connection ID, removing the legacy MDC fallback.
*   **Thread Pool Audit**: Wrapped tasks submitted to background executors in `BigQueryDatabaseMetaData` with `Context.current().wrap()`, ensuring trace context is not lost during parallel metadata fetching.

### Span Enrichment & Semantic Conventions
*   **Attributes**: Enriched JDBC spans with standard attributes: `db.system = "bigquery"`, `db.connection_id`, and `db.application` (derived from `partnerToken` or falling back to `"Google-BigQuery-JDBC-Driver"`).
*   **Scope Separation**: Implemented separate tracers for the JDBC driver (`com.google.cloud.bigquery.jdbc`) and the SDK (`com.google.cloud.bigquery`) to allow clean filtering in tracing UIs while maintaining correlation.

### Instrumentation
*   **PreparedStatement**: Added missing instrumentation for `BigQueryPreparedStatement` execution methods (`execute`, `executeQuery`, `executeLargeUpdate`) to generate spans.

### Refactoring & Cleanups
*   **Centralized Tracing**: Created a centralized `withTracing` helper in `BigQueryJdbcOpenTelemetry.java` to eliminate duplicated tracing logic in `BigQueryStatement` and `BigQueryDatabaseMetaData`.
*   **Constants**: Defined all semantic convention keys as constants in `BigQueryJdbcOpenTelemetry.java` to eliminate magic strings from method bodies.
*   **Simplifications**: Simplified redundant boolean checks in `BigQueryConnection.java`.