### PR TITLE
fix(hermetic_build): add grpc-gcp to module allowlist in root pom generator

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -303,6 +303,13 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-bigtable-deps-bom</artifactId>
+        <version>2.78.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable-deps:current} -->
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-billing-bom</artifactId>
         <version>2.93.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-billing:current} -->
         <type>pom</type>

--- a/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
@@ -72,7 +72,6 @@ MODULE_ALLOWLIST = set(
         "google-auth-library-java",
         "sdk-platform-java",
         "java-showcase",
-        "grpc-gcp",
         "grpc-gcp-java",
     ]
 )

--- a/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
@@ -72,6 +72,8 @@ MODULE_ALLOWLIST = set(
         "google-auth-library-java",
         "sdk-platform-java",
         "java-showcase",
+        "grpc-gcp",
+        "grpc-gcp-java",
     ]
 )
 


### PR DESCRIPTION
This PR adds grpc-gcp and grpc-gcp-java to the MODULE_ALLOWLIST in pom_generator.py. This ensures that when grpc-gcp-java is migrated to the monorepo, the root pom generator will correctly preserve its module entry in the root pom.xml without requiring a java- prefix.