### PR TITLE
fix(gax): adjust RetryAlgorithm logic for timeout v. exception

### DIFF
--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -232,14 +232,17 @@ public class RetryAlgorithm<ResponseT> {
       ResponseT previousResponse,
       TimedAttemptSettings nextAttemptSettings)
       throws CancellationException {
-    boolean retryBasedOnResult = shouldRetryBasedOnResult(context, previousThrowable, previousResponse);
+    boolean retryBasedOnResult =
+        shouldRetryBasedOnResult(context, previousThrowable, previousResponse);
 
-    // Short-circuit when operation has succeeded to avoid erroneously throwing CancellationException below
+    // Short-circuit when operation has succeeded to avoid erroneously throwing
+    // CancellationException below
     if (!retryBasedOnResult && previousThrowable == null) {
       return false;
     }
 
-    boolean retryBasedOnTiming = shouldRetryBasedOnTiming(context, nextAttemptSettings); // throws CancellationException
+    // throws CancellationException
+    boolean retryBasedOnTiming = shouldRetryBasedOnTiming(context, nextAttemptSettings);
     return retryBasedOnResult && retryBasedOnTiming;
   }
 

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -153,19 +153,25 @@ public class RetryAlgorithm<ResponseT> {
       Throwable previousThrowable,
       ResponseT previousResponse,
       TimedAttemptSettings previousSettings) {
-    // a small optimization that avoids calling relatively heavy methods
-    // like timedAlgorithm.createNextAttempt(), when it is not necessary.
-    if (!shouldRetryBasedOnResult(context, previousThrowable, previousResponse)) {
-      return null;
+    if (shouldRetryBasedOnResult(context, previousThrowable, previousResponse)) {
+      TimedAttemptSettings newSettings =
+          createNextAttemptBasedOnResult(
+              context, previousThrowable, previousResponse, previousSettings);
+      if (newSettings == null) {
+        newSettings = createNextAttemptBasedOnTiming(context, previousSettings);
+      }
+      return newSettings;
     }
-
-    TimedAttemptSettings newSettings =
-        createNextAttemptBasedOnResult(
-            context, previousThrowable, previousResponse, previousSettings);
-    if (newSettings == null) {
-      newSettings = createNextAttemptBasedOnTiming(context, previousSettings);
+    // If we shouldn't retry based on result and the last attempt failed with an
+    // exception, defer to any exception thrown by shouldRetryBasedOnTiming.
+    // This lets a timeout-related exception get propagated when justified
+    // rather than e.g. exceptions caused by very short RPC deadlines on a
+    // final polling attempt.
+    if (previousThrowable != null) {
+      TimedAttemptSettings nextSettings = createNextAttemptBasedOnTiming(context, previousSettings);
+      shouldRetryBasedOnTiming(context, nextSettings);
     }
-    return newSettings;
+    return null;
   }
 
   private TimedAttemptSettings createNextAttemptBasedOnResult(
@@ -232,18 +238,8 @@ public class RetryAlgorithm<ResponseT> {
       ResponseT previousResponse,
       TimedAttemptSettings nextAttemptSettings)
       throws CancellationException {
-    boolean retryBasedOnResult =
-        shouldRetryBasedOnResult(context, previousThrowable, previousResponse);
-
-    // Short-circuit when operation has succeeded to avoid erroneously throwing
-    // CancellationException below
-    if (!retryBasedOnResult && previousThrowable == null) {
-      return false;
-    }
-
-    // throws CancellationException
-    boolean retryBasedOnTiming = shouldRetryBasedOnTiming(context, nextAttemptSettings);
-    return retryBasedOnResult && retryBasedOnTiming;
+    return shouldRetryBasedOnResult(context, previousThrowable, previousResponse)
+        && shouldRetryBasedOnTiming(context, nextAttemptSettings);
   }
 
   boolean shouldRetryBasedOnResult(

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/retrying/RetryAlgorithm.java
@@ -232,8 +232,15 @@ public class RetryAlgorithm<ResponseT> {
       ResponseT previousResponse,
       TimedAttemptSettings nextAttemptSettings)
       throws CancellationException {
-    return shouldRetryBasedOnResult(context, previousThrowable, previousResponse)
-        && shouldRetryBasedOnTiming(context, nextAttemptSettings);
+    boolean retryBasedOnResult = shouldRetryBasedOnResult(context, previousThrowable, previousResponse);
+
+    // Short-circuit when operation has succeeded to avoid erroneously throwing CancellationException below
+    if (!retryBasedOnResult && previousThrowable == null) {
+      return false;
+    }
+
+    boolean retryBasedOnTiming = shouldRetryBasedOnTiming(context, nextAttemptSettings); // throws CancellationException
+    return retryBasedOnResult && retryBasedOnTiming;
   }
 
   boolean shouldRetryBasedOnResult(

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
@@ -204,7 +204,7 @@ class RetryAlgorithmTest {
   }
 
   @Test
-  void testShouldRetry_prevThrowableNotNull_shouldRetryBasedOnResultFalse_callsTimedAlgorithm() {
+  void testShouldRetry_resultFalseAndThrowableNotNull_callsTimed() {
     ResultRetryAlgorithm<Object> resultAlgorithm = mock(ResultRetryAlgorithm.class);
     TimedRetryAlgorithm timedAlgorithm = mock(TimedRetryAlgorithm.class);
     RetryAlgorithm<Object> algorithm = new RetryAlgorithm<>(resultAlgorithm, timedAlgorithm);
@@ -219,7 +219,7 @@ class RetryAlgorithmTest {
   }
 
   @Test
-  void testShouldRetry_prevThrowableNull_shouldRetryBasedOnResultFalse_shortCircuits() {
+  void testShouldRetry_resultFalseAndThrowableNull_shortCircuits() {
     ResultRetryAlgorithm<Object> resultAlgorithm = mock(ResultRetryAlgorithm.class);
     TimedRetryAlgorithm timedAlgorithm = mock(TimedRetryAlgorithm.class);
     RetryAlgorithm<Object> algorithm = new RetryAlgorithm<>(resultAlgorithm, timedAlgorithm);

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
@@ -30,11 +30,14 @@
 package com.google.api.gax.retrying;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.concurrent.CancellationException;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings({"unchecked", "deprecation"})
@@ -112,6 +115,45 @@ class RetryAlgorithmTest {
 
     algorithm.createNextAttempt(context, previousThrowable, previousResult, previousSettings);
     verify(resultAlgorithm).shouldRetry(context, previousThrowable, previousResult);
+  }
+
+  @Test
+  void testCreateNextAttempt_exceptionAndTimeout_defersToTimingException() {
+    ResultRetryAlgorithm<Object> resultAlgorithm = mock(ResultRetryAlgorithm.class);
+    TimedRetryAlgorithm timedAlgorithm = mock(TimedRetryAlgorithm.class);
+    RetryAlgorithm<Object> algorithm = new RetryAlgorithm<>(resultAlgorithm, timedAlgorithm);
+    Throwable throwable = new Throwable();
+    Object result = new Object();
+    TimedAttemptSettings previousSettings = mock(TimedAttemptSettings.class);
+    TimedAttemptSettings nextSettings = mock(TimedAttemptSettings.class);
+
+    when(resultAlgorithm.shouldRetry(throwable, result)).thenReturn(false);
+    when(timedAlgorithm.createNextAttempt(previousSettings)).thenReturn(nextSettings);
+    when(timedAlgorithm.shouldRetry(nextSettings)).thenThrow(new CancellationException());
+
+    assertThrows(
+        CancellationException.class,
+        () -> algorithm.createNextAttempt(throwable, result, previousSettings));
+  }
+
+  @Test
+  void testCreateNextAttempt_exceptionAndNoTimeout_returnsNull() {
+    ResultRetryAlgorithm<Object> resultAlgorithm = mock(ResultRetryAlgorithm.class);
+    TimedRetryAlgorithm timedAlgorithm = mock(TimedRetryAlgorithm.class);
+    RetryAlgorithm<Object> algorithm = new RetryAlgorithm<>(resultAlgorithm, timedAlgorithm);
+    Throwable throwable = new Throwable();
+    Object result = new Object();
+    TimedAttemptSettings previousSettings = mock(TimedAttemptSettings.class);
+    TimedAttemptSettings nextSettings = mock(TimedAttemptSettings.class);
+
+    when(resultAlgorithm.shouldRetry(throwable, result)).thenReturn(false);
+    when(timedAlgorithm.createNextAttempt(previousSettings)).thenReturn(nextSettings);
+    when(timedAlgorithm.shouldRetry(nextSettings)).thenReturn(true);
+
+    TimedAttemptSettings nextAttemptSettings =
+        algorithm.createNextAttempt(throwable, result, previousSettings);
+
+    assertNull(nextAttemptSettings);
   }
 
   @Test
@@ -201,23 +243,6 @@ class RetryAlgorithmTest {
     Object previousResult = new Object();
 
     assertFalse(algorithm.shouldRetry(context, previousThrowable, previousResult, null));
-  }
-
-  @Test
-  void testShouldRetry_resultFalseAndThrowableNotNull_callsTimed() {
-    ResultRetryAlgorithm<Object> resultAlgorithm = mock(ResultRetryAlgorithm.class);
-    TimedRetryAlgorithm timedAlgorithm = mock(TimedRetryAlgorithm.class);
-    RetryAlgorithm<Object> algorithm = new RetryAlgorithm<>(resultAlgorithm, timedAlgorithm);
-    Throwable previousThrowable = new Throwable();
-    Object previousResult = new Object();
-    TimedAttemptSettings previousSettings = mock(TimedAttemptSettings.class);
-    when(resultAlgorithm.shouldRetry(previousThrowable, previousResult)).thenReturn(false);
-
-    boolean shouldRetry =
-        algorithm.shouldRetry(previousThrowable, previousResult, previousSettings);
-
-    assertFalse(shouldRetry);
-    verify(timedAlgorithm).shouldRetry(previousSettings);
   }
 
   @Test

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
@@ -213,8 +213,10 @@ class RetryAlgorithmTest {
     TimedAttemptSettings previousSettings = mock(TimedAttemptSettings.class);
     when(resultAlgorithm.shouldRetry(previousThrowable, previousResult)).thenReturn(false);
 
-    algorithm.shouldRetry(previousThrowable, previousResult, previousSettings);
+    boolean shouldRetry =
+        algorithm.shouldRetry(previousThrowable, previousResult, previousSettings);
 
+    assertFalse(shouldRetry);
     verify(timedAlgorithm).shouldRetry(previousSettings);
   }
 

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/retrying/RetryAlgorithmTest.java
@@ -31,6 +31,7 @@ package com.google.api.gax.retrying;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -200,5 +201,35 @@ class RetryAlgorithmTest {
     Object previousResult = new Object();
 
     assertFalse(algorithm.shouldRetry(context, previousThrowable, previousResult, null));
+  }
+
+  @Test
+  void testShouldRetry_prevThrowableNotNull_shouldRetryBasedOnResultFalse_callsTimedAlgorithm() {
+    ResultRetryAlgorithm<Object> resultAlgorithm = mock(ResultRetryAlgorithm.class);
+    TimedRetryAlgorithm timedAlgorithm = mock(TimedRetryAlgorithm.class);
+    RetryAlgorithm<Object> algorithm = new RetryAlgorithm<>(resultAlgorithm, timedAlgorithm);
+    Throwable previousThrowable = new Throwable();
+    Object previousResult = new Object();
+    TimedAttemptSettings previousSettings = mock(TimedAttemptSettings.class);
+    when(resultAlgorithm.shouldRetry(previousThrowable, previousResult)).thenReturn(false);
+
+    algorithm.shouldRetry(previousThrowable, previousResult, previousSettings);
+
+    verify(timedAlgorithm).shouldRetry(previousSettings);
+  }
+
+  @Test
+  void testShouldRetry_prevThrowableNull_shouldRetryBasedOnResultFalse_shortCircuits() {
+    ResultRetryAlgorithm<Object> resultAlgorithm = mock(ResultRetryAlgorithm.class);
+    TimedRetryAlgorithm timedAlgorithm = mock(TimedRetryAlgorithm.class);
+    RetryAlgorithm<Object> algorithm = new RetryAlgorithm<>(resultAlgorithm, timedAlgorithm);
+    Object previousResult = new Object();
+    TimedAttemptSettings previousSettings = mock(TimedAttemptSettings.class);
+    when(resultAlgorithm.shouldRetry(null, previousResult)).thenReturn(false);
+
+    boolean shouldRetry = algorithm.shouldRetry(null, previousResult, previousSettings);
+
+    assertFalse(shouldRetry);
+    verify(timedAlgorithm, never()).shouldRetry(previousSettings);
   }
 }

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/rpc/StreamingRetryAlgorithmTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/rpc/StreamingRetryAlgorithmTest.java
@@ -116,12 +116,17 @@ class StreamingRetryAlgorithmTest {
     StreamingRetryAlgorithm<String> algorithm =
         new StreamingRetryAlgorithm<>(resultAlgorithm, timedAlgorithm);
 
+    TimedAttemptSettings previousSettings = mock(TimedAttemptSettings.class);
+    when(previousSettings.getGlobalSettings()).thenReturn(DEFAULT_RETRY_SETTINGS);
+    when(previousSettings.getRpcTimeoutDuration())
+        .thenReturn(DEFAULT_RETRY_SETTINGS.getInitialRpcTimeoutDuration());
+
     TimedAttemptSettings attempt =
-        algorithm.createNextAttempt(context, exception, null, mock(TimedAttemptSettings.class));
+        algorithm.createNextAttempt(context, exception, null, previousSettings);
     assertThat(attempt).isNull();
 
     TimedAttemptSettings attemptWithoutContext =
-        algorithm.createNextAttempt(exception, null, mock(TimedAttemptSettings.class));
+        algorithm.createNextAttempt(exception, null, previousSettings);
     assertThat(attemptWithoutContext).isNull();
   }
 


### PR DESCRIPTION
The current RetryAlgorithm logic is susceptible to an edge case if a short RPC deadline is [set near the end of polling](https://github.com/googleapis/google-cloud-java/blob/main/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/retrying/ExponentialRetryAlgorithm.java#L161).  If an exception results from a too-short deadline, the exception thrown by the associated Future will be an ExecutionException rather than e.g. CancellationException (for LRO polling). This likely causes flakiness observed in #12373 and [#3277.](https://github.com/googleapis/sdk-platform-java/issues/3277)

This change ensures that shouldRetryBasedOnTiming executes if the operation hasn't completed successfully, even when shouldRetryBasedOnResult is false (e.g. due to non-retriable RPC exception due to the short deadline). This way a timeout-related exception will be thrown instead if the overall timeout has been reached.

Resolves #12373 