### PR TITLE
feat(gax): implement dynamic channel refreshing on 401 retries

### DIFF
--- a/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
+++ b/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/ChannelPool.java
@@ -82,6 +82,7 @@ class ChannelPool extends ManagedChannel {
   private ScheduledFuture<?> resizeFuture = null;
 
   private final Object entryWriteLock = new Object();
+  private long lastRefreshTimeNanos = 0;
   @VisibleForTesting final AtomicReference<ImmutableList<Entry>> entries = new AtomicReference<>();
   private final AtomicInteger indexTicker = new AtomicInteger();
   private final String authority;
@@ -441,6 +442,13 @@ class ChannelPool extends ManagedChannel {
     // - then thread2 will shut down channel that thread1 will put back into circulation (after it
     //   replaces the list)
     synchronized (entryWriteLock) {
+      long now = System.nanoTime();
+      if (now - lastRefreshTimeNanos < TimeUnit.SECONDS.toNanos(5)) {
+        LOG.fine("Channel pool was refreshed recently, skipping duplicate refresh");
+        return;
+      }
+      lastRefreshTimeNanos = now;
+
       LOG.fine("Refreshing all channels");
       ArrayList<Entry> newEntries = new ArrayList<>(entries.get());
 

--- a/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
+++ b/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcCallContext.java
@@ -97,6 +97,7 @@ public final class GrpcCallContext implements ApiCallContext {
   private final ApiCallContextOptions options;
   private final EndpointContext endpointContext;
   private final boolean isDirectPath;
+  @Nullable private final TransportChannel transportChannel;
 
   /** Returns an empty instance with a null channel and default {@link CallOptions}. */
   public static GrpcCallContext createDefault() {
@@ -113,7 +114,8 @@ public final class GrpcCallContext implements ApiCallContext {
         null,
         null,
         null,
-        false);
+        false,
+        null);
   }
 
   /** Returns an instance with the given channel and {@link CallOptions}. */
@@ -131,7 +133,8 @@ public final class GrpcCallContext implements ApiCallContext {
         null,
         null,
         null,
-        false);
+        false,
+        null);
   }
 
   private GrpcCallContext(
@@ -147,7 +150,8 @@ public final class GrpcCallContext implements ApiCallContext {
       @Nullable RetrySettings retrySettings,
       @Nullable Set<StatusCode.Code> retryableCodes,
       @Nullable EndpointContext endpointContext,
-      boolean isDirectPath) {
+      boolean isDirectPath,
+      @Nullable TransportChannel transportChannel) {
     this.channel = channel;
     this.credentials = credentials;
     Preconditions.checkNotNull(callOptions);
@@ -167,6 +171,7 @@ public final class GrpcCallContext implements ApiCallContext {
     this.endpointContext =
         endpointContext == null ? EndpointContext.getDefaultInstance() : endpointContext;
     this.isDirectPath = isDirectPath;
+    this.transportChannel = transportChannel;
   }
 
   /**
@@ -208,7 +213,13 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
+  }
+
+  @Override
+  public TransportChannel getTransportChannel() {
+    return transportChannel;
   }
 
   @Override
@@ -232,7 +243,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        transportChannel.isDirectPath());
+        transportChannel.isDirectPath(),
+        inputChannel);
   }
 
   @Override
@@ -251,7 +263,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   /** This method is obsolete. Use {@link #withTimeoutDuration(java.time.Duration)} instead. */
@@ -286,7 +299,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   /** This method is obsolete. Use {@link #getTimeoutDuration()} instead. */
@@ -335,7 +349,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   /**
@@ -370,7 +385,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   @BetaApi("The surface for channel affinity is not stable yet and may change in the future.")
@@ -388,7 +404,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   @BetaApi("The surface for extra headers is not stable yet and may change in the future.")
@@ -410,7 +427,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   @Override
@@ -433,7 +451,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   @Override
@@ -456,7 +475,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   @Override
@@ -558,7 +578,8 @@ public final class GrpcCallContext implements ApiCallContext {
         newRetrySettings,
         newRetryableCodes,
         endpointContext,
-        newIsDirectPath);
+        newIsDirectPath,
+        transportChannel);
   }
 
   /** The {@link Channel} set on this context. */
@@ -641,7 +662,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   /** Returns a new instance with the call options set to the given call options. */
@@ -659,7 +681,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   public GrpcCallContext withRequestParamsDynamicHeaderOption(String requestParams) {
@@ -704,7 +727,8 @@ public final class GrpcCallContext implements ApiCallContext {
         retrySettings,
         retryableCodes,
         endpointContext,
-        isDirectPath);
+        isDirectPath,
+        transportChannel);
   }
 
   /** {@inheritDoc} */

--- a/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
+++ b/sdk-platform-java/gax-java/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcTransportChannel.java
@@ -67,6 +67,14 @@ public abstract class GrpcTransportChannel implements TransportChannel {
   }
 
   @Override
+  public void refresh() {
+    Channel channel = getChannel();
+    if (channel instanceof ChannelPool) {
+      ((ChannelPool) channel).refresh();
+    }
+  }
+
+  @Override
   public void shutdown() {
     getManagedChannel().shutdown();
   }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiCallContext.java
@@ -63,6 +63,14 @@ public interface ApiCallContext extends RetryingContext {
   /** Returns a new ApiCallContext with the given channel set. */
   ApiCallContext withTransportChannel(TransportChannel channel);
 
+  /**
+   * Returns the {@link TransportChannel} associated with this call context, or {@code null} if none
+   * is set.
+   */
+  default TransportChannel getTransportChannel() {
+    return null;
+  }
+
   /** Returns a new ApiCallContext with the given Endpoint Context. */
   ApiCallContext withEndpointContext(EndpointContext endpointContext);
 

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiResultRetryAlgorithm.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ApiResultRetryAlgorithm.java
@@ -38,6 +38,10 @@ class ApiResultRetryAlgorithm<ResponseT> extends BasicResultRetryAlgorithm<Respo
   /** Returns true if previousThrowable is an {@link ApiException} that is retryable. */
   @Override
   public boolean shouldRetry(Throwable previousThrowable, ResponseT previousResponse) {
+    if ("true".equalsIgnoreCase(System.getenv("isMwlidEnvironment"))
+        && previousThrowable instanceof UnauthenticatedException) {
+      return true;
+    }
     return (previousThrowable instanceof ApiException)
         && ((ApiException) previousThrowable).isRetryable();
   }
@@ -51,6 +55,10 @@ class ApiResultRetryAlgorithm<ResponseT> extends BasicResultRetryAlgorithm<Respo
   @Override
   public boolean shouldRetry(
       RetryingContext context, Throwable previousThrowable, ResponseT previousResponse) {
+    if ("true".equalsIgnoreCase(System.getenv("isMwlidEnvironment"))
+        && previousThrowable instanceof UnauthenticatedException) {
+      return true;
+    }
     if (context.getRetryableCodes() != null) {
       // Ignore the isRetryable() value of the throwable if the RetryingContext has a specific list
       // of codes that should be retried.

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/AttemptCallable.java
@@ -84,6 +84,28 @@ class AttemptCallable<RequestT, ResponseT> implements Callable<ResponseT> {
           .attemptStarted(request, externalFuture.getAttemptSettings().getOverallAttemptCount());
 
       ApiFuture<ResponseT> internalFuture = callable.futureCall(request, callContext);
+
+      if ("true".equalsIgnoreCase(System.getenv("isMwlidEnvironment"))) {
+        final ApiCallContext finalContext = callContext;
+        ApiFutures.addCallback(
+            internalFuture,
+            new com.google.api.core.ApiFutureCallback<ResponseT>() {
+              @Override
+              public void onFailure(Throwable t) {
+                if (t instanceof UnauthenticatedException) {
+                  TransportChannel transportChannel = finalContext.getTransportChannel();
+                  if (transportChannel != null) {
+                    transportChannel.refresh();
+                  }
+                }
+              }
+
+              @Override
+              public void onSuccess(ResponseT result) {}
+            },
+            com.google.common.util.concurrent.MoreExecutors.directExecutor());
+      }
+
       externalFuture.setAttemptFuture(internalFuture);
     } catch (Throwable e) {
       externalFuture.setAttemptFuture(ApiFutures.<ResponseT>immediateFailedFuture(e));

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/BidiStreamingCallable.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/BidiStreamingCallable.java
@@ -236,11 +236,45 @@ public abstract class BidiStreamingCallable<RequestT, ResponseT> {
     return new BidiStreamingCallable<RequestT, ResponseT>() {
       @Override
       public ClientStream<RequestT> internalCall(
-          ResponseObserver<ResponseT> responseObserver,
+          final ResponseObserver<ResponseT> responseObserver,
           ClientStreamReadyObserver<RequestT> onReady,
           ApiCallContext thisCallContext) {
+        final ApiCallContext mergedContext = defaultCallContext.merge(thisCallContext);
+        ResponseObserver<ResponseT> refreshingObserver = responseObserver;
+
+        if ("true".equalsIgnoreCase(System.getenv("isMwlidEnvironment"))) {
+          refreshingObserver =
+              new ResponseObserver<ResponseT>() {
+                @Override
+                public void onStart(StreamController controller) {
+                  responseObserver.onStart(controller);
+                }
+
+                @Override
+                public void onResponse(ResponseT response) {
+                  responseObserver.onResponse(response);
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                  if (t instanceof UnauthenticatedException) {
+                    TransportChannel transportChannel = mergedContext.getTransportChannel();
+                    if (transportChannel != null) {
+                      transportChannel.refresh();
+                    }
+                  }
+                  responseObserver.onError(t);
+                }
+
+                @Override
+                public void onComplete() {
+                  responseObserver.onComplete();
+                }
+              };
+        }
+
         return BidiStreamingCallable.this.internalCall(
-            responseObserver, onReady, defaultCallContext.merge(thisCallContext));
+            refreshingObserver, onReady, mergedContext);
       }
     };
   }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientStreamingCallable.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ClientStreamingCallable.java
@@ -73,9 +73,38 @@ public abstract class ClientStreamingCallable<RequestT, ResponseT> {
     return new ClientStreamingCallable<RequestT, ResponseT>() {
       @Override
       public ApiStreamObserver<RequestT> clientStreamingCall(
-          ApiStreamObserver<ResponseT> responseObserver, ApiCallContext thisCallContext) {
+          final ApiStreamObserver<ResponseT> responseObserver, ApiCallContext thisCallContext) {
+        final ApiCallContext mergedContext = defaultCallContext.merge(thisCallContext);
+        ApiStreamObserver<ResponseT> refreshingObserver = responseObserver;
+
+        if ("true".equalsIgnoreCase(System.getenv("isMwlidEnvironment"))) {
+          refreshingObserver =
+              new ApiStreamObserver<ResponseT>() {
+                @Override
+                public void onNext(ResponseT response) {
+                  responseObserver.onNext(response);
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                  if (t instanceof UnauthenticatedException) {
+                    TransportChannel transportChannel = mergedContext.getTransportChannel();
+                    if (transportChannel != null) {
+                      transportChannel.refresh();
+                    }
+                  }
+                  responseObserver.onError(t);
+                }
+
+                @Override
+                public void onCompleted() {
+                  responseObserver.onCompleted();
+                }
+              };
+        }
+
         return ClientStreamingCallable.this.clientStreamingCall(
-            responseObserver, defaultCallContext.merge(thisCallContext));
+            refreshingObserver, mergedContext);
       }
     };
   }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/ServerStreamingAttemptCallable.java
@@ -219,6 +219,7 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
         .getTracer()
         .attemptStarted(request, outerRetryingFuture.getAttemptSettings().getOverallAttemptCount());
 
+    final ApiCallContext finalContext = attemptContext;
     innerCallable.call(
         request,
         new StateCheckingResponseObserver<ResponseT>() {
@@ -234,6 +235,18 @@ final class ServerStreamingAttemptCallable<RequestT, ResponseT> implements Calla
 
           @Override
           public void onErrorImpl(Throwable t) {
+            if ("true".equalsIgnoreCase(System.getenv("isMwlidEnvironment"))) {
+              Throwable cause = t;
+              if (cause instanceof com.google.api.gax.retrying.ServerStreamingAttemptException) {
+                cause = cause.getCause();
+              }
+              if (cause instanceof UnauthenticatedException) {
+                TransportChannel transportChannel = finalContext.getTransportChannel();
+                if (transportChannel != null) {
+                  transportChannel.refresh();
+                }
+              }
+            }
             onAttemptError(t);
           }
 

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannel.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/rpc/TransportChannel.java
@@ -47,4 +47,12 @@ public interface TransportChannel extends BackgroundResource {
    * Returns an empty {@link ApiCallContext} that is compatible with this {@code TransportChannel}.
    */
   ApiCallContext getEmptyCallContext();
+
+  /**
+   * Refreshes or recreates the underlying network connections of this transport channel.
+   *
+   * <p>By default, this is a no-op for transports that do not require stateful connection lifecycle
+   * management.
+   */
+  default void refresh() {}
 }


### PR DESCRIPTION
This PR implements dynamic channel refreshing on 401 Unauthenticated retries under the isMwlidEnvironment environment variable. It introduces compile-time type-safe refresh contracts across TransportChannel and ApiCallContext, with debouncing protection in ChannelPool to prevent connection stampedes.