### PR TITLE
fix(bqjdbc): avoid reusing statement in DatabaseMetaData

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -2638,13 +2638,13 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     return Schema.of(fields);
   }
 
-  private void closeStatementIgnoreException(Statement statement){
-    if (statement == null){
+  private void closeStatementIgnoreException(Statement statement) {
+    if (statement == null) {
       return;
     }
     try {
       statement.close();
-    } catch (SQLException e){
+    } catch (SQLException e) {
       // pass
     }
   }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -139,7 +139,6 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
 
   String URL;
   BigQueryConnection connection;
-  Statement statement = null;
   private final BigQuery bigquery;
   private final int metadataFetchThreadCount;
   private static final AtomicReference<String> parsedDriverVersion = new AtomicReference<>(null);
@@ -2643,11 +2642,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
     String sql = readSqlFromFile(GET_PRIMARY_KEYS_SQL);
     try {
-      if (this.statement == null) {
-        this.statement = this.connection.createStatement();
-      }
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException("Error executing getPrimaryKeys", e);
     }
@@ -2658,11 +2656,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       throws SQLException {
     String sql = readSqlFromFile(GET_IMPORTED_KEYS_SQL);
     try {
-      if (this.statement == null) {
-        this.statement = this.connection.createStatement();
-      }
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException("Error executing getImportedKeys", e);
     }
@@ -2673,11 +2670,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       throws SQLException {
     String sql = readSqlFromFile(GET_EXPORTED_KEYS_SQL);
     try {
-      if (this.statement == null) {
-        this.statement = this.connection.createStatement();
-      }
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException("Error executing getExportedKeys", e);
     }
@@ -2694,9 +2690,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       throws SQLException {
     String sql = readSqlFromFile(GET_CROSS_REFERENCE_SQL);
     try {
-      if (this.statement == null) {
-        this.statement = this.connection.createStatement();
-      }
+      Statement stmt = this.connection.createStatement();
+      stmt.closeOnCompletion();
       String formattedSql =
           replaceSqlParameters(
               sql,
@@ -2706,7 +2701,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               foreignCatalog,
               foreignSchema,
               foreignTable);
-      return this.statement.executeQuery(formattedSql);
+      return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
       throw new BigQueryJdbcException("Error executing getCrossReference", e);
     }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -2638,15 +2638,27 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     return Schema.of(fields);
   }
 
+  private void closeStatementIgnoreException(Statement statement){
+    if (statement == null){
+      return;
+    }
+    try {
+      statement.close();
+    } catch (SQLException e){
+      // pass
+    }
+  }
+
   @Override
   public ResultSet getPrimaryKeys(String catalog, String schema, String table) throws SQLException {
     String sql = readSqlFromFile(GET_PRIMARY_KEYS_SQL);
+    Statement stmt = this.connection.createStatement();
     try {
-      Statement stmt = this.connection.createStatement();
       stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
       return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
+      closeStatementIgnoreException(stmt);
       throw new BigQueryJdbcException("Error executing getPrimaryKeys", e);
     }
   }
@@ -2655,12 +2667,13 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getImportedKeys(String catalog, String schema, String table)
       throws SQLException {
     String sql = readSqlFromFile(GET_IMPORTED_KEYS_SQL);
+    Statement stmt = this.connection.createStatement();
     try {
-      Statement stmt = this.connection.createStatement();
       stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
       return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
+      closeStatementIgnoreException(stmt);
       throw new BigQueryJdbcException("Error executing getImportedKeys", e);
     }
   }
@@ -2669,12 +2682,13 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
   public ResultSet getExportedKeys(String catalog, String schema, String table)
       throws SQLException {
     String sql = readSqlFromFile(GET_EXPORTED_KEYS_SQL);
+    Statement stmt = this.connection.createStatement();
     try {
-      Statement stmt = this.connection.createStatement();
       stmt.closeOnCompletion();
       String formattedSql = replaceSqlParameters(sql, catalog, schema, table);
       return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
+      closeStatementIgnoreException(stmt);
       throw new BigQueryJdbcException("Error executing getExportedKeys", e);
     }
   }
@@ -2689,8 +2703,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       String foreignTable)
       throws SQLException {
     String sql = readSqlFromFile(GET_CROSS_REFERENCE_SQL);
+    Statement stmt = this.connection.createStatement();
     try {
-      Statement stmt = this.connection.createStatement();
       stmt.closeOnCompletion();
       String formattedSql =
           replaceSqlParameters(
@@ -2703,6 +2717,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               foreignTable);
       return stmt.executeQuery(formattedSql);
     } catch (SQLException e) {
+      closeStatementIgnoreException(stmt);
       throw new BigQueryJdbcException("Error executing getCrossReference", e);
     }
   }

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -3206,4 +3206,35 @@ public class BigQueryDatabaseMetaDataTest {
   public void testGetSQLStateType() throws SQLException {
     assertEquals(DatabaseMetaData.sqlStateSQL, dbMetadata.getSQLStateType());
   }
+
+  @Test
+  public void testMetadataMethodsDoNotInterfere() throws SQLException {
+    Statement mockStatement1 = mock(Statement.class);
+    Statement mockStatement2 = mock(Statement.class);
+    ResultSet mockResultSet1 = mock(ResultSet.class);
+    ResultSet mockResultSet2 = mock(ResultSet.class);
+
+    when(bigQueryConnection.createStatement())
+        .thenReturn(mockStatement1)
+        .thenReturn(mockStatement2);
+
+    when(mockStatement1.executeQuery(any())).thenReturn(mockResultSet1);
+    when(mockStatement2.executeQuery(any())).thenReturn(mockResultSet2);
+
+    // Call first metadata method
+    ResultSet rs1 = dbMetadata.getPrimaryKeys("cat", "schema", "table");
+    assertSame(mockResultSet1, rs1);
+
+    // Call second metadata method
+    ResultSet rs2 = dbMetadata.getImportedKeys("cat", "schema", "table");
+    assertSame(mockResultSet2, rs2);
+
+    // Verify closeOnCompletion was called on both statements
+    verify(mockStatement1).closeOnCompletion();
+    verify(mockStatement2).closeOnCompletion();
+
+    // Verify connection.createStatement() was called twice
+    verify(bigQueryConnection, times(2)).createStatement();
+  }
 }
+

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -3237,4 +3237,3 @@ public class BigQueryDatabaseMetaDataTest {
     verify(bigQueryConnection, times(2)).createStatement();
   }
 }
-

--- a/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITDatabaseMetadataTest.java
+++ b/java-bigquery/google-cloud-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITDatabaseMetadataTest.java
@@ -342,6 +342,40 @@ public class ITDatabaseMetadataTest extends ITBase {
   }
 
   @Test
+  public void testMetadataResultSetsDoNotInterfere() throws SQLException {
+    try (Connection connection =
+        DriverManager.getConnection(String.format(connectionUrl, DEFAULT_CATALOG))) {
+      DatabaseMetaData metaData = connection.getMetaData();
+
+      // Get primary keys for table 1
+      ResultSet primaryKeys1 =
+          metaData.getPrimaryKeys(PROJECT_ID, CONSTRAINTS_DATASET, CONSTRAINTS_TABLE_NAME);
+
+      // Get imported keys for table 1, BEFORE fully consuming primaryKeys1
+      ResultSet importedKeys =
+          metaData.getImportedKeys(PROJECT_ID, CONSTRAINTS_DATASET, CONSTRAINTS_TABLE_NAME);
+
+      // Now try to read from primaryKeys1
+      Assertions.assertTrue(primaryKeys1.next());
+      Assertions.assertEquals("id", primaryKeys1.getString("COLUMN_NAME"));
+
+      // Read from importedKeys
+      Assertions.assertTrue(importedKeys.next());
+      Assertions.assertEquals(CONSTRAINTS_TABLE_NAME2, importedKeys.getString("PKTABLE_NAME"));
+
+      // Read more from primaryKeys1 (should be finished now)
+      Assertions.assertFalse(primaryKeys1.next());
+
+      // Read more from importedKeys
+      Assertions.assertTrue(importedKeys.next());
+      Assertions.assertEquals(CONSTRAINTS_TABLE_NAME2, importedKeys.getString("PKTABLE_NAME"));
+
+      primaryKeys1.close();
+      importedKeys.close();
+    }
+  }
+
+  @Test
   public void testDatabaseMetadataGetCatalogs() throws SQLException {
 
     Connection connection =


### PR DESCRIPTION
Potential issue with reusing statement is that each use of it invalidates previous ResultSet objects.

So is multiple times API methods are called, results are invalid.

```
ResultSet pk = metadata.getPrimaryKeys();
ResultSet ek = metadata.getExportedKeys();

<iterate over results>
```