### PR TITLE
ci(graalvm): exclude java-common-protos and java-iam from nightly graalvm testing

### DIFF
--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -39,6 +39,8 @@ excluded_modules=(
   'java-firestore'
   'java-bigtable'
   'java-pubsub'
+  'java-common-protos'
+  'java-iam'
 )
 
 function retry_with_backoff {


### PR DESCRIPTION
Graalvm nightly tests [have been failing](https://fusion2.corp.google.com/invocations/4879edfa-b5fd-4657-9e5a-1953bdb9f044/targets/cloud-devrel%2Fclient-libraries%2Fjava%2Fgoogle-cloud-java%2Fnightly%2Fgraalvm-native-a/log) 

Excludes java-common-protos and java-iam from GraalVM nightly test runs following their migration to top-level directories in #12839. These packages contain zero test files and do not need native image testing.