### PR TITLE
fix(bqjdbc): update shading to be more targeted

### DIFF
--- a/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
+++ b/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
@@ -115,23 +115,64 @@
                   </transformers>
                   <relocations>
                     <relocation>
-                      <pattern>com</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com</shadedPattern>
+                      <pattern>com.google</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google</shadedPattern>
                       <excludes>
                         <exclude>com.google.cloud.bigquery.**</exclude>
                         <exclude>com.google.api.services.bigquery.**</exclude>
                       </excludes>
                     </relocation>
                     <relocation>
-                      <pattern>org</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.org</shadedPattern>
-                      <excludes>
-                        <exclude>org.conscrypt.*</exclude>
-                      </excludes>
+                      <pattern>com.fasterxml.jackson</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.fasterxml.jackson</shadedPattern>
                     </relocation>
                     <relocation>
-                      <pattern>io</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.io</shadedPattern>
+                      <pattern>org.apache</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.org.apache</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.checkerframework</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.org.checkerframework</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.codehaus</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.org.codehaus</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.jspecify</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.org.jspecify</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.threeten</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.org.threeten</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.json</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.org.json</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.slf4j</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.org.slf4j</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>io.grpc</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.io.grpc</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>io.netty</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.io.netty</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>io.opencensus</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.io.opencensus</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>io.opentelemetry</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.io.opentelemetry</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>io.perfmark</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.io.perfmark</shadedPattern>
                     </relocation>
                   </relocations>
                   <filters>

--- a/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
+++ b/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
@@ -117,112 +117,12 @@
                   </transformers>
                   <relocations>
                     <relocation>
-                      <pattern>com.google.api.client</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.client</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.api.core</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.core</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.api.gax</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.gax</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.api.pathtemplate</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.pathtemplate</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.api.resourcenames</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.resourcenames</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.apps</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.apps</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.auth</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.auth</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.auto</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.auto</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.cloud.audit</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.audit</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.cloud.http</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.http</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.cloud.location</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.location</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.cloud.spi</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.spi</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.cloud.testing</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.testing</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.common</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.common</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.errorprone</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.errorprone</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.flatbuffers</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.flatbuffers</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.geo</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.geo</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.gson</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.gson</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.iam</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.iam</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.j2objc</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.j2objc</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.logging</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.logging</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.longrunning</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.longrunning</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.protobuf</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.protobuf</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.rpc</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.rpc</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.shopping</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.shopping</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.thirdparty</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.thirdparty</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>com.google.type</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google.type</shadedPattern>
+                      <pattern>com.google</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google</shadedPattern>
+                      <excludes>
+                        <exclude>com.google.cloud.bigquery.**</exclude>
+                        <exclude>com.google.api.services.bigquery.**</exclude>
+                      </excludes>
                     </relocation>
                     <relocation>
                       <pattern>com.fasterxml.jackson</pattern>
@@ -251,10 +151,6 @@
                     <relocation>
                       <pattern>org.json</pattern>
                       <shadedPattern>com.google.bqjdbc.shaded.org.json</shadedPattern>
-                    </relocation>
-                    <relocation>
-                      <pattern>org.slf4j</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.org.slf4j</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>io.grpc</pattern>

--- a/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
+++ b/java-bigquery/google-cloud-bigquery-jdbc/pom.xml
@@ -88,7 +88,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.5.2</version> <!-- Use the latest version -->
+            <version>3.6.1</version>
             <executions>
               <execution>
                 <phase>package</phase>
@@ -97,6 +97,8 @@
                 </goals>
                 <configuration>
                   <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <createSourcesJar>true</createSourcesJar>
+                  <shadeSourcesContent>true</shadeSourcesContent>
                   <shadedClassifierName>all</shadedClassifierName> <!-- Any name that makes sense -->
                   <createDependencyReducedPom>false</createDependencyReducedPom>
                   <archive>
@@ -115,12 +117,112 @@
                   </transformers>
                   <relocations>
                     <relocation>
-                      <pattern>com.google</pattern>
-                      <shadedPattern>com.google.bqjdbc.shaded.com.google</shadedPattern>
-                      <excludes>
-                        <exclude>com.google.cloud.bigquery.**</exclude>
-                        <exclude>com.google.api.services.bigquery.**</exclude>
-                      </excludes>
+                      <pattern>com.google.api.client</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.client</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.api.core</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.core</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.api.gax</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.gax</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.api.pathtemplate</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.pathtemplate</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.api.resourcenames</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.api.resourcenames</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.apps</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.apps</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.auth</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.auth</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.auto</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.auto</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.cloud.audit</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.audit</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.cloud.http</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.http</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.cloud.location</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.location</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.cloud.spi</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.spi</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.cloud.testing</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.cloud.testing</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.common</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.common</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.errorprone</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.errorprone</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.flatbuffers</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.flatbuffers</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.geo</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.geo</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.gson</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.gson</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.iam</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.iam</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.j2objc</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.j2objc</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.logging</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.logging</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.longrunning</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.longrunning</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.protobuf</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.protobuf</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.rpc</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.rpc</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.shopping</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.shopping</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.thirdparty</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.thirdparty</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.google.type</pattern>
+                      <shadedPattern>com.google.bqjdbc.shaded.com.google.type</shadedPattern>
                     </relocation>
                     <relocation>
                       <pattern>com.fasterxml.jackson</pattern>
@@ -187,6 +289,10 @@
                               <exclude>META-INF/*.DSA</exclude>
                               <exclude>META-INF/*.RSA</exclude>
                               <exclude>arrow-git.properties</exclude>
+                              <exclude>module-info.class</exclude>
+                              <exclude>META-INF/versions/*/module-info.class</exclude>
+                              <exclude>module-info.java</exclude>
+                              <exclude>META-INF/versions/*/module-info.java</exclude>
                           </excludes>
                       </filter>
                   </filters>


### PR DESCRIPTION
- Fixed shading warnings
- Adding shaded sources JAR (gemini recommendation for debugging via IDE)
- More explicit shading for libraries: there was a bug due to aggressive shading of `com`. It also updated constant strings, such as 'computeMetadata' which is a part of certain URLs which broke GCE auth flow. b/514870009