### PR TITLE
chore: ignore python build artifacts for library_generation tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ monorepo
 *.tfstate.lock.info
 
 .jqwik-database
+
+# Python build artifacts for library_generation tool
+sdk-platform-java/hermetic_build/library_generation/build/


### PR DESCRIPTION
Ignore python build artifacts for library_generation tool.

For context, `librarian install` will install synthtool with pip and creates build artifacts in this folder.