### PR TITLE
fix(firestore): increase ITShutdownTest timeout to 50s

### DIFF
--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITShutdownTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITShutdownTest.java
@@ -38,7 +38,8 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class ITShutdownTest extends ITBaseTest {
-  @Rule public final Timeout timeout = new Timeout(5, TimeUnit.SECONDS);
+  // 45s budget for ITBaseTest backend priming + 5s budget for shutdown execution
+  @Rule public final Timeout timeout = new Timeout(50, TimeUnit.SECONDS);
   @Rule public TestName testName = new TestName();
 
   @Test


### PR DESCRIPTION
Increases the timeout rule in `ITShutdownTest` from 5 seconds to 50 seconds. This accommodates the 45-second backend priming budget established in `ITBaseTest` while still protecting CI from hanging indefinitely if a shutdown deadlock occurs.

fixes: https://github.com/googleapis/google-cloud-java/issues/13198