### PR TITLE
fix(bigtable): resolve deadlock in ClientConfigurationManager when notifying callbacks

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManager.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManager.java
@@ -48,12 +48,10 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -88,6 +86,7 @@ public class ClientConfigurationManager implements AutoCloseable {
   private class ListenerEntry<T> implements ListenerHandle {
     private final Function<ClientConfiguration, T> extractor;
     private final ConfigListener<T> listener;
+    private volatile boolean closed = false;
 
     private ListenerEntry(Function<ClientConfiguration, T> extractor, ConfigListener<T> listener) {
       this.extractor = extractor;
@@ -95,6 +94,9 @@ public class ClientConfigurationManager implements AutoCloseable {
     }
 
     private void maybeNotify(ClientConfiguration oldConfig, ClientConfiguration newConfig) {
+      if (closed) {
+        return;
+      }
       T oldValue = extractor.apply(oldConfig);
       T newValue = extractor.apply(newConfig);
       if (Objects.equals(oldValue, newValue)) {
@@ -105,12 +107,9 @@ public class ClientConfigurationManager implements AutoCloseable {
 
     @Override
     public void close() {
+      closed = true;
       synchronized (ClientConfigurationManager.this) {
-        if (notifying) {
-          pendingListenerRemovals.add(this);
-        } else {
-          listeners.remove(this);
-        }
+        listeners.remove(this);
       }
     }
   }
@@ -140,12 +139,6 @@ public class ClientConfigurationManager implements AutoCloseable {
 
   @GuardedBy("this")
   private final List<ListenerEntry<?>> listeners = new ArrayList<>();
-
-  @GuardedBy("this")
-  private boolean notifying = false;
-
-  @GuardedBy("this")
-  private final Set<ListenerEntry<?>> pendingListenerRemovals = new HashSet<>();
 
   @GuardedBy("this")
   @Nullable
@@ -443,22 +436,24 @@ public class ClientConfigurationManager implements AutoCloseable {
             TimeUnit.MILLISECONDS);
   }
 
-  private synchronized void setClientConfiguration(ClientConfiguration result) {
-    ClientConfiguration old = this.clientConfiguration;
-
-    clientConfiguration = result;
-    if (clientConfiguration.hasPollingConfiguration()) {
-      this.validUntil =
-          Instant.now()
-              .plus(
-                  toJavaDuration(
-                      clientConfiguration.getPollingConfiguration().getValidityDuration()));
-    } else if (clientConfiguration.getStopPolling()) {
-      this.validUntil = Instant.MAX;
+  private void setClientConfiguration(ClientConfiguration result) {
+    ClientConfiguration old;
+    synchronized (this) {
+      old = this.clientConfiguration;
+      clientConfiguration = result;
+      if (clientConfiguration.hasPollingConfiguration()) {
+        this.validUntil =
+            Instant.now()
+                .plus(
+                    toJavaDuration(
+                        clientConfiguration.getPollingConfiguration().getValidityDuration()));
+      } else if (clientConfiguration.getStopPolling()) {
+        this.validUntil = Instant.MAX;
+      }
     }
 
     maybeLogConfigChange(old, result);
-    notifyListeners(old, clientConfiguration);
+    notifyListeners(old, result);
   }
 
   private void maybeLogConfigChange(ClientConfiguration oldCfg, ClientConfiguration newCfg) {
@@ -486,26 +481,24 @@ public class ClientConfigurationManager implements AutoCloseable {
     return oldCfg.equals(newCfg);
   }
 
-  @GuardedBy("this")
   private void notifyListeners(ClientConfiguration oldConfig, ClientConfiguration newConfig) {
-    notifying = true;
-    // Snapshot the listeners so that new listeners added this cycle dont get notified
-    List<ListenerEntry<?>> snapshot = new ArrayList<>(listeners);
-
+    List<ListenerEntry<?>> snapshot;
+    synchronized (this) {
+      snapshot = new ArrayList<>(listeners);
+    }
     for (ListenerEntry<?> e : snapshot) {
-      if (pendingListenerRemovals.contains(e)) {
-        continue;
-      }
       e.maybeNotify(oldConfig, newConfig);
     }
-
-    listeners.removeAll(pendingListenerRemovals);
-    pendingListenerRemovals.clear();
-    notifying = false;
   }
 
-  private synchronized boolean handleFailedFetch(Throwable throwable, int attempt) {
-    if (validUntil.isBefore(Instant.now())) {
+  private boolean handleFailedFetch(Throwable throwable, int attempt) {
+    boolean shouldReset = false;
+    synchronized (this) {
+      if (validUntil.isBefore(Instant.now())) {
+        shouldReset = true;
+      }
+    }
+    if (shouldReset) {
       setClientConfiguration(defaultConfig);
     }
 
@@ -524,10 +517,17 @@ public class ClientConfigurationManager implements AutoCloseable {
       case INVALID_ARGUMENT:
         return false;
       default:
-        if (closing) {
+        boolean isClosing;
+        int maxRpcRetryCount;
+        synchronized (this) {
+          isClosing = closing;
+          maxRpcRetryCount =
+              getClientConfiguration().getPollingConfiguration().getMaxRpcRetryCount();
+        }
+        if (isClosing) {
           return false;
         }
-        return attempt < getClientConfiguration().getPollingConfiguration().getMaxRpcRetryCount();
+        return attempt < maxRpcRetryCount;
     }
   }
 

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
@@ -56,6 +56,7 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -298,6 +299,90 @@ class ClientConfigurationManagerTest {
     expectedConfig.getSessionConfigurationBuilder().setSessionLoad(0);
 
     assertThat(initialConfig).isEqualTo(service.config.get());
+  }
+
+  @Test
+  void testDeadlockPrevention() throws Exception {
+    // Initialize the manager and fetch the initial config to schedule polling.
+    manager.start().get();
+
+    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(mockExecutor, times(1)).schedule(runnableCaptor.capture(), anyLong(), any());
+    Runnable triggerPollRunnable = runnableCaptor.getValue();
+
+    // Define the "alien" lock object.
+    final Object alienLock = new Object();
+
+    // Latches to coordinate the deadlock scenario deterministically.
+    final CountDownLatch alienLockAcquiredLatch = new CountDownLatch(1);
+    final CountDownLatch startGetterLatch = new CountDownLatch(1);
+
+    // Register a listener that acts as the "alien" callback.
+    manager.addListener(
+        ClientConfiguration::getSessionConfiguration,
+        new ConfigListener<SessionClientConfiguration>() {
+          @Override
+          public void onChange(SessionClientConfiguration newValue) {
+            // Signal that we have entered the listener callback (released the manager monitor lock)
+            startGetterLatch.countDown();
+
+            // Try to acquire the alien lock. If we still hold the manager monitor lock,
+            // this will cause a deadlock with the other thread calling getClientConfiguration().
+            synchronized (alienLock) {
+              // Do nothing
+            }
+          }
+        });
+
+    // Start Thread B which will hold the alienLock and call getClientConfiguration()
+    final AtomicReference<ClientConfiguration> retrievedConfig = new AtomicReference<>();
+    final AtomicReference<Throwable> threadBError = new AtomicReference<>();
+
+    Thread threadB =
+        new Thread(
+            () -> {
+              synchronized (alienLock) {
+                // Signal that we hold the alien lock
+                alienLockAcquiredLatch.countDown();
+                try {
+                  // Wait until Thread A enters the onChange callback
+                  if (startGetterLatch.await(5, TimeUnit.SECONDS)) {
+                    // Call getClientConfiguration() which requires the synchronized lock on
+                    // ClientConfigurationManager
+                    retrievedConfig.set(manager.getClientConfiguration());
+                  } else {
+                    threadBError.set(
+                        new RuntimeException("Timeout waiting for listener onChange to start"));
+                  }
+                } catch (InterruptedException e) {
+                  threadBError.set(e);
+                }
+              }
+            });
+    threadB.start();
+
+    // Wait for Thread B to acquire the alien lock
+    assertThat(alienLockAcquiredLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+    // Thread A (current thread): Trigger config change to invoke listener
+    ClientConfiguration.Builder builder = service.config.get().toBuilder();
+    builder
+        .getSessionConfigurationBuilder()
+        .getSessionPoolConfigurationBuilder()
+        .setLoadBalancingOptions(
+            LoadBalancingOptions.newBuilder()
+                .setLeastInFlight(LeastInFlight.newBuilder().setRandomSubsetSize(20)));
+    service.config.set(builder.build());
+
+    // Trigger the poll (which calls setClientConfiguration -> notifyListeners)
+    triggerPollRunnable.run();
+    outstandingRpcCounter.waitUntilRpcsDone();
+
+    // Wait for Thread B to finish
+    threadB.join(5000);
+    assertThat(threadB.isAlive()).isFalse();
+    assertThat(threadBError.get()).isNull();
+    assertThat(retrievedConfig.get()).isNotNull();
   }
 
   static class FakeConfigService extends BigtableGrpc.BigtableImplBase {


### PR DESCRIPTION

Resolve a circular dependency deadlock between ClientConfigurationManagerand SessionPoolImpl monitor locks.
- Release the ClientConfigurationManager lock before executing listener callbacks.
- Remove synchronized from setClientConfiguration and handleFailedFetch signatures,restricting synchronization to direct field updates.
- Simplify concurrency design by introducing a volatile closed flag onListenerEntry, making notifying state and pendingListenerRemovals redundant.