### PR TITLE
fix(ci): correct directory typo in shared-dependencies workflow

### DIFF
--- a/.github/workflows/sdk-platform-java-shared_dependencies.yaml
+++ b/.github/workflows/sdk-platform-java-shared_dependencies.yaml
@@ -40,4 +40,4 @@ jobs:
         mvn install -B -ntp -DskipTests -Pquick-build
     - name: Check the BOM content satisfies the upper-bound-check test case
       run: mvn -B -V -ntp verify -Pquick-build
-      working-directory: sdk-plaform-java/java-shared-dependencies/upper-bound-check
+      working-directory: sdk-platform-java/java-shared-dependencies/upper-bound-check


### PR DESCRIPTION
upper-bound-check has been failing on main. See [error logs](https://github.com/googleapis/google-cloud-java/actions/runs/26060308731/job/76618752972).

This PR corrects the typo in the working directory path (`sdk-plaform-java` -> `sdk-platform-java`), which should resolve the CI failure.