### PR TITLE
test(spanner): fix MockAutoTaggingTest test environment pollution

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockAutoTaggingTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockAutoTaggingTest.java
@@ -35,12 +35,14 @@ public class MockAutoTaggingTest extends AbstractMockServerTest {
 
   @Before
   public void setUpProperties() {
+    SpannerOptions.useDefaultEnvironment();
     System.clearProperty("spanner.disable_auto_tagging");
     System.clearProperty("spanner.enable_auto_tagging");
   }
 
   @After
   public void tearDownProperties() {
+    SpannerOptions.useDefaultEnvironment();
     System.clearProperty("spanner.disable_auto_tagging");
     System.clearProperty("spanner.enable_auto_tagging");
   }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockAutoTaggingTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockAutoTaggingTest.java
@@ -35,16 +35,16 @@ public class MockAutoTaggingTest extends AbstractMockServerTest {
 
   @Before
   public void setUpProperties() {
-    SpannerOptions.useDefaultEnvironment();
     System.clearProperty("spanner.disable_auto_tagging");
     System.clearProperty("spanner.enable_auto_tagging");
+    SpannerOptions.useDefaultEnvironment();
   }
 
   @After
   public void tearDownProperties() {
-    SpannerOptions.useDefaultEnvironment();
     System.clearProperty("spanner.disable_auto_tagging");
     System.clearProperty("spanner.enable_auto_tagging");
+    SpannerOptions.useDefaultEnvironment();
   }
 
   private Spanner createSpanner(boolean enableAutoTag, String targetPackage) {


### PR DESCRIPTION
Cleans up static SpannerOptions.environment pollution between test executions in the test suite by explicitly resetting to the default environment in @Before and @After methods. This ensures that System properties enabling or disabling auto-tagging are correctly picked up during test runs.