### PR TITLE
fix(bigquery-jdbc): Add escape character support for pattern matching

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -5083,55 +5083,27 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     boolean escaped = false;
     for (int i = 0; i < sqlLikePattern.length(); i++) {
       char c = sqlLikePattern.charAt(i);
-      if (escaped) {
-        if (isRegexMetacharacter(c)) {
-          regex.append('\\').append(c);
-        } else {
-          regex.append(c);
-        }
-        escaped = false;
-      } else if (c == '\\') {
+      if (!escaped && c == '\\') {
         escaped = true;
+        continue;
+      } else if (!escaped && c == '%') {
+        regex.append(".*");
+      } else if (!escaped && c == '_') {
+        regex.append('.');
       } else {
-        switch (c) {
-          case '%':
-            regex.append(".*");
-            break;
-          case '_':
-            regex.append('.');
-            break;
-          default:
-            if (isRegexMetacharacter(c)) {
-              regex.append('\\').append(c);
-            } else {
-              regex.append(c);
-            }
-            break;
+        if (isRegexMetacharacter(c)) {
+          regex.append('\\');
         }
+        regex.append(c);
+        escaped = false;
       }
-    }
-    if (escaped) {
-      regex.append('\\').append('\\');
     }
     regex.append('$');
     return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
   }
 
-  private boolean isRegexMetacharacter(char c) {
-    return c == '\\'
-        || c == '.'
-        || c == '['
-        || c == ']'
-        || c == '('
-        || c == ')'
-        || c == '{'
-        || c == '}'
-        || c == '*'
-        || c == '+'
-        || c == '?'
-        || c == '^'
-        || c == '$'
-        || c == '|';
+  private static boolean isRegexMetacharacter(char c) {
+    return "\\.[]{}()*+?^$|".indexOf(c) != -1;
   }
 
   boolean needsListing(String pattern) {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -5080,38 +5080,58 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     }
     StringBuilder regex = new StringBuilder(sqlLikePattern.length() * 2);
     regex.append('^');
+    boolean escaped = false;
     for (int i = 0; i < sqlLikePattern.length(); i++) {
       char c = sqlLikePattern.charAt(i);
-      switch (c) {
-        case '%':
-          regex.append(".*");
-          break;
-        case '_':
-          regex.append('.');
-          break;
-        case '\\':
-        case '.':
-        case '[':
-        case ']':
-        case '(':
-        case ')':
-        case '{':
-        case '}':
-        case '*':
-        case '+':
-        case '?':
-        case '^':
-        case '$':
-        case '|':
+      if (escaped) {
+        if (isRegexMetacharacter(c)) {
           regex.append('\\').append(c);
-          break;
-        default:
+        } else {
           regex.append(c);
-          break;
+        }
+        escaped = false;
+      } else if (c == '\\') {
+        escaped = true;
+      } else {
+        switch (c) {
+          case '%':
+            regex.append(".*");
+            break;
+          case '_':
+            regex.append('.');
+            break;
+          default:
+            if (isRegexMetacharacter(c)) {
+              regex.append('\\').append(c);
+            } else {
+              regex.append(c);
+            }
+            break;
+        }
       }
+    }
+    if (escaped) {
+      regex.append('\\').append('\\');
     }
     regex.append('$');
     return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
+  }
+
+  private boolean isRegexMetacharacter(char c) {
+    return c == '\\'
+        || c == '.'
+        || c == '['
+        || c == ']'
+        || c == '('
+        || c == ')'
+        || c == '{'
+        || c == '}'
+        || c == '*'
+        || c == '+'
+        || c == '?'
+        || c == '^'
+        || c == '$'
+        || c == '|';
   }
 
   boolean needsListing(String pattern) {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -5098,6 +5098,9 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
         escaped = false;
       }
     }
+    if (escaped) {
+      regex.append('\\').append('\\');
+    }
     regex.append('$');
     return Pattern.compile(regex.toString(), Pattern.CASE_INSENSITIVE);
   }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -254,6 +254,12 @@ public class BigQueryDatabaseMetaDataTest {
     assertNotNull(escapedPercent);
     assertTrue(escapedPercent.matcher("100%discount").matches());
     assertFalse(escapedPercent.matcher("100PERCENTdiscount").matches());
+
+    // Escape character at the end
+    Pattern escapeLast = dbMetadata.compileSqlLikePattern("test\\");
+    assertNotNull(escapeLast);
+    assertTrue(escapeLast.matcher("test\\").matches());
+    assertFalse(escapeLast.matcher("test").matches());
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -243,6 +243,17 @@ public class BigQueryDatabaseMetaDataTest {
     assertNotNull(bracketPattern);
     assertTrue(bracketPattern.matcher("array[0]").matches());
     assertFalse(bracketPattern.matcher("array_0_").matches());
+
+    // Escaped wildcards
+    Pattern escapedUnderscore = dbMetadata.compileSqlLikePattern("test\\_table");
+    assertNotNull(escapedUnderscore);
+    assertTrue(escapedUnderscore.matcher("test_table").matches());
+    assertFalse(escapedUnderscore.matcher("test1table").matches());
+
+    Pattern escapedPercent = dbMetadata.compileSqlLikePattern("100\\%discount");
+    assertNotNull(escapedPercent);
+    assertTrue(escapedPercent.matcher("100%discount").matches());
+    assertFalse(escapedPercent.matcher("100PERCENTdiscount").matches());
   }
 
   @Test


### PR DESCRIPTION
Various metadata methods (`getColumns`, `getTables`) rely on pattern matching. This PR adds a support for the escape character in these pattern matches.

Example of issue: 
`test\_table` is not matching `test_table`.