### PR TITLE
fix(spanner): derive built-in metrics project from database client

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsConstant.java
@@ -144,6 +144,7 @@ public class BuiltInMetricsConstant {
       ImmutableList.of(EEF_FALLBACK_COUNT_NAME, EEF_CALL_STATUS_NAME);
 
   public static final String SPANNER_RESOURCE_TYPE = "spanner_instance_client";
+  public static final String UNDEFINED_PROJECT_ID = "undefined-project";
 
   public static final AttributeKey<String> PROJECT_ID_KEY = AttributeKey.stringKey("project_id");
   public static final AttributeKey<String> INSTANCE_ID_KEY = AttributeKey.stringKey("instance_id");

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -78,6 +78,7 @@ final class BuiltInMetricsProvider {
   private OpenTelemetry openTelemetry;
   private String projectId;
   private boolean mismatchedProjectIdLogged;
+  private Thread shutdownHook;
 
   private BuiltInMetricsProvider() {}
 
@@ -96,7 +97,8 @@ final class BuiltInMetricsProvider {
         sdkMeterProviderBuilder.setResource(Resource.create(createResourceAttributes(projectId)));
         SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
         this.openTelemetry = OpenTelemetrySdk.builder().setMeterProvider(sdkMeterProvider).build();
-        Runtime.getRuntime().addShutdownHook(new Thread(sdkMeterProvider::close));
+        this.shutdownHook = new Thread(sdkMeterProvider::close);
+        Runtime.getRuntime().addShutdownHook(this.shutdownHook);
       }
       return this.openTelemetry;
     } catch (IOException ex) {
@@ -116,8 +118,9 @@ final class BuiltInMetricsProvider {
       mismatchedProjectIdLogged = true;
       logger.log(
           Level.WARNING,
-          "Built-in metrics are already initialized for project {0}. Metrics for project {1} will"
-              + " be exported using the existing project.",
+          "Built-in metrics fallback project is already initialized to project {0}. Non-Spanner"
+              + " metrics without project information will be exported using that project instead"
+              + " of project {1}.",
           new Object[] {this.projectId, projectId});
     }
   }
@@ -127,7 +130,6 @@ final class BuiltInMetricsProvider {
     return this.openTelemetry;
   }
 
-  @VisibleForTesting
   synchronized String getProjectId() {
     return this.projectId;
   }
@@ -137,9 +139,17 @@ final class BuiltInMetricsProvider {
     if (this.openTelemetry instanceof OpenTelemetrySdk) {
       ((OpenTelemetrySdk) this.openTelemetry).getSdkMeterProvider().close();
     }
+    if (this.shutdownHook != null) {
+      try {
+        Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+      } catch (IllegalStateException ignored) {
+        // The JVM is already shutting down.
+      }
+    }
     this.openTelemetry = null;
     this.projectId = null;
     this.mismatchedProjectIdLogged = false;
+    this.shutdownHook = null;
   }
 
   // TODO: Remove when

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/BuiltInMetricsProvider.java
@@ -32,6 +32,7 @@ import com.google.auth.Credentials;
 import com.google.cloud.opentelemetry.detection.AttributeKeys;
 import com.google.cloud.opentelemetry.detection.DetectedPlatform;
 import com.google.cloud.opentelemetry.detection.GCPPlatformDetector;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
@@ -75,10 +76,12 @@ final class BuiltInMetricsProvider {
   private static final String default_location = "global";
 
   private OpenTelemetry openTelemetry;
+  private String projectId;
+  private boolean mismatchedProjectIdLogged;
 
   private BuiltInMetricsProvider() {}
 
-  OpenTelemetry getOrCreateOpenTelemetry(
+  synchronized OpenTelemetry getOrCreateOpenTelemetry(
       String projectId,
       @Nullable Credentials credentials,
       @Nullable String monitoringHost,
@@ -88,7 +91,7 @@ final class BuiltInMetricsProvider {
         SdkMeterProviderBuilder sdkMeterProviderBuilder = SdkMeterProvider.builder();
         BuiltInMetricsView.registerBuiltinMetrics(
             SpannerCloudMonitoringExporter.create(
-                projectId, credentials, monitoringHost, universeDomain),
+                this::getProjectId, credentials, monitoringHost, universeDomain),
             sdkMeterProviderBuilder);
         sdkMeterProviderBuilder.setResource(Resource.create(createResourceAttributes(projectId)));
         SdkMeterProvider sdkMeterProvider = sdkMeterProviderBuilder.build();
@@ -104,6 +107,39 @@ final class BuiltInMetricsProvider {
           ex);
       return null;
     }
+  }
+
+  synchronized void setProjectIdIfAbsent(String projectId) {
+    if (this.projectId == null) {
+      this.projectId = projectId;
+    } else if (!this.projectId.equals(projectId) && !mismatchedProjectIdLogged) {
+      mismatchedProjectIdLogged = true;
+      logger.log(
+          Level.WARNING,
+          "Built-in metrics are already initialized for project {0}. Metrics for project {1} will"
+              + " be exported using the existing project.",
+          new Object[] {this.projectId, projectId});
+    }
+  }
+
+  @Nullable
+  synchronized OpenTelemetry getOpenTelemetry() {
+    return this.openTelemetry;
+  }
+
+  @VisibleForTesting
+  synchronized String getProjectId() {
+    return this.projectId;
+  }
+
+  @VisibleForTesting
+  synchronized void reset() {
+    if (this.openTelemetry instanceof OpenTelemetrySdk) {
+      ((OpenTelemetrySdk) this.openTelemetry).getSdkMeterProvider().close();
+    }
+    this.openTelemetry = null;
+    this.projectId = null;
+    this.mismatchedProjectIdLogged = false;
   }
 
   // TODO: Remove when

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -231,7 +231,6 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     if (spannerExportFailureLoggedProjects.add(projectName.getProject())) {
       String msg = "createServiceTimeSeries request failed for spanner metrics.";
       if (throwable instanceof PermissionDeniedException) {
-        // TODO: Add the link of public documentation when available in the log message.
         msg +=
             String.format(
                 " Need monitoring metric writer permission on project=%s. Follow"

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -42,16 +42,15 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import io.opentelemetry.sdk.resources.Resource;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -72,10 +71,19 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
   private final AtomicBoolean spannerExportFailureLogged = new AtomicBoolean(false);
   private final AtomicBoolean lastExportSkippedData = new AtomicBoolean(false);
   private final MetricServiceClient client;
-  private final String spannerProjectId;
+  private final Supplier<String> spannerProjectIdSupplier;
 
   static SpannerCloudMonitoringExporter create(
       String projectId,
+      @Nullable Credentials credentials,
+      @Nullable String monitoringHost,
+      String universeDomain)
+      throws IOException {
+    return create(() -> projectId, credentials, monitoringHost, universeDomain);
+  }
+
+  static SpannerCloudMonitoringExporter create(
+      Supplier<String> projectIdSupplier,
       @Nullable Credentials credentials,
       @Nullable String monitoringHost,
       String universeDomain)
@@ -114,13 +122,18 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     settingsBuilder.createServiceTimeSeriesSettings().setSimpleTimeoutNoRetriesDuration(timeout);
 
     return new SpannerCloudMonitoringExporter(
-        projectId, MetricServiceClient.create(settingsBuilder.build()));
+        projectIdSupplier, MetricServiceClient.create(settingsBuilder.build()));
   }
 
   @VisibleForTesting
   SpannerCloudMonitoringExporter(String projectId, MetricServiceClient client) {
+    this(() -> projectId, client);
+  }
+
+  @VisibleForTesting
+  SpannerCloudMonitoringExporter(Supplier<String> projectIdSupplier, MetricServiceClient client) {
     this.client = client;
-    this.spannerProjectId = projectId;
+    this.spannerProjectIdSupplier = projectIdSupplier;
   }
 
   @Override
@@ -140,29 +153,14 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
 
   /** Export client built in metrics */
   private CompletableResultCode exportSpannerClientMetrics(Collection<MetricData> collection) {
-    // Filter spanner metrics. Only include metrics that contain a valid project.
-    List<MetricData> spannerMetricData = collection.stream().collect(Collectors.toList());
-
-    // Log warnings for metrics that will be skipped.
-    boolean mustFilter = false;
-    if (spannerMetricData.stream()
-        .map(metricData -> metricData.getResource())
-        .anyMatch(this::shouldSkipPointDataDueToProjectId)) {
-      logger.log(
-          Level.WARNING, "Some metric data contain a different projectId. These will be skipped.");
-      mustFilter = true;
+    String spannerProjectId = spannerProjectIdSupplier.get();
+    if (Strings.isNullOrEmpty(spannerProjectId)) {
+      return CompletableResultCode.ofSuccess();
     }
-
-    if (mustFilter) {
-      spannerMetricData =
-          spannerMetricData.stream()
-              .filter(this::shouldSkipMetricData)
-              .collect(Collectors.toList());
-    }
-    lastExportSkippedData.set(mustFilter);
+    lastExportSkippedData.set(false);
 
     // Skips exporting if there's none
-    if (spannerMetricData.isEmpty()) {
+    if (collection.isEmpty()) {
       return CompletableResultCode.ofSuccess();
     }
 
@@ -170,7 +168,7 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     try {
       spannerTimeSeries =
           SpannerCloudMonitoringExporterUtils.convertToSpannerTimeSeries(
-              spannerMetricData, this.spannerProjectId);
+              new ArrayList<>(collection), spannerProjectId);
     } catch (Throwable e) {
       logger.log(
           Level.WARNING,
@@ -216,14 +214,6 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
         MoreExecutors.directExecutor());
 
     return spannerExportCode;
-  }
-
-  private boolean shouldSkipMetricData(MetricData metricData) {
-    return shouldSkipPointDataDueToProjectId(metricData.getResource());
-  }
-
-  private boolean shouldSkipPointDataDueToProjectId(Resource resource) {
-    return !spannerProjectId.equals(SpannerCloudMonitoringExporterUtils.getProjectId(resource));
   }
 
   boolean lastExportSkippedData() {

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -47,10 +47,13 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -68,21 +71,12 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
   // This the quota limit from Cloud Monitoring. More details in
   // https://cloud.google.com/monitoring/quotas#custom_metrics_quotas.
   private static final int EXPORT_BATCH_SIZE_LIMIT = 200;
-  private final AtomicBoolean spannerExportFailureLogged = new AtomicBoolean(false);
+  private final Set<String> spannerExportFailureLoggedProjects = ConcurrentHashMap.newKeySet();
   private final MetricServiceClient client;
-  private final Supplier<String> spannerProjectIdSupplier;
+  private final Supplier<String> fallbackProjectIdSupplier;
 
   static SpannerCloudMonitoringExporter create(
-      String projectId,
-      @Nullable Credentials credentials,
-      @Nullable String monitoringHost,
-      String universeDomain)
-      throws IOException {
-    return create(() -> projectId, credentials, monitoringHost, universeDomain);
-  }
-
-  static SpannerCloudMonitoringExporter create(
-      Supplier<String> projectIdSupplier,
+      Supplier<String> fallbackProjectIdSupplier,
       @Nullable Credentials credentials,
       @Nullable String monitoringHost,
       String universeDomain)
@@ -121,18 +115,19 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     settingsBuilder.createServiceTimeSeriesSettings().setSimpleTimeoutNoRetriesDuration(timeout);
 
     return new SpannerCloudMonitoringExporter(
-        projectIdSupplier, MetricServiceClient.create(settingsBuilder.build()));
+        fallbackProjectIdSupplier, MetricServiceClient.create(settingsBuilder.build()));
   }
 
   @VisibleForTesting
-  SpannerCloudMonitoringExporter(String projectId, MetricServiceClient client) {
-    this(() -> projectId, client);
+  SpannerCloudMonitoringExporter(MetricServiceClient client) {
+    this(() -> null, client);
   }
 
   @VisibleForTesting
-  SpannerCloudMonitoringExporter(Supplier<String> projectIdSupplier, MetricServiceClient client) {
+  SpannerCloudMonitoringExporter(
+      Supplier<String> fallbackProjectIdSupplier, MetricServiceClient client) {
     this.client = client;
-    this.spannerProjectIdSupplier = projectIdSupplier;
+    this.fallbackProjectIdSupplier = fallbackProjectIdSupplier;
   }
 
   @Override
@@ -152,10 +147,6 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
 
   /** Export client built in metrics */
   private CompletableResultCode exportSpannerClientMetrics(Collection<MetricData> collection) {
-    String spannerProjectId = spannerProjectIdSupplier.get();
-    if (Strings.isNullOrEmpty(spannerProjectId)) {
-      return CompletableResultCode.ofSuccess();
-    }
     // Skips exporting if there's none
     if (collection.isEmpty()) {
       return CompletableResultCode.ofSuccess();
@@ -165,7 +156,7 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     try {
       spannerTimeSeries =
           SpannerCloudMonitoringExporterUtils.convertToSpannerTimeSeries(
-              collection, spannerProjectId);
+              collection, fallbackProjectIdSupplier.get());
     } catch (Throwable e) {
       logger.log(
           Level.WARNING,
@@ -174,9 +165,48 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
       return CompletableResultCode.ofFailure();
     }
 
-    ProjectName projectName = ProjectName.of(spannerProjectId);
+    if (spannerTimeSeries.isEmpty()) {
+      return CompletableResultCode.ofSuccess();
+    }
 
-    ApiFuture<List<Empty>> futureList = exportTimeSeriesInBatch(projectName, spannerTimeSeries);
+    Map<String, List<TimeSeries>> timeSeriesByProject =
+        spannerTimeSeries.stream()
+            .collect(
+                Collectors.groupingBy(
+                    timeSeries ->
+                        timeSeries
+                            .getResource()
+                            .getLabelsMap()
+                            .get(BuiltInMetricsConstant.PROJECT_ID_KEY.getKey())));
+
+    List<ApiFuture<List<Empty>>> futures = new ArrayList<>();
+    for (Map.Entry<String, List<TimeSeries>> entry : timeSeriesByProject.entrySet()) {
+      ProjectName projectName = ProjectName.of(entry.getKey());
+      ApiFuture<List<Empty>> future = exportTimeSeriesInBatch(projectName, entry.getValue());
+      ApiFutures.addCallback(
+          future,
+          new ApiFutureCallback<List<Empty>>() {
+            @Override
+            public void onFailure(Throwable throwable) {
+              logExportFailure(throwable, projectName);
+            }
+
+            @Override
+            public void onSuccess(List<Empty> ignored) {
+              spannerExportFailureLoggedProjects.remove(projectName.getProject());
+            }
+          },
+          MoreExecutors.directExecutor());
+      futures.add(future);
+    }
+
+    ApiFuture<List<List<Empty>>> groupedFuture = ApiFutures.allAsList(futures);
+    ApiFuture<List<Empty>> futureList =
+        ApiFutures.transform(
+            groupedFuture,
+            groupedResults ->
+                groupedResults.stream().flatMap(List::stream).collect(Collectors.toList()),
+            MoreExecutors.directExecutor());
 
     CompletableResultCode spannerExportCode = new CompletableResultCode();
     ApiFutures.addCallback(
@@ -184,33 +214,36 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
         new ApiFutureCallback<List<Empty>>() {
           @Override
           public void onFailure(Throwable throwable) {
-            if (spannerExportFailureLogged.compareAndSet(false, true)) {
-              String msg = "createServiceTimeSeries request failed for spanner metrics.";
-              if (throwable instanceof PermissionDeniedException) {
-                // TODO: Add the link of public documentation when available in the log message.
-                msg +=
-                    String.format(
-                        " Need monitoring metric writer permission on project=%s. Follow"
-                            + " https://cloud.google.com/spanner/docs/view-manage-client-side-metrics#access-client-side-metrics"
-                            + " to set up permissions",
-                        projectName.getProject());
-              }
-              logger.log(Level.WARNING, msg, throwable);
-            }
             spannerExportCode.fail();
           }
 
           @Override
           public void onSuccess(List<Empty> empty) {
-            // When an export succeeded reset the export failure flag to false so if there's a
-            // transient failure it'll be logged.
-            spannerExportFailureLogged.set(false);
             spannerExportCode.succeed();
           }
         },
         MoreExecutors.directExecutor());
 
     return spannerExportCode;
+  }
+
+  private void logExportFailure(Throwable throwable, ProjectName projectName) {
+    if (spannerExportFailureLoggedProjects.add(projectName.getProject())) {
+      String msg = "createServiceTimeSeries request failed for spanner metrics.";
+      if (throwable instanceof PermissionDeniedException) {
+        // TODO: Add the link of public documentation when available in the log message.
+        msg +=
+            String.format(
+                " Need monitoring metric writer permission on project=%s. Follow"
+                    + " https://cloud.google.com/spanner/docs/view-manage-client-side-metrics"
+                    + "#access-client-side-metrics"
+                    + " to set up permissions",
+                projectName.getProject());
+      } else {
+        msg += String.format(" project=%s.", projectName.getProject());
+      }
+      logger.log(Level.WARNING, msg, throwable);
+    }
   }
 
   private ApiFuture<List<Empty>> exportTimeSeriesInBatch(

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporter.java
@@ -69,7 +69,6 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
   // https://cloud.google.com/monitoring/quotas#custom_metrics_quotas.
   private static final int EXPORT_BATCH_SIZE_LIMIT = 200;
   private final AtomicBoolean spannerExportFailureLogged = new AtomicBoolean(false);
-  private final AtomicBoolean lastExportSkippedData = new AtomicBoolean(false);
   private final MetricServiceClient client;
   private final Supplier<String> spannerProjectIdSupplier;
 
@@ -157,8 +156,6 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     if (Strings.isNullOrEmpty(spannerProjectId)) {
       return CompletableResultCode.ofSuccess();
     }
-    lastExportSkippedData.set(false);
-
     // Skips exporting if there's none
     if (collection.isEmpty()) {
       return CompletableResultCode.ofSuccess();
@@ -168,7 +165,7 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
     try {
       spannerTimeSeries =
           SpannerCloudMonitoringExporterUtils.convertToSpannerTimeSeries(
-              new ArrayList<>(collection), spannerProjectId);
+              collection, spannerProjectId);
     } catch (Throwable e) {
       logger.log(
           Level.WARNING,
@@ -214,10 +211,6 @@ class SpannerCloudMonitoringExporter implements MetricExporter {
         MoreExecutors.directExecutor());
 
     return spannerExportCode;
-  }
-
-  boolean lastExportSkippedData() {
-    return this.lastExportSkippedData.get();
   }
 
   private ApiFuture<List<Empty>> exportTimeSeriesInBatch(

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
@@ -62,6 +62,7 @@ import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import io.opentelemetry.sdk.metrics.data.SumData;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -75,7 +76,7 @@ class SpannerCloudMonitoringExporterUtils {
   private SpannerCloudMonitoringExporterUtils() {}
 
   static List<TimeSeries> convertToSpannerTimeSeries(
-      List<MetricData> collection, String projectId) {
+      Collection<MetricData> collection, String projectId) {
     List<TimeSeries> allTimeSeries = new ArrayList<>();
 
     for (MetricData metricData : collection) {

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
@@ -61,7 +61,6 @@ import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.metrics.data.PointData;
 import io.opentelemetry.sdk.metrics.data.SumData;
-import io.opentelemetry.sdk.resources.Resource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -74,10 +73,6 @@ class SpannerCloudMonitoringExporterUtils {
       Logger.getLogger(SpannerCloudMonitoringExporterUtils.class.getName());
 
   private SpannerCloudMonitoringExporterUtils() {}
-
-  static String getProjectId(Resource resource) {
-    return resource.getAttributes().get(PROJECT_ID_KEY);
-  }
 
   static List<TimeSeries> convertToSpannerTimeSeries(
       List<MetricData> collection, String projectId) {
@@ -102,6 +97,7 @@ class SpannerCloudMonitoringExporterUtils {
         monitoredResourceBuilder.putLabels(
             key.getKey(), String.valueOf(resourceAttributes.get(key)));
       }
+      monitoredResourceBuilder.putLabels(PROJECT_ID_KEY.getKey(), projectId);
 
       metricData.getData().getPoints().stream()
           .map(

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterUtils.java
@@ -30,6 +30,7 @@ import static com.google.cloud.spanner.BuiltInMetricsConstant.PROJECT_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.SPANNER_METER_NAME;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.SPANNER_PROMOTED_RESOURCE_LABELS;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.SPANNER_RESOURCE_TYPE;
+import static com.google.cloud.spanner.BuiltInMetricsConstant.UNDEFINED_PROJECT_ID;
 
 import com.google.api.Distribution;
 import com.google.api.Distribution.BucketOptions;
@@ -64,9 +65,11 @@ import io.opentelemetry.sdk.metrics.data.SumData;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 class SpannerCloudMonitoringExporterUtils {
 
@@ -76,7 +79,7 @@ class SpannerCloudMonitoringExporterUtils {
   private SpannerCloudMonitoringExporterUtils() {}
 
   static List<TimeSeries> convertToSpannerTimeSeries(
-      Collection<MetricData> collection, String projectId) {
+      Collection<MetricData> collection, String fallbackProjectId) {
     List<TimeSeries> allTimeSeries = new ArrayList<>();
 
     for (MetricData metricData : collection) {
@@ -95,26 +98,30 @@ class SpannerCloudMonitoringExporterUtils {
 
       Attributes resourceAttributes = metricData.getResource().getAttributes();
       for (AttributeKey<?> key : resourceAttributes.asMap().keySet()) {
-        monitoredResourceBuilder.putLabels(
-            key.getKey(), String.valueOf(resourceAttributes.get(key)));
+        if (!PROJECT_ID_KEY.equals(key)) {
+          monitoredResourceBuilder.putLabels(
+              key.getKey(), String.valueOf(resourceAttributes.get(key)));
+        }
       }
-      monitoredResourceBuilder.putLabels(PROJECT_ID_KEY.getKey(), projectId);
+      MonitoredResource baseMonitoredResource = monitoredResourceBuilder.build();
 
       metricData.getData().getPoints().stream()
           .map(
               pointData ->
                   convertPointToSpannerTimeSeries(
-                      metricData, pointData, monitoredResourceBuilder, projectId))
+                      metricData, pointData, baseMonitoredResource, fallbackProjectId))
+          .filter(Objects::nonNull)
           .forEach(allTimeSeries::add);
     }
     return allTimeSeries;
   }
 
+  @Nullable
   private static TimeSeries convertPointToSpannerTimeSeries(
       MetricData metricData,
       PointData pointData,
-      MonitoredResource.Builder monitoredResourceBuilder,
-      String projectId) {
+      MonitoredResource baseMonitoredResource,
+      String fallbackProjectId) {
     MetricKind metricKind = convertMetricKind(metricData);
     TimeSeries.Builder builder =
         TimeSeries.newBuilder()
@@ -123,9 +130,20 @@ class SpannerCloudMonitoringExporterUtils {
     Metric.Builder metricBuilder = Metric.newBuilder().setType(metricData.getName());
 
     Attributes attributes = pointData.getAttributes();
+    String projectId = attributes.get(PROJECT_ID_KEY);
+    if (!isUsableProjectId(projectId)) {
+      projectId = shouldUseFallbackProject(metricData) ? fallbackProjectId : null;
+    }
+    if (!isUsableProjectId(projectId)) {
+      return null;
+    }
+    MonitoredResource.Builder monitoredResourceBuilder = baseMonitoredResource.toBuilder();
+    monitoredResourceBuilder.putLabels(PROJECT_ID_KEY.getKey(), projectId);
 
     for (AttributeKey<?> key : attributes.asMap().keySet()) {
-      if (SPANNER_PROMOTED_RESOURCE_LABELS.contains(key)) {
+      if (PROJECT_ID_KEY.equals(key)) {
+        continue;
+      } else if (SPANNER_PROMOTED_RESOURCE_LABELS.contains(key)) {
         monitoredResourceBuilder.putLabels(key.getKey(), String.valueOf(attributes.get(key)));
       } else {
         // Replace metric label names by converting "." to "_" since Cloud Monitoring does not
@@ -154,6 +172,15 @@ class SpannerCloudMonitoringExporterUtils {
     builder.addPoints(createPoint(metricData.getType(), pointData, timeInterval, projectId));
 
     return builder.build();
+  }
+
+  private static boolean isUsableProjectId(String projectId) {
+    return projectId != null && !projectId.isEmpty() && !UNDEFINED_PROJECT_ID.equals(projectId);
+  }
+
+  private static boolean shouldUseFallbackProject(MetricData metricData) {
+    String meterName = metricData.getInstrumentationScopeInfo().getName();
+    return GRPC_METER_NAME.equals(meterName) || GRPC_GCP_METER_NAME.equals(meterName);
   }
 
   private static MetricKind convertMetricKind(MetricData metricData) {

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerImpl.java
@@ -309,6 +309,7 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
         if (clientId == null) {
           clientId = nextDatabaseClientId(db);
         }
+        getOptions().initializeBuiltInMetrics(db);
         MultiplexedSessionDatabaseClient multiplexedSessionDatabaseClient =
             new MultiplexedSessionDatabaseClient(SpannerImpl.this.getSessionClient(db));
         DatabaseClientImpl dbClient =
@@ -337,6 +338,7 @@ class SpannerImpl extends BaseService<SpannerOptions> implements Spanner {
       if (this.dbBatchClients.containsKey(db)) {
         return this.dbBatchClients.get(db);
       }
+      getOptions().initializeBuiltInMetrics(db);
       BatchClientImpl batchClient = new BatchClientImpl(getSessionClient(db));
       this.dbBatchClients.put(db, batchClient);
       return batchClient;

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -2520,6 +2520,17 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     }
   }
 
+  void initializeBuiltInMetrics(DatabaseId databaseId) {
+    if (isEnableBuiltInMetrics() && !usesNoCredentials()) {
+      this.builtInMetricsProvider.setProjectIdIfAbsent(databaseId.getInstanceId().getProject());
+      this.builtInMetricsProvider.getOrCreateOpenTelemetry(
+          databaseId.getInstanceId().getProject(),
+          getCredentials(),
+          this.monitoringHost,
+          getUniverseDomain());
+    }
+  }
+
   public ApiTracerFactory getApiTracerFactory(boolean isAdminClient, boolean isEmulatorEnabled) {
     return createApiTracerFactory(isAdminClient, isEmulatorEnabled);
   }

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -2523,11 +2523,6 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   void initializeBuiltInMetrics(DatabaseId databaseId) {
     if (isEnableBuiltInMetrics() && !usesNoCredentials()) {
       this.builtInMetricsProvider.setProjectIdIfAbsent(databaseId.getInstanceId().getProject());
-      this.builtInMetricsProvider.getOrCreateOpenTelemetry(
-          databaseId.getInstanceId().getProject(),
-          getCredentials(),
-          this.monitoringHost,
-          getUniverseDomain());
     }
   }
 

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/HeaderInterceptor.java
@@ -16,6 +16,7 @@
 package com.google.cloud.spanner.spi.v1;
 
 import static com.google.api.gax.grpc.GrpcCallContext.TRACER_KEY;
+import static com.google.cloud.spanner.BuiltInMetricsConstant.UNDEFINED_PROJECT_ID;
 import static com.google.cloud.spanner.spi.v1.SpannerRpcViews.DATABASE_ID;
 import static com.google.cloud.spanner.spi.v1.SpannerRpcViews.INSTANCE_ID;
 import static com.google.cloud.spanner.spi.v1.SpannerRpcViews.METHOD;
@@ -268,7 +269,7 @@ class HeaderInterceptor implements ClientInterceptor {
       return databaseNameCache.get(
           googleResourcePrefix,
           () -> {
-            String projectId = "undefined-project";
+            String projectId = UNDEFINED_PROJECT_ID;
             String instanceId = "undefined-database";
             String databaseId = "undefined-database";
             Matcher matcher = GOOGLE_CLOUD_RESOURCE_PREFIX_PATTERN.matcher(googleResourcePrefix);
@@ -329,6 +330,10 @@ class HeaderInterceptor implements ClientInterceptor {
         key,
         () -> {
           Map<String, String> attributes = new HashMap<>();
+          if (!UNDEFINED_PROJECT_ID.equals(databaseName.getProject())) {
+            attributes.put(
+                BuiltInMetricsConstant.PROJECT_ID_KEY.getKey(), databaseName.getProject());
+          }
           attributes.put(BuiltInMetricsConstant.DATABASE_KEY.getKey(), databaseName.getDatabase());
           attributes.put(
               BuiltInMetricsConstant.INSTANCE_ID_KEY.getKey(), databaseName.getInstance());

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInOpenTelemetryMetricsProviderTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInOpenTelemetryMetricsProviderTest.java
@@ -95,6 +95,7 @@ public class BuiltInOpenTelemetryMetricsProviderTest {
     SpannerOptions options = newTestOptions();
 
     options.initializeBuiltInMetrics(DatabaseId.of("database-project", "i", "d"));
+    options.initializeBuiltInMetrics(DatabaseId.of("other-project", "i", "d"));
 
     assertEquals("database-project", BuiltInMetricsProvider.INSTANCE.getProjectId());
   }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInOpenTelemetryMetricsProviderTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInOpenTelemetryMetricsProviderTest.java
@@ -17,14 +17,30 @@
 package com.google.cloud.spanner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.OAuth2Credentials;
+import java.util.Date;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class BuiltInOpenTelemetryMetricsProviderTest {
+
+  @Before
+  public void setUp() {
+    BuiltInMetricsProvider.INSTANCE.reset();
+  }
+
+  @After
+  public void tearDown() {
+    BuiltInMetricsProvider.INSTANCE.reset();
+  }
 
   @Test
   public void testGenerateClientHashWithSimpleUid() {
@@ -56,11 +72,46 @@ public class BuiltInOpenTelemetryMetricsProviderTest {
     verifyHash(BuiltInMetricsProvider.generateClientHash(clientUid));
   }
 
+  @Test
+  public void testApiTracerFactoryDoesNotSetBuiltInMetricsProject() {
+    SpannerOptions options = newTestOptions();
+
+    options.getApiTracerFactory(/* isAdminClient= */ false, /* isEmulatorEnabled= */ false);
+
+    assertNull(BuiltInMetricsProvider.INSTANCE.getProjectId());
+  }
+
+  @Test
+  public void testBuiltInOpenTelemetryDoesNotSetMetricsProject() {
+    SpannerOptions options = newTestOptions();
+
+    options.getBuiltInOpenTelemetry();
+
+    assertNull(BuiltInMetricsProvider.INSTANCE.getProjectId());
+  }
+
+  @Test
+  public void testInitializeBuiltInMetricsUsesDatabaseProject() {
+    SpannerOptions options = newTestOptions();
+
+    options.initializeBuiltInMetrics(DatabaseId.of("database-project", "i", "d"));
+
+    assertEquals("database-project", BuiltInMetricsProvider.INSTANCE.getProjectId());
+  }
+
   private void verifyHash(String hash) {
     // Check if the hash length is 6
     assertEquals(hash.length(), 6);
     // Check if the hash is in the range [000000, 0003ff]
     long hashValue = Long.parseLong(hash, 16); // Convert hash from hex to decimal
     assertTrue(hashValue >= 0 && hashValue <= 0x3FF);
+  }
+
+  private SpannerOptions newTestOptions() {
+    return SpannerOptions.newBuilder()
+        .setProjectId("host-project")
+        .setCredentials(
+            OAuth2Credentials.create(new AccessToken("test-token", new Date(Long.MAX_VALUE))))
+        .build();
   }
 }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -74,6 +74,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       BuiltInMetricsProvider.INSTANCE.createClientAttributes();
   private static final Attributes expectedCommonBaseAttributes =
       Attributes.builder()
+          .put(BuiltInMetricsConstant.PROJECT_ID_KEY, "test-project")
           .put(BuiltInMetricsConstant.CLIENT_NAME_KEY, "spanner-java/")
           .put(BuiltInMetricsConstant.CLIENT_UID_KEY, attributes.get("client_uid"))
           .put(BuiltInMetricsConstant.INSTANCE_ID_KEY, "i")

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
@@ -203,6 +203,47 @@ public class SpannerCloudMonitoringExporterTest {
   }
 
   @Test
+  public void testExportingOverridesResourceProject() {
+    ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
+        ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
+
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = Mockito.mock(UnaryCallable.class);
+    Mockito.when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
+    ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
+    Mockito.when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
+
+    Resource resourceWithDifferentProject =
+        Resource.create(
+            resourceAttributes.toBuilder().put(PROJECT_ID_KEY, "resource-project").build());
+    LongPointData longPointData = ImmutableLongPointData.create(10, 15, attributes, 11L);
+    MetricData longData =
+        ImmutableMetricData.createLongSum(
+            resourceWithDifferentProject,
+            scope,
+            "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
+            "description",
+            "1",
+            ImmutableSumData.create(
+                true, AggregationTemporality.CUMULATIVE, ImmutableList.of(longPointData)));
+
+    exporter.export(Collections.singletonList(longData));
+
+    CreateTimeSeriesRequest request = argumentCaptor.getValue();
+    assertThat(request.getName()).isEqualTo("projects/" + projectId);
+    assertThat(request.getTimeSeries(0).getResource().getLabelsMap())
+        .containsEntry(PROJECT_ID_KEY.getKey(), projectId);
+  }
+
+  @Test
+  public void testExportingSkipsUntilProjectIsSet() {
+    exporter = new SpannerCloudMonitoringExporter(() -> null, fakeMetricServiceClient);
+
+    exporter.export(Collections.emptyList());
+
+    Mockito.verify(mockMetricServiceStub, Mockito.never()).createServiceTimeSeriesCallable();
+  }
+
+  @Test
   public void testExportingHistogramData() {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
@@ -23,12 +23,14 @@ import static com.google.cloud.spanner.BuiltInMetricsConstant.DATABASE_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.DIRECT_PATH_ENABLED_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.DIRECT_PATH_USED_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.GAX_METER_NAME;
+import static com.google.cloud.spanner.BuiltInMetricsConstant.GRPC_METER_NAME;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.INSTANCE_CONFIG_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.INSTANCE_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.LOCATION_ID_KEY;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.OPERATION_COUNT_NAME;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.OPERATION_LATENCIES_NAME;
 import static com.google.cloud.spanner.BuiltInMetricsConstant.PROJECT_ID_KEY;
+import static com.google.cloud.spanner.BuiltInMetricsConstant.UNDEFINED_PROJECT_ID;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -106,12 +108,13 @@ public class SpannerCloudMonitoringExporterTest {
   @Before
   public void setUp() {
     fakeMetricServiceClient = new FakeMetricServiceClient(mockMetricServiceStub);
-    exporter = new SpannerCloudMonitoringExporter(projectId, fakeMetricServiceClient);
+    exporter = new SpannerCloudMonitoringExporter(fakeMetricServiceClient);
 
     this.client_uid = BuiltInMetricsProvider.INSTANCE.createClientAttributes().get("client_uid");
 
     attributes =
         Attributes.builder()
+            .put(PROJECT_ID_KEY, projectId)
             .put(INSTANCE_ID_KEY, instanceId)
             .put(DATABASE_KEY, databaseId)
             .put(CLIENT_NAME_KEY, clientName)
@@ -155,7 +158,7 @@ public class SpannerCloudMonitoringExporterTest {
     MetricData longData =
         ImmutableMetricData.createLongSum(
             resource,
-            scope,
+            InstrumentationScopeInfo.create(GRPC_METER_NAME),
             "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
             "description",
             "1",
@@ -200,7 +203,7 @@ public class SpannerCloudMonitoringExporterTest {
   }
 
   @Test
-  public void testExportingOverridesResourceProject() {
+  public void testExportingUsesPointProjectOverResourceProject() {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
@@ -212,7 +215,10 @@ public class SpannerCloudMonitoringExporterTest {
     Resource resourceWithDifferentProject =
         Resource.create(
             resourceAttributes.toBuilder().put(PROJECT_ID_KEY, "resource-project").build());
-    LongPointData longPointData = ImmutableLongPointData.create(10, 15, attributes, 11L);
+    Attributes attributesWithDifferentProject =
+        attributes.toBuilder().put(PROJECT_ID_KEY, "target-project").build();
+    LongPointData longPointData =
+        ImmutableLongPointData.create(10, 15, attributesWithDifferentProject, 11L);
     MetricData longData =
         ImmutableMetricData.createLongSum(
             resourceWithDifferentProject,
@@ -226,18 +232,30 @@ public class SpannerCloudMonitoringExporterTest {
     exporter.export(Collections.singletonList(longData));
 
     CreateTimeSeriesRequest request = argumentCaptor.getValue();
-    assertThat(request.getName()).isEqualTo("projects/" + projectId);
+    assertThat(request.getName()).isEqualTo("projects/target-project");
     assertThat(request.getTimeSeries(0).getResource().getLabelsMap())
-        .containsEntry(PROJECT_ID_KEY.getKey(), projectId);
+        .containsEntry(PROJECT_ID_KEY.getKey(), "target-project");
   }
 
   @Test
-  public void testExportingSkipsUntilProjectIsSet() {
-    exporter = new SpannerCloudMonitoringExporter(() -> null, fakeMetricServiceClient);
-    LongPointData longPointData = ImmutableLongPointData.create(10, 15, attributes, 11L);
+  public void testExportingSkipsMetricsWithoutPointProjectOrFallbackProject() {
+    Resource resourceWithProject =
+        Resource.create(
+            resourceAttributes.toBuilder().put(PROJECT_ID_KEY, "resource-project").build());
+    Attributes attributesWithoutProject =
+        Attributes.builder()
+            .put(INSTANCE_ID_KEY, instanceId)
+            .put(DATABASE_KEY, databaseId)
+            .put(CLIENT_NAME_KEY, clientName)
+            .put(CLIENT_UID_KEY, this.client_uid)
+            .put(String.valueOf(DIRECT_PATH_ENABLED_KEY), true)
+            .put(String.valueOf(DIRECT_PATH_USED_KEY), true)
+            .build();
+    LongPointData longPointData =
+        ImmutableLongPointData.create(10, 15, attributesWithoutProject, 11L);
     MetricData longData =
         ImmutableMetricData.createLongSum(
-            resource,
+            resourceWithProject,
             scope,
             "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
             "description",
@@ -248,6 +266,141 @@ public class SpannerCloudMonitoringExporterTest {
     exporter.export(Collections.singletonList(longData));
 
     Mockito.verify(mockMetricServiceStub, Mockito.never()).createServiceTimeSeriesCallable();
+  }
+
+  @Test
+  public void testExportingUsesFallbackProjectForMetricsWithUndefinedPointProject() {
+    exporter =
+        new SpannerCloudMonitoringExporter(() -> "fallback-project", fakeMetricServiceClient);
+    ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
+        ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
+
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
+    ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
+    when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
+
+    Attributes attributesWithUndefinedProject =
+        Attributes.builder()
+            .put(PROJECT_ID_KEY, UNDEFINED_PROJECT_ID)
+            .put(INSTANCE_ID_KEY, instanceId)
+            .put(DATABASE_KEY, databaseId)
+            .put(CLIENT_NAME_KEY, clientName)
+            .put(CLIENT_UID_KEY, this.client_uid)
+            .build();
+    LongPointData longPointData =
+        ImmutableLongPointData.create(10, 15, attributesWithUndefinedProject, 11L);
+    MetricData longData =
+        ImmutableMetricData.createLongSum(
+            resource,
+            InstrumentationScopeInfo.create(GRPC_METER_NAME),
+            "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
+            "description",
+            "1",
+            ImmutableSumData.create(
+                true, AggregationTemporality.CUMULATIVE, ImmutableList.of(longPointData)));
+
+    exporter.export(Collections.singletonList(longData));
+
+    CreateTimeSeriesRequest request = argumentCaptor.getValue();
+    assertThat(request.getName()).isEqualTo("projects/fallback-project");
+    assertThat(request.getTimeSeries(0).getResource().getLabelsMap())
+        .containsEntry(PROJECT_ID_KEY.getKey(), "fallback-project");
+  }
+
+  @Test
+  public void testExportingRoutesPointProjectAndFallbackProject() {
+    exporter =
+        new SpannerCloudMonitoringExporter(() -> "fallback-project", fakeMetricServiceClient);
+    ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
+        ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
+
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
+    ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
+    when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
+
+    LongPointData pointWithProject =
+        ImmutableLongPointData.create(
+            10, 15, attributes.toBuilder().put(PROJECT_ID_KEY, "point-project").build(), 100L);
+    LongPointData pointWithoutProject =
+        ImmutableLongPointData.create(
+            10, 15, Attributes.builder().put(INSTANCE_ID_KEY, instanceId).build(), 200L);
+    MetricData metricWithProject =
+        ImmutableMetricData.createLongSum(
+            resource,
+            scope,
+            "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
+            "description",
+            "1",
+            ImmutableSumData.create(
+                true, AggregationTemporality.CUMULATIVE, ImmutableList.of(pointWithProject)));
+    MetricData metricWithoutProject =
+        ImmutableMetricData.createLongSum(
+            resource,
+            InstrumentationScopeInfo.create(GRPC_METER_NAME),
+            "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
+            "description",
+            "1",
+            ImmutableSumData.create(
+                true, AggregationTemporality.CUMULATIVE, ImmutableList.of(pointWithoutProject)));
+
+    exporter.export(Arrays.asList(metricWithProject, metricWithoutProject));
+
+    Map<String, CreateTimeSeriesRequest> requestsByName =
+        argumentCaptor.getAllValues().stream()
+            .collect(Collectors.toMap(CreateTimeSeriesRequest::getName, request -> request));
+    assertThat(requestsByName.keySet())
+        .containsExactly("projects/point-project", "projects/fallback-project");
+  }
+
+  @Test
+  public void testExportingRoutesMultipleProjects() {
+    ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
+        ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
+
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
+    ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
+    when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
+
+    Attributes attributesProjectX = attributes.toBuilder().put(PROJECT_ID_KEY, "project-x").build();
+    Attributes attributesProjectY = attributes.toBuilder().put(PROJECT_ID_KEY, "project-y").build();
+    LongPointData pointX = ImmutableLongPointData.create(10, 15, attributesProjectX, 100L);
+    LongPointData pointY = ImmutableLongPointData.create(10, 15, attributesProjectY, 200L);
+
+    MetricData metricX =
+        ImmutableMetricData.createLongSum(
+            resource,
+            scope,
+            "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
+            "description",
+            "1",
+            ImmutableSumData.create(
+                true, AggregationTemporality.CUMULATIVE, ImmutableList.of(pointX)));
+    MetricData metricY =
+        ImmutableMetricData.createLongSum(
+            resource,
+            scope,
+            "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
+            "description",
+            "1",
+            ImmutableSumData.create(
+                true, AggregationTemporality.CUMULATIVE, ImmutableList.of(pointY)));
+
+    exporter.export(Arrays.asList(metricX, metricY));
+
+    assertThat(argumentCaptor.getAllValues()).hasSize(2);
+    Map<String, CreateTimeSeriesRequest> requestsByName =
+        argumentCaptor.getAllValues().stream()
+            .collect(Collectors.toMap(CreateTimeSeriesRequest::getName, request -> request));
+    assertThat(requestsByName.keySet()).containsExactly("projects/project-x", "projects/project-y");
+    assertThat(
+            requestsByName.get("projects/project-x").getTimeSeries(0).getResource().getLabelsMap())
+        .containsEntry(PROJECT_ID_KEY.getKey(), "project-x");
+    assertThat(
+            requestsByName.get("projects/project-y").getTimeSeries(0).getResource().getLabelsMap())
+        .containsEntry(PROJECT_ID_KEY.getKey(), "project-y");
   }
 
   @Test
@@ -500,7 +653,7 @@ public class SpannerCloudMonitoringExporterTest {
   @Test
   public void getAggregationTemporality() throws IOException {
     SpannerCloudMonitoringExporter actualExporter =
-        SpannerCloudMonitoringExporter.create(projectId, null, null, null);
+        SpannerCloudMonitoringExporter.create(() -> null, null, null, null);
     assertThat(actualExporter.getAggregationTemporality(InstrumentType.COUNTER))
         .isEqualTo(AggregationTemporality.CUMULATIVE);
   }
@@ -508,7 +661,7 @@ public class SpannerCloudMonitoringExporterTest {
   @Test
   public void testUniverseDomain() throws IOException {
     SpannerCloudMonitoringExporter actualExporter =
-        SpannerCloudMonitoringExporter.create(projectId, null, null, "abc.goog");
+        SpannerCloudMonitoringExporter.create(() -> null, null, null, "abc.goog");
     MetricServiceSettings metricServiceSettings =
         actualExporter.getMetricServiceClient().getSettings();
 
@@ -517,7 +670,7 @@ public class SpannerCloudMonitoringExporterTest {
 
     actualExporter =
         SpannerCloudMonitoringExporter.create(
-            projectId, null, "monitoringa.abc.goog:443", "abc.goog");
+            () -> null, null, "monitoringa.abc.goog:443", "abc.goog");
     metricServiceSettings = actualExporter.getMetricServiceClient().getSettings();
 
     assertEquals("abc.goog", metricServiceSettings.getUniverseDomain());

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
@@ -31,7 +31,6 @@ import static com.google.cloud.spanner.BuiltInMetricsConstant.OPERATION_LATENCIE
 import static com.google.cloud.spanner.BuiltInMetricsConstant.PROJECT_ID_KEY;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -164,8 +163,6 @@ public class SpannerCloudMonitoringExporterTest {
                 true, AggregationTemporality.CUMULATIVE, ImmutableList.of(longPointData)));
 
     exporter.export(Collections.singletonList(longData));
-    assertFalse(exporter.lastExportSkippedData());
-
     CreateTimeSeriesRequest request = argumentCaptor.getValue();
 
     assertThat(request.getTimeSeriesList()).hasSize(1);
@@ -237,8 +234,18 @@ public class SpannerCloudMonitoringExporterTest {
   @Test
   public void testExportingSkipsUntilProjectIsSet() {
     exporter = new SpannerCloudMonitoringExporter(() -> null, fakeMetricServiceClient);
+    LongPointData longPointData = ImmutableLongPointData.create(10, 15, attributes, 11L);
+    MetricData longData =
+        ImmutableMetricData.createLongSum(
+            resource,
+            scope,
+            "spanner.googleapis.com/internal/client/" + OPERATION_COUNT_NAME,
+            "description",
+            "1",
+            ImmutableSumData.create(
+                true, AggregationTemporality.CUMULATIVE, ImmutableList.of(longPointData)));
 
-    exporter.export(Collections.emptyList());
+    exporter.export(Collections.singletonList(longData));
 
     Mockito.verify(mockMetricServiceStub, Mockito.never()).createServiceTimeSeriesCallable();
   }
@@ -279,8 +286,6 @@ public class SpannerCloudMonitoringExporterTest {
                 AggregationTemporality.CUMULATIVE, ImmutableList.of(histogramPointData)));
 
     exporter.export(Collections.singletonList(histogramData));
-    assertFalse(exporter.lastExportSkippedData());
-
     CreateTimeSeriesRequest request = argumentCaptor.getValue();
 
     assertThat(request.getTimeSeriesList()).hasSize(1);
@@ -355,8 +360,6 @@ public class SpannerCloudMonitoringExporterTest {
 
     assertThat(firstRequest.getTimeSeriesList()).hasSize(200);
     assertThat(secondRequest.getTimeSeriesList()).hasSize(50);
-    assertFalse(exporter.lastExportSkippedData());
-
     for (int i = 0; i < 250; i++) {
       TimeSeries timeSeries;
       if (i < 200) {
@@ -449,8 +452,6 @@ public class SpannerCloudMonitoringExporterTest {
                 AggregationTemporality.CUMULATIVE, ImmutableList.of(histogramPointData)));
 
     exporter.export(Collections.singletonList(histogramData));
-    assertFalse(exporter.lastExportSkippedData());
-
     CreateTimeSeriesRequest request = argumentCaptor.getValue();
     TimeSeries timeSeries = request.getTimeSeriesList().get(0);
     Distribution distribution = timeSeries.getPoints(0).getValue().getDistributionValue();

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerImplTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.core.NanoClock;
@@ -113,6 +114,7 @@ public class SpannerImplTest {
     DatabaseClient databaseClient1 = impl.getDatabaseClient(db);
 
     assertThat(databaseClient1).isSameInstanceAs(databaseClient);
+    verify(spannerOptions).initializeBuiltInMetrics(db);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-java/issues/13240

### Problem

  The built-in-metrics Cloud Monitoring exporter can initialize before any DatabaseClient exists, so the OpenTelemetry Resource may carry the host/GKE project instead of the Spanner project — metrics get attributed to the wrong project. A  single resource-level project also misattributes metrics for multi-project clients (RPCs to databases in other  projects).

 ### Solution

  Route each metric by its point-level project_id instead of the resource project:

  1. HeaderInterceptor adds project_id to its existing cached built-in attribute map (cache-miss only, only when parsed from the resource prefix and not the undefined-project sentinel). No new parsing or per-RPC work.
  2. The exporter ignores the resource-level project_id, derives each TimeSeries' project from the point, groups by
  project, and calls createServiceTimeSeries once per project (still batched at the 200 quota limit).
  3. Fallback for points with no usable project is meter-scoped: grpc-java/grpc-gcp core metrics use a fallback project (first DatabaseClient/BatchClient project, set in initializeBuiltInMetrics); Spanner/GAX DB-scoped metrics are skipped rather than exported under an unrelated project. No fallback yet → skip.

#### Notes / trade-offs

  - gRPC/core metrics for multi-project clients are attributed to the first client's project (they carry no point project).
  - gRPC/core metrics before the first data/batch client, or in admin-only processes, are dropped.
  - Per-project export-failure logging (once per project, with PermissionDeniedException setup guidance + project id; cleared on a successful export).
