### PR TITLE
feat(storage): add checksum validation in the json read channel

### DIFF
--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -38,7 +38,9 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import com.google.common.hash.HashingInputStream;
 import com.google.common.io.BaseEncoding;
+import com.google.common.primitives.Ints;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import java.io.IOException;
@@ -61,6 +63,7 @@ import javax.annotation.concurrent.Immutable;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+@SuppressWarnings("UnstableApiUsage")
 class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChannel {
 
   private final ApiaryReadRequest apiaryReadRequest;
@@ -68,6 +71,7 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
   private final SettableApiFuture<StorageObject> result;
   private final ResultRetryAlgorithm<?> resultRetryAlgorithm;
   private final Retrier retrier;
+  private final Hasher hasher;
 
   private long position;
   private ScatteringByteChannel sbc;
@@ -77,16 +81,21 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
   // returned X-Goog-Generation header value
   private Long xGoogGeneration;
 
+  private HashingInputStream hashingInputStream;
+  private String expectedCrc32cBase64;
+
   ApiaryUnbufferedReadableByteChannel(
       ApiaryReadRequest apiaryReadRequest,
       Storage storage,
       SettableApiFuture<StorageObject> result,
       Retrier retrier,
-      ResultRetryAlgorithm<?> resultRetryAlgorithm) {
+      ResultRetryAlgorithm<?> resultRetryAlgorithm,
+      Hasher hasher) {
     this.apiaryReadRequest = apiaryReadRequest;
     this.storage = storage;
     this.result = result;
     this.retrier = retrier;
+    this.hasher = hasher;
     this.resultRetryAlgorithm =
         new BasicResultRetryAlgorithm<Object>() {
           @Override
@@ -126,6 +135,16 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
         long read = sbc.read(dsts, offset, length);
         if (read == -1) {
           returnEOF = true;
+          if (hashingInputStream != null && expectedCrc32cBase64 != null) {
+            int calculatedCrc32c = hashingInputStream.hash().asInt();
+            byte[] decoded = BaseEncoding.base64().decode(expectedCrc32cBase64);
+            int expectedVal = Ints.fromByteArray(decoded);
+
+            Crc32cValue<?> expected = Crc32cValue.of(expectedVal, 0);
+            Crc32cValue.Crc32cLengthKnown actual = Crc32cValue.of(calculatedCrc32c, 0);
+
+            Hasher.defaultHasher().validate(expected, actual);
+          }
         } else {
           totalRead += read;
         }
@@ -211,7 +230,17 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
           if (!result.isDone()) {
             result.set(clone);
           }
+
+          Map<String, String> hashes = ChecksumResponseParser.extractHashesFromHeader(media);
+          this.expectedCrc32cBase64 = hashes.get("crc32c");
         }
+      }
+
+      boolean isHasherEnabled = !(hasher instanceof Hasher.NoOpHasher);
+      boolean isFullObjectDownload = (request.getByteRangeSpec().getHttpRangeHeader() == null);
+      if (isHasherEnabled && isFullObjectDownload) {
+        this.hashingInputStream = new HashingInputStream(Hashing.crc32c(), content);
+        content = this.hashingInputStream;
       }
 
       ReadableByteChannel rbc = Channels.newChannel(content);

--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -199,6 +199,10 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
 
       HttpResponse media = get.executeMedia();
       InputStream content = media.getContent();
+
+      Map<String, String> hashes = ChecksumResponseParser.extractHashesFromHeader(media);
+      this.expectedCrc32cBase64 = hashes.get("crc32c");
+
       if (xGoogGeneration == null) {
         HttpHeaders responseHeaders = media.getHeaders();
 
@@ -230,15 +234,13 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
           if (!result.isDone()) {
             result.set(clone);
           }
-
-          Map<String, String> hashes = ChecksumResponseParser.extractHashesFromHeader(media);
-          this.expectedCrc32cBase64 = hashes.get("crc32c");
         }
       }
 
       boolean isHasherEnabled = !(hasher instanceof Hasher.NoOpHasher);
-      boolean isFullObjectDownload = (request.getByteRangeSpec().getHttpRangeHeader() == null);
-      if (isHasherEnabled && isFullObjectDownload && expectedCrc32cBase64 != null) {
+      boolean shouldValidate =
+          isHasherEnabled && HttpStorageRpcHasherHelper.INSTANCE.shouldValidate(media);
+      if (shouldValidate && expectedCrc32cBase64 != null) {
         this.hashingInputStream = new HashingInputStream(Hashing.crc32c(), content);
         content = this.hashingInputStream;
       }

--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannel.java
@@ -143,7 +143,7 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
             Crc32cValue<?> expected = Crc32cValue.of(expectedVal, 0);
             Crc32cValue.Crc32cLengthKnown actual = Crc32cValue.of(calculatedCrc32c, 0);
 
-            Hasher.defaultHasher().validate(expected, actual);
+            hasher.validate(expected, actual);
           }
         } else {
           totalRead += read;
@@ -238,7 +238,7 @@ class ApiaryUnbufferedReadableByteChannel implements UnbufferedReadableByteChann
 
       boolean isHasherEnabled = !(hasher instanceof Hasher.NoOpHasher);
       boolean isFullObjectDownload = (request.getByteRangeSpec().getHttpRangeHeader() == null);
-      if (isHasherEnabled && isFullObjectDownload) {
+      if (isHasherEnabled && isFullObjectDownload && expectedCrc32cBase64 != null) {
         this.hashingInputStream = new HashingInputStream(Hashing.crc32c(), content);
         content = this.hashingInputStream;
       }

--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpDownloadSessionBuilder.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpDownloadSessionBuilder.java
@@ -54,10 +54,11 @@ final class HttpDownloadSessionBuilder {
     private final BlobReadChannelContext blobReadChannelContext;
     private boolean autoGzipDecompression;
 
-    // private Hasher hasher; // TODO: wire in Hasher
+    private final Hasher hasher;
 
     private ReadableByteChannelSessionBuilder(BlobReadChannelContext blobReadChannelContext) {
       this.blobReadChannelContext = blobReadChannelContext;
+      this.hasher = Hasher.defaultHasher();
       this.autoGzipDecompression = false;
     }
 
@@ -96,7 +97,8 @@ final class HttpDownloadSessionBuilder {
                   blobReadChannelContext.getApiaryClient(),
                   resultFuture,
                   blobReadChannelContext.getRetrier(),
-                  blobReadChannelContext.getRetryAlgorithmManager().idempotent()),
+                  blobReadChannelContext.getRetryAlgorithmManager().idempotent(),
+                  hasher),
               ApiFutures.transform(
                   resultFuture, StorageObject::getContentEncoding, MoreExecutors.directExecutor()));
         } else {
@@ -105,7 +107,8 @@ final class HttpDownloadSessionBuilder {
               blobReadChannelContext.getApiaryClient(),
               resultFuture,
               blobReadChannelContext.getRetrier(),
-              blobReadChannelContext.getRetryAlgorithmManager().idempotent());
+              blobReadChannelContext.getRetryAlgorithmManager().idempotent(),
+              hasher);
         }
       };
     }

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannelTest.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannelTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
+import java.util.Map;
 import org.junit.Test;
 
 public class ApiaryUnbufferedReadableByteChannelTest {
@@ -43,6 +44,11 @@ public class ApiaryUnbufferedReadableByteChannelTest {
   private static final String WRONG_CRC32C_BASE64 = "AAAAAA==";
 
   private Storage createMockStorageClient(String googHashHeader) {
+    return createMockStorageClient(200, googHashHeader, null);
+  }
+
+  private Storage createMockStorageClient(
+      int statusCode, String googHashHeader, Map<String, String> extraHeaders) {
     HttpTransport transport =
         new HttpTransport() {
           @Override
@@ -53,12 +59,18 @@ public class ApiaryUnbufferedReadableByteChannelTest {
               public com.google.api.client.http.LowLevelHttpResponse execute() throws IOException {
                 MockLowLevelHttpResponse lowLevelResponse =
                     new MockLowLevelHttpResponse()
+                        .setStatusCode(statusCode)
                         .setContent(CONTENT_BYTES)
                         .setContentLength(CONTENT_BYTES.length)
                         .addHeader("Content-Length", String.valueOf(CONTENT_BYTES.length))
                         .addHeader("x-goog-generation", "12345");
                 if (googHashHeader != null) {
                   lowLevelResponse.addHeader("x-goog-hash", googHashHeader);
+                }
+                if (extraHeaders != null) {
+                  for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {
+                    lowLevelResponse.addHeader(entry.getKey(), entry.getValue());
+                  }
                 }
                 return lowLevelResponse;
               }
@@ -131,6 +143,79 @@ public class ApiaryUnbufferedReadableByteChannelTest {
               });
 
       assertTrue(expected.getMessage().contains("Mismatch checksum value"));
+    }
+  }
+
+  @Test
+  public void testRead_suffixRangeFullObjectCrc32cValidation() throws IOException {
+    // Suffix range request resulting in content-range: bytes 0-12/13
+    Map<String, String> extraHeaders = ImmutableMap.of("Content-Range", "bytes 0-12/13");
+    Storage storageClient =
+        createMockStorageClient(206, "crc32c=" + CORRECT_CRC32C_BASE64, extraHeaders);
+
+    StorageObject from = new StorageObject().setBucket("bucket").setName("blob");
+    ApiaryReadRequest apiaryReadRequest =
+        new ApiaryReadRequest(from, ImmutableMap.of(), ByteRangeSpec.nullRange());
+
+    SettableApiFuture<StorageObject> resultFuture = SettableApiFuture.create();
+    try (ApiaryUnbufferedReadableByteChannel channel =
+        new ApiaryUnbufferedReadableByteChannel(
+            apiaryReadRequest,
+            storageClient,
+            resultFuture,
+            RetrierWithAlg.attemptOnce(),
+            Retrying.neverRetry(),
+            Hasher.defaultHasher()); ) {
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try (WritableByteChannel w = Channels.newChannel(out)) {
+        ByteBuffer buf = ByteBuffer.allocate(4096);
+        while (channel.read(new ByteBuffer[] {buf}, 0, 1) != -1) {
+          buf.flip();
+          w.write(buf);
+          buf.clear();
+        }
+      }
+
+      assertArrayEquals(CONTENT_BYTES, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testRead_partialRangeNoCrc32cValidation() throws IOException {
+    // Partial range request resulting in content-range: bytes 1-12/13
+    Map<String, String> extraHeaders = ImmutableMap.of("Content-Range", "bytes 1-12/13");
+    // Even if checksum is wrong, it shouldn't throw ChecksumMismatchException because validation is
+    // skipped for partial downloads.
+    Storage storageClient =
+        createMockStorageClient(206, "crc32c=" + WRONG_CRC32C_BASE64, extraHeaders);
+
+    StorageObject from = new StorageObject().setBucket("bucket").setName("blob");
+    ApiaryReadRequest apiaryReadRequest =
+        new ApiaryReadRequest(from, ImmutableMap.of(), ByteRangeSpec.nullRange());
+
+    SettableApiFuture<StorageObject> resultFuture = SettableApiFuture.create();
+    try (ApiaryUnbufferedReadableByteChannel channel =
+        new ApiaryUnbufferedReadableByteChannel(
+            apiaryReadRequest,
+            storageClient,
+            resultFuture,
+            RetrierWithAlg.attemptOnce(),
+            Retrying.neverRetry(),
+            Hasher.defaultHasher()); ) {
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try (WritableByteChannel w = Channels.newChannel(out)) {
+        ByteBuffer buf = ByteBuffer.allocate(4096);
+        while (channel.read(new ByteBuffer[] {buf}, 0, 1) != -1) {
+          buf.flip();
+          w.write(buf);
+          buf.clear();
+        }
+      }
+
+      // We read the entire response content successfully (no exception thrown)
+      assertArrayEquals(CONTENT_BYTES, out.toByteArray());
     }
   }
 }

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannelTest.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannelTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.storage;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
+import com.google.cloud.storage.ApiaryUnbufferedReadableByteChannel.ApiaryReadRequest;
+import com.google.cloud.storage.Retrying.RetrierWithAlg;
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import org.junit.Test;
+
+public class ApiaryUnbufferedReadableByteChannelTest {
+
+  private static final byte[] CONTENT_BYTES = "Hello, World!".getBytes();
+  private static final String CORRECT_CRC32C_BASE64 = "TVUQaA==";
+  private static final String WRONG_CRC32C_BASE64 = "AAAAAA==";
+
+  private Storage createMockStorageClient(String googHashHeader) {
+    HttpTransport transport =
+        new HttpTransport() {
+          @Override
+          protected com.google.api.client.http.LowLevelHttpRequest buildRequest(
+              String method, String url) throws IOException {
+            return new com.google.api.client.testing.http.MockLowLevelHttpRequest() {
+              @Override
+              public com.google.api.client.http.LowLevelHttpResponse execute() throws IOException {
+                MockLowLevelHttpResponse lowLevelResponse =
+                    new MockLowLevelHttpResponse()
+                        .setContent(CONTENT_BYTES)
+                        .setContentLength(CONTENT_BYTES.length)
+                        .addHeader("Content-Length", String.valueOf(CONTENT_BYTES.length))
+                        .addHeader("x-goog-generation", "12345");
+                if (googHashHeader != null) {
+                  lowLevelResponse.addHeader("x-goog-hash", googHashHeader);
+                }
+                return lowLevelResponse;
+              }
+            };
+          }
+        };
+    return new Storage.Builder(transport, GsonFactory.getDefaultInstance(), null)
+        .setApplicationName("test")
+        .build();
+  }
+
+  @Test
+  public void testRead_successfulCrc32cValidation() throws IOException {
+    Storage storageClient = createMockStorageClient("crc32c=" + CORRECT_CRC32C_BASE64);
+
+    StorageObject from = new StorageObject().setBucket("bucket").setName("blob");
+    ApiaryReadRequest apiaryReadRequest =
+        new ApiaryReadRequest(from, ImmutableMap.of(), ByteRangeSpec.nullRange());
+
+    SettableApiFuture<StorageObject> resultFuture = SettableApiFuture.create();
+    try (ApiaryUnbufferedReadableByteChannel channel =
+        new ApiaryUnbufferedReadableByteChannel(
+            apiaryReadRequest,
+            storageClient,
+            resultFuture,
+            RetrierWithAlg.attemptOnce(),
+            Retrying.neverRetry(),
+            Hasher.defaultHasher()); ) {
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      try (WritableByteChannel w = Channels.newChannel(out)) {
+        ByteBuffer buf = ByteBuffer.allocate(4096);
+        while (channel.read(new ByteBuffer[] {buf}, 0, 1) != -1) {
+          buf.flip();
+          w.write(buf);
+          buf.clear();
+        }
+      }
+
+      assertArrayEquals(CONTENT_BYTES, out.toByteArray());
+    }
+  }
+
+  @Test
+  public void testRead_mismatchedCrc32cValidation_throwsChecksumMismatch() throws IOException {
+    Storage storageClient = createMockStorageClient("crc32c=" + WRONG_CRC32C_BASE64);
+
+    StorageObject from = new StorageObject().setBucket("bucket").setName("blob");
+    ApiaryReadRequest apiaryReadRequest =
+        new ApiaryReadRequest(from, ImmutableMap.of(), ByteRangeSpec.nullRange());
+
+    SettableApiFuture<StorageObject> resultFuture = SettableApiFuture.create();
+    try (ApiaryUnbufferedReadableByteChannel channel =
+        new ApiaryUnbufferedReadableByteChannel(
+            apiaryReadRequest,
+            storageClient,
+            resultFuture,
+            RetrierWithAlg.attemptOnce(),
+            Retrying.neverRetry(),
+            Hasher.defaultHasher()); ) {
+
+      ByteBuffer buf = ByteBuffer.allocate(4096);
+      IOException expected =
+          assertThrows(
+              IOException.class,
+              () -> {
+                while (channel.read(new ByteBuffer[] {buf}, 0, 1) != -1) {
+                  buf.clear();
+                }
+              });
+
+      assertTrue(expected instanceof Hasher.ChecksumMismatchException);
+      assertTrue(expected.getMessage().contains("Mismatch checksum value"));
+    }
+  }
+}

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannelTest.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/ApiaryUnbufferedReadableByteChannelTest.java
@@ -121,16 +121,15 @@ public class ApiaryUnbufferedReadableByteChannelTest {
             Hasher.defaultHasher()); ) {
 
       ByteBuffer buf = ByteBuffer.allocate(4096);
-      IOException expected =
+      Hasher.ChecksumMismatchException expected =
           assertThrows(
-              IOException.class,
+              Hasher.ChecksumMismatchException.class,
               () -> {
                 while (channel.read(new ByteBuffer[] {buf}, 0, 1) != -1) {
                   buf.clear();
                 }
               });
 
-      assertTrue(expected instanceof Hasher.ChecksumMismatchException);
       assertTrue(expected.getMessage().contains("Mismatch checksum value"));
     }
   }


### PR DESCRIPTION
Enabled default full object checksum validation for the following:
`Storage#reader(blobId)`
`Storage#reader(bucketName, blobName)`