### PR TITLE
fix(hermetic_build): add grpc-gcp-java to module allowlist in root pom generator

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
@@ -72,7 +72,6 @@ MODULE_ALLOWLIST = set(
         "google-auth-library-java",
         "sdk-platform-java",
         "java-showcase",
-        "grpc-gcp",
         "grpc-gcp-java",
     ]
 )

--- a/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/pom_generator.py
@@ -72,6 +72,8 @@ MODULE_ALLOWLIST = set(
         "google-auth-library-java",
         "sdk-platform-java",
         "java-showcase",
+        "grpc-gcp",
+        "grpc-gcp-java",
     ]
 )
 


### PR DESCRIPTION
This PR adds grpc-gcp-java to the MODULE_ALLOWLIST in pom_generator.py. This ensures that when grpc-gcp-java is migrated to the monorepo, the root pom generator will correctly preserve its module entry in the root pom.xml without requiring a java- prefix.

This unblocks https://github.com/googleapis/google-cloud-java/pull/13184