### PR TITLE
fix(storage): add junit-vintage-engine to support native test discovery

### DIFF
--- a/java-storage/gapic-google-cloud-storage-v2/pom.xml
+++ b/java-storage/gapic-google-cloud-storage-v2/pom.xml
@@ -79,18 +79,33 @@
       <scope>test</scope>
       <version>2.81.0-SNAPSHOT</version><!-- {x-version-update:gax-grpc:current} -->
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>native</id>
-      <properties>
-          <!-- skip native tests for this module, it will be tested in google-cloud-storage -->
-          <skipTests>true</skipTests>
-      </properties>
-    </profile>
-    <profile>
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.junit.vintage</groupId>
+                                <artifactId>junit-vintage-engine</artifactId>
+                                <version>5.14.3</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
       <id>java9</id>
       <activation>
         <jdk>[9,)</jdk>

--- a/java-storage/gapic-google-cloud-storage-v2/pom.xml
+++ b/java-storage/gapic-google-cloud-storage-v2/pom.xml
@@ -98,7 +98,7 @@
                             <dependency>
                                 <groupId>org.junit.vintage</groupId>
                                 <artifactId>junit-vintage-engine</artifactId>
-                                <version>5.14.3</version>
+                                <version>${junit.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/java-storage/gapic-google-cloud-storage-v2/pom.xml
+++ b/java-storage/gapic-google-cloud-storage-v2/pom.xml
@@ -84,6 +84,13 @@
 
   <profiles>
     <profile>
+      <id>native</id>
+      <properties>
+          <!-- skip native tests for this module, it will be tested in google-cloud-storage -->
+          <skipTests>true</skipTests>
+      </properties>
+    </profile>
+    <profile>
       <id>java9</id>
       <activation>
         <jdk>[9,)</jdk>

--- a/java-storage/google-cloud-storage-control/pom.xml
+++ b/java-storage/google-cloud-storage-control/pom.xml
@@ -100,6 +100,13 @@
 
     <profiles>
         <profile>
+            <id>native</id>
+            <properties>
+                <!-- skip native tests for this module, it will be tested in google-cloud-storage -->
+                <skipTests>true</skipTests>
+            </properties>
+        </profile>
+        <profile>
             <id>java9</id>
             <activation>
                 <jdk>[9,)</jdk>

--- a/java-storage/google-cloud-storage-control/pom.xml
+++ b/java-storage/google-cloud-storage-control/pom.xml
@@ -115,7 +115,7 @@
                             <dependency>
                                 <groupId>org.junit.vintage</groupId>
                                 <artifactId>junit-vintage-engine</artifactId>
-                                <version>5.14.3</version>
+                                <version>${junit.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/java-storage/google-cloud-storage-control/pom.xml
+++ b/java-storage/google-cloud-storage-control/pom.xml
@@ -96,15 +96,31 @@
             <artifactId>google-http-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>
         <profile>
             <id>native</id>
-            <properties>
-                <!-- skip native tests for this module, it will be tested in google-cloud-storage -->
-                <skipTests>true</skipTests>
-            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.junit.vintage</groupId>
+                                <artifactId>junit-vintage-engine</artifactId>
+                                <version>5.14.3</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>java9</id>

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
@@ -67,11 +67,11 @@ public final class Registry extends RunListener {
   private static final Object shutdownHookRegistrationLock = new Object();
 
   private static final Registry INSTANCE = new Registry();
-    private final ListeningScheduledExecutorService exec =
-            MoreExecutors.listeningDecorator(
-                    Executors.newScheduledThreadPool(
-                            Math.min(8, 2 * Runtime.getRuntime().availableProcessors()),
-                            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-run-%d").build()));
+  private final ListeningScheduledExecutorService exec =
+      MoreExecutors.listeningDecorator(
+          Executors.newScheduledThreadPool(
+              Math.min(8, 2 * Runtime.getRuntime().availableProcessors()),
+              new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-run-%d").build()));
 
   private final TestRunScopedInstance<TestBench> testBench =
       TestRunScopedInstance.of("fixture/TEST_BENCH", () -> TestBench.newBuilder().build());

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
@@ -67,11 +67,11 @@ public final class Registry extends RunListener {
   private static final Object shutdownHookRegistrationLock = new Object();
 
   private static final Registry INSTANCE = new Registry();
-  private final ListeningScheduledExecutorService exec =
-      MoreExecutors.listeningDecorator(
-          Executors.newScheduledThreadPool(
-              2 * Runtime.getRuntime().availableProcessors(),
-              new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-run-%d").build()));
+    private final ListeningScheduledExecutorService exec =
+            MoreExecutors.listeningDecorator(
+                    Executors.newScheduledThreadPool(
+                            Math.min(8, 2 * Runtime.getRuntime().availableProcessors()),
+                            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-run-%d").build()));
 
   private final TestRunScopedInstance<TestBench> testBench =
       TestRunScopedInstance.of("fixture/TEST_BENCH", () -> TestBench.newBuilder().build());

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/Registry.java
@@ -70,7 +70,7 @@ public final class Registry extends RunListener {
   private final ListeningScheduledExecutorService exec =
       MoreExecutors.listeningDecorator(
           Executors.newScheduledThreadPool(
-              Math.min(8, 2 * Runtime.getRuntime().availableProcessors()),
+              2 * Runtime.getRuntime().availableProcessors(),
               new ThreadFactoryBuilder().setDaemon(true).setNameFormat("test-run-%d").build()));
 
   private final TestRunScopedInstance<TestBench> testBench =

--- a/java-storage/pom.xml
+++ b/java-storage/pom.xml
@@ -56,6 +56,7 @@
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-storage-parent</site.installationModule>
     <google.cloud.shared-dependencies.version>3.31.0</google.cloud.shared-dependencies.version>
+    <junit.version>5.14.3</junit.version>
   </properties>
 
   <dependencyManagement>
@@ -63,7 +64,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.14.3</version>
+        <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
When running native presubmit checks or building with the native profile, the builds for gapic-google-cloud-storage-v2 and google-cloud-storage-control fail with a `SurefireBooterForkException`. The specific error indicates that the TestEngine with ID junit-vintage failed to discover tests.
```
[ERROR] There was an error in the forked process
[ERROR] TestEngine with ID 'junit-vintage' failed to discover tests
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked process
[ERROR] TestEngine with ID 'junit-vintage' failed to discover tests
```
This failure occurs because:
- The global native profile triggers the `maven-surefire-plugin` to perform test discovery using the modern JUnit 5 Platform Launcher
- The unit tests in these modules (e.g., `StorageClientTest.java`) are standard JUnit 4 tests
- The JUnit 5 launcher requires the `junit-vintage-engine` on the classpath to discover and execute these JUnit 4 tests

This PR fixes the discovery crash:
- Adds the `junit-vintage-engine` as a test-scope dependency in both `gapic-google-cloud-storage-v2/pom.xml` and `google-cloud-storage-control/pom.xml`
- Configures the maven-surefire-plugin within a local native profile to explicitly include the junit-vintage-engine dependency.

