### PR TITLE
chore(bigquery-jdbc): Force integration tests to use per-run datasets

### DIFF
--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
@@ -41,7 +41,7 @@ public class ITBase extends BigQueryJdbcBaseTest {
           + "  name STRING,\n"
           + "  id INT64,\n"
           + "  result STRING\n"
-          + ");";
+          + ");\n";
 
   private static final String DDL_IT_CALLABLE_STMT_PROC_TABLE =
       "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.IT_CALLABLE_STMT_PROC_TABLE`\n"
@@ -49,39 +49,39 @@ public class ITBase extends BigQueryJdbcBaseTest {
           + "  name STRING,\n"
           + "  id INT64,\n"
           + "  result STRING\n"
-          + ");";
+          + ");\n";
 
   private static final String DDL_IT_CALLABLE_STMT_PROC_DML_INSERT_TEST =
       "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_INSERT_TEST`(in_name STRING, in_id INT64, in_result STRING)\n"
           + "BEGIN\n"
           + "  INSERT INTO `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_TABLE` VALUES(in_name, in_id, in_result);\n"
-          + "END;";
+          + "END;\n";
 
   private static final String DDL_IT_CALLABLE_STMT_PROC_DML_UPDATE_TEST =
       "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_UPDATE_TEST`(in_name STRING, in_id INT64, in_result STRING)\n"
           + "BEGIN\n"
           + "  UPDATE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_TABLE` SET name = in_name, result = in_result WHERE id = in_id;\n"
-          + "END;";
+          + "END;\n";
 
   private static final String DDL_IT_CALLABLE_STMT_PROC_DML_DELETE_TEST =
       "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_DELETE_TEST`(in_id INT64)\n"
           + "BEGIN\n"
           + "  DELETE FROM `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_TABLE` WHERE id = in_id;\n"
-          + "END;";
+          + "END;\n";
 
   private static final String DDL_IT_CALLABLE_STMT_PROC_TEST =
       "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_TEST`(name STRING, id INT64, OUT result STRING)\n"
           + "BEGIN\n"
           + "  SET result = CONCAT(name, '-', id);\n"
           + "  INSERT INTO `%1$s.%2$s.IT_CALLABLE_STMT_PROC_TABLE` VALUES(name, id, result);\n"
-          + "END;";
+          + "END;\n";
 
   private static final String DDL_JDBC_CONSTRAINTS_TEST_TABLE3 =
       "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE3`\n"
           + "(\n"
           + "  address STRING,\n"
           + "  PRIMARY KEY (address) NOT ENFORCED\n"
-          + ");";
+          + ");\n";
 
   private static final String DDL_JDBC_CONSTRAINTS_TEST_TABLE2 =
       "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE2`\n"
@@ -89,7 +89,7 @@ public class ITBase extends BigQueryJdbcBaseTest {
           + "  first_name STRING,\n"
           + "  last_name STRING,\n"
           + "  PRIMARY KEY (first_name, last_name) NOT ENFORCED\n"
-          + ");";
+          + ");\n";
 
   private static final String DDL_JDBC_CONSTRAINTS_TEST_TABLE =
       "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE`\n"
@@ -101,22 +101,26 @@ public class ITBase extends BigQueryJdbcBaseTest {
           + "  PRIMARY KEY (id) NOT ENFORCED,\n"
           + "  CONSTRAINT my_fk FOREIGN KEY (name, second_name) REFERENCES `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE2`(first_name, last_name) NOT ENFORCED,\n"
           + "  CONSTRAINT my_fk2 FOREIGN KEY (address) REFERENCES `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE3`(address) NOT ENFORCED\n"
-          + ");";
+          + ");\n";
 
   private static final String CREATE_RESOURCES_SCRIPT =
-      DDL_IT_CALLABLE_STMT_PROC_DML_TABLE + "\n"
-          + DDL_IT_CALLABLE_STMT_PROC_TABLE + "\n"
-          + DDL_JDBC_CONSTRAINTS_TEST_TABLE3 + "\n"
-          + DDL_JDBC_CONSTRAINTS_TEST_TABLE2 + "\n"
-          + DDL_JDBC_CONSTRAINTS_TEST_TABLE + "\n"
-          + DDL_IT_CALLABLE_STMT_PROC_DML_INSERT_TEST + "\n"
-          + DDL_IT_CALLABLE_STMT_PROC_DML_UPDATE_TEST + "\n"
-          + DDL_IT_CALLABLE_STMT_PROC_DML_DELETE_TEST + "\n"
+      DDL_IT_CALLABLE_STMT_PROC_DML_TABLE
+          + DDL_IT_CALLABLE_STMT_PROC_TABLE
+          + DDL_JDBC_CONSTRAINTS_TEST_TABLE3
+          + DDL_JDBC_CONSTRAINTS_TEST_TABLE2
+          + DDL_JDBC_CONSTRAINTS_TEST_TABLE
+          + DDL_IT_CALLABLE_STMT_PROC_DML_INSERT_TEST
+          + DDL_IT_CALLABLE_STMT_PROC_DML_UPDATE_TEST
+          + DDL_IT_CALLABLE_STMT_PROC_DML_DELETE_TEST
           + DDL_IT_CALLABLE_STMT_PROC_TEST;
 
   public static synchronized String getSharedDataset() {
     if (sharedDataset == null) {
-      sharedDataset = "JDBC_IT_SHARED_" + System.currentTimeMillis() + "_" + (100 + new java.util.Random().nextInt(900));
+      sharedDataset =
+          "JDBC_IT_SHARED_"
+              + System.currentTimeMillis()
+              + "_"
+              + (100 + new java.util.Random().nextInt(900));
       try {
         setUpDataset(sharedDataset);
         registerShutdownHook(sharedDataset);
@@ -131,7 +135,11 @@ public class ITBase extends BigQueryJdbcBaseTest {
 
   public static synchronized String getSharedDataset2() {
     if (sharedDataset2 == null) {
-      sharedDataset2 = "JDBC_IT_SHARED_2_" + System.currentTimeMillis() + "_" + (100 + new java.util.Random().nextInt(900));
+      sharedDataset2 =
+          "JDBC_IT_SHARED_2_"
+              + System.currentTimeMillis()
+              + "_"
+              + (100 + new java.util.Random().nextInt(900));
       try {
         setUpDataset(sharedDataset2);
         registerShutdownHook(sharedDataset2);
@@ -151,15 +159,21 @@ public class ITBase extends BigQueryJdbcBaseTest {
   }
 
   private static void registerShutdownHook(final String dataset) {
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      try {
-        BigQuery bigQuery = BigQueryOptions.getDefaultInstance().getService();
-        bigQuery.query(QueryJobConfiguration.of(String.format(dropSchema, DEFAULT_CATALOG, dataset)));
-        System.out.println("Cleaned up shared dataset: " + dataset);
-      } catch (Exception e) {
-        System.err.println("Failed to cleanup shared dataset " + dataset + ": " + e.getMessage());
-      }
-    }));
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    BigQuery bigQuery = BigQueryOptions.getDefaultInstance().getService();
+                    bigQuery.query(
+                        QueryJobConfiguration.of(
+                            String.format(dropSchema, DEFAULT_CATALOG, dataset)));
+                    System.out.println("Cleaned up shared dataset: " + dataset);
+                  } catch (Exception e) {
+                    System.err.println(
+                        "Failed to cleanup shared dataset " + dataset + ": " + e.getMessage());
+                  }
+                }));
   }
 
   public static final String DEFAULT_CATALOG = ServiceOptions.getDefaultProjectId();

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
@@ -32,6 +32,136 @@ import java.util.List;
 
 public class ITBase extends BigQueryJdbcBaseTest {
 
+  private static String sharedDataset;
+  private static String sharedDataset2;
+
+  private static final String DDL_IT_CALLABLE_STMT_PROC_DML_TABLE =
+      "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_TABLE`\n"
+          + "(\n"
+          + "  name STRING,\n"
+          + "  id INT64,\n"
+          + "  result STRING\n"
+          + ");";
+
+  private static final String DDL_IT_CALLABLE_STMT_PROC_TABLE =
+      "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.IT_CALLABLE_STMT_PROC_TABLE`\n"
+          + "(\n"
+          + "  name STRING,\n"
+          + "  id INT64,\n"
+          + "  result STRING\n"
+          + ");";
+
+  private static final String DDL_IT_CALLABLE_STMT_PROC_DML_INSERT_TEST =
+      "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_INSERT_TEST`(in_name STRING, in_id INT64, in_result STRING)\n"
+          + "BEGIN\n"
+          + "  INSERT INTO `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_TABLE` VALUES(in_name, in_id, in_result);\n"
+          + "END;";
+
+  private static final String DDL_IT_CALLABLE_STMT_PROC_DML_UPDATE_TEST =
+      "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_UPDATE_TEST`(in_name STRING, in_id INT64, in_result STRING)\n"
+          + "BEGIN\n"
+          + "  UPDATE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_TABLE` SET name = in_name, result = in_result WHERE id = in_id;\n"
+          + "END;";
+
+  private static final String DDL_IT_CALLABLE_STMT_PROC_DML_DELETE_TEST =
+      "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_DELETE_TEST`(in_id INT64)\n"
+          + "BEGIN\n"
+          + "  DELETE FROM `%1$s.%2$s.IT_CALLABLE_STMT_PROC_DML_TABLE` WHERE id = in_id;\n"
+          + "END;";
+
+  private static final String DDL_IT_CALLABLE_STMT_PROC_TEST =
+      "CREATE OR REPLACE PROCEDURE `%1$s.%2$s.IT_CALLABLE_STMT_PROC_TEST`(name STRING, id INT64, OUT result STRING)\n"
+          + "BEGIN\n"
+          + "  SET result = CONCAT(name, '-', id);\n"
+          + "  INSERT INTO `%1$s.%2$s.IT_CALLABLE_STMT_PROC_TABLE` VALUES(name, id, result);\n"
+          + "END;";
+
+  private static final String DDL_JDBC_CONSTRAINTS_TEST_TABLE3 =
+      "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE3`\n"
+          + "(\n"
+          + "  address STRING,\n"
+          + "  PRIMARY KEY (address) NOT ENFORCED\n"
+          + ");";
+
+  private static final String DDL_JDBC_CONSTRAINTS_TEST_TABLE2 =
+      "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE2`\n"
+          + "(\n"
+          + "  first_name STRING,\n"
+          + "  last_name STRING,\n"
+          + "  PRIMARY KEY (first_name, last_name) NOT ENFORCED\n"
+          + ");";
+
+  private static final String DDL_JDBC_CONSTRAINTS_TEST_TABLE =
+      "CREATE TABLE IF NOT EXISTS `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE`\n"
+          + "(\n"
+          + "  id INT64,\n"
+          + "  name STRING,\n"
+          + "  second_name STRING,\n"
+          + "  address STRING,\n"
+          + "  PRIMARY KEY (id) NOT ENFORCED,\n"
+          + "  CONSTRAINT my_fk FOREIGN KEY (name, second_name) REFERENCES `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE2`(first_name, last_name) NOT ENFORCED,\n"
+          + "  CONSTRAINT my_fk2 FOREIGN KEY (address) REFERENCES `%1$s.%2$s.JDBC_CONSTRAINTS_TEST_TABLE3`(address) NOT ENFORCED\n"
+          + ");";
+
+  private static final String CREATE_RESOURCES_SCRIPT =
+      DDL_IT_CALLABLE_STMT_PROC_DML_TABLE + "\n"
+          + DDL_IT_CALLABLE_STMT_PROC_TABLE + "\n"
+          + DDL_JDBC_CONSTRAINTS_TEST_TABLE3 + "\n"
+          + DDL_JDBC_CONSTRAINTS_TEST_TABLE2 + "\n"
+          + DDL_JDBC_CONSTRAINTS_TEST_TABLE + "\n"
+          + DDL_IT_CALLABLE_STMT_PROC_DML_INSERT_TEST + "\n"
+          + DDL_IT_CALLABLE_STMT_PROC_DML_UPDATE_TEST + "\n"
+          + DDL_IT_CALLABLE_STMT_PROC_DML_DELETE_TEST + "\n"
+          + DDL_IT_CALLABLE_STMT_PROC_TEST;
+
+  public static synchronized String getSharedDataset() {
+    if (sharedDataset == null) {
+      sharedDataset = "JDBC_IT_SHARED_" + System.currentTimeMillis() + "_" + (100 + new java.util.Random().nextInt(900));
+      try {
+        setUpDataset(sharedDataset);
+        registerShutdownHook(sharedDataset);
+        createSharedResources(sharedDataset);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    }
+    return sharedDataset;
+  }
+
+  public static synchronized String getSharedDataset2() {
+    if (sharedDataset2 == null) {
+      sharedDataset2 = "JDBC_IT_SHARED_2_" + System.currentTimeMillis() + "_" + (100 + new java.util.Random().nextInt(900));
+      try {
+        setUpDataset(sharedDataset2);
+        registerShutdownHook(sharedDataset2);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    }
+    return sharedDataset2;
+  }
+
+  private static void createSharedResources(String dataset) throws InterruptedException {
+    BigQuery bigQuery = BigQueryOptions.getDefaultInstance().getService();
+    String project = DEFAULT_CATALOG;
+    String script = String.format(CREATE_RESOURCES_SCRIPT, project, dataset);
+    bigQuery.query(QueryJobConfiguration.of(script));
+  }
+
+  private static void registerShutdownHook(final String dataset) {
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      try {
+        BigQuery bigQuery = BigQueryOptions.getDefaultInstance().getService();
+        bigQuery.query(QueryJobConfiguration.of(String.format(dropSchema, DEFAULT_CATALOG, dataset)));
+        System.out.println("Cleaned up shared dataset: " + dataset);
+      } catch (Exception e) {
+        System.err.println("Failed to cleanup shared dataset " + dataset + ": " + e.getMessage());
+      }
+    }));
+  }
+
   public static final String DEFAULT_CATALOG = ServiceOptions.getDefaultProjectId();
   public static String connectionUrl =
       "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId="

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
@@ -76,7 +76,7 @@ public class ITBigQueryJDBCTest extends ITBase {
           + " trip_distance asc LIMIT %s";
   private static final Random random = new Random();
   private static final int randomNumber = random.nextInt(9999);
-  private static final String DATASET = "JDBC_PRESUBMIT_INTEGRATION_DATASET";
+  private static String DATASET;
   private static final Object EXCEPTION_REPLACEMENT = "EXCEPTION-WAS-RAISED";
   static Connection bigQueryConnection;
   static BigQuery bigQuery;
@@ -86,6 +86,7 @@ public class ITBigQueryJDBCTest extends ITBase {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
+    DATASET = ITBase.getSharedDataset();
     bigQueryConnection = DriverManager.getConnection(connection_uri, new Properties());
     bigQueryStatement = bigQueryConnection.createStatement();
 
@@ -1567,7 +1568,6 @@ public class ITBigQueryJDBCTest extends ITBase {
   @Test
   public void testPreparedStatementExecuteUpdate() throws SQLException {
     Random random = new Random();
-    String DATASET = "JDBC_INTEGRATION_DATASET";
     String TABLE_NAME1 = "Inventory" + random.nextInt(9999);
     String TABLE_NAME2 = "DetailedInventory" + random.nextInt(9999);
 
@@ -1658,7 +1658,6 @@ public class ITBigQueryJDBCTest extends ITBase {
   @Test
   public void testPreparedStatementDateTimeValues() throws SQLException {
     Random random = new Random();
-    String DATASET = "JDBC_INTEGRATION_DATASET";
     String TABLE_NAME1 = "DateTimeTestTable" + random.nextInt(9999);
 
     final String createTableQuery =
@@ -1680,7 +1679,7 @@ public class ITBigQueryJDBCTest extends ITBase {
     PreparedStatement insertPs = bigQueryConnection.prepareStatement(insertQuery);
     insertPs.setString(1, "dishwasher");
     insertPs.setInt(2, 1);
-    insertPs.setTimestamp(3, Timestamp.from(Instant.now()));
+    insertPs.setTimestamp(3, new Timestamp(System.currentTimeMillis()));
     insertPs.setTime(4, Time.valueOf(LocalTime.NOON));
     insertPs.setDate(5, Date.valueOf("2025-12-3"));
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
@@ -53,7 +53,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.time.LocalTime;
 import java.util.Properties;
 import java.util.Random;

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITCallableStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITCallableStatementTest.java
@@ -53,7 +53,7 @@ public class ITCallableStatementTest extends ITBase {
           + PROJECT_ID
           + ";OAUTHTYPE=3";
   private static final Random random = new Random();
-  private static final String DATASET = "JDBC_PRESUBMIT_INTEGRATION_DATASET";
+  private static String DATASET;
   private static final String CALLABLE_STMT_PROC_NAME = "IT_CALLABLE_STMT_PROC_TEST";
   private static final String CALLABLE_STMT_TABLE_NAME = "IT_CALLABLE_STMT_PROC_TABLE";
   private static final String CALLABLE_STMT_PARAM_KEY = "CALL_STMT_PARAM_KEY";
@@ -71,6 +71,7 @@ public class ITCallableStatementTest extends ITBase {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
+    DATASET = ITBase.getSharedDataset();
     bigQueryConnection = DriverManager.getConnection(connection_uri, new Properties());
     bigQueryStatement = bigQueryConnection.createStatement();
     bigQuery = BigQueryOptions.newBuilder().build().getService();

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITConnectionTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 
 public class ITConnectionTest {
 
-  private static final String DATASET = "JDBC_CONNECTION_TEST_DATASET";
+  private static String DATASET;
   private static final String DEFAULT_CATALOG = ServiceOptions.getDefaultProjectId();
   static Random random = new Random();
   static int randomNumber = random.nextInt(999);
@@ -53,15 +53,14 @@ public class ITConnectionTest {
 
   @BeforeClass
   public static void beforeClass() throws InterruptedException {
-
-    ITBase.setUpDataset(DATASET);
+    DATASET = ITBase.getSharedDataset();
     ITBase.setUpTable(DATASET, TABLE_NAME);
     ITBase.setUpProcedure(DATASET, TABLE_NAME);
   }
 
   @AfterClass
   public static void afterClass() throws InterruptedException {
-    ITBase.cleanUp(DATASET);
+    // Shared dataset cleanup is handled by shutdown hook
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITDatabaseMetadataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITDatabaseMetadataTest.java
@@ -55,9 +55,9 @@ public class ITDatabaseMetadataTest extends ITBase {
           + ";OAUTHTYPE=3";
   private static final Random random = new Random();
   private static final int randomNumber = random.nextInt(9999);
-  private static final String DATASET = "JDBC_PRESUBMIT_INTEGRATION_DATASET";
-  private static final String DATASET2 = "JDBC_PRESUBMIT_INTEGRATION_DATASET_2";
-  private static final String CONSTRAINTS_DATASET = "JDBC_CONSTRAINTS_TEST_DATASET";
+  private static String DATASET;
+  private static String DATASET2;
+  private static String CONSTRAINTS_DATASET;
   private static final String CONSTRAINTS_TABLE_NAME = "JDBC_CONSTRAINTS_TEST_TABLE";
   private static final String CONSTRAINTS_TABLE_NAME2 = "JDBC_CONSTRAINTS_TEST_TABLE2";
   private static final String CONSTRAINTS_TABLE_NAME3 = "JDBC_CONSTRAINTS_TEST_TABLE3";
@@ -70,6 +70,9 @@ public class ITDatabaseMetadataTest extends ITBase {
 
   @BeforeClass
   public static void beforeClass() throws InterruptedException, SQLException {
+    DATASET = ITBase.getSharedDataset();
+    DATASET2 = ITBase.getSharedDataset2();
+    CONSTRAINTS_DATASET = ITBase.getSharedDataset();
     // Set up Dataset
     ITBase.setUpTable(DATASET, TABLE_NAME);
   }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -79,8 +79,8 @@ public class ITNightlyBigQueryTest {
   private static final String CALLABLE_STMT_DML_DELETE_PROC_NAME =
       "IT_CALLABLE_STMT_PROC_DML_DELETE_TEST";
   private static final String CALLABLE_STMT_DML_TABLE_NAME = "IT_CALLABLE_STMT_PROC_DML_TABLE";
-  private static final String DATASET = "JDBC_NIGHTLY_IT_DATASET";
-  private static final String DATASET2 = "JDBC_PRESUBMIT_INTEGRATION_DATASET_2";
+  private static String DATASET;
+  private static String DATASET2;
   static final String session_enabled_connection_uri =
       "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;PROJECTID="
           + PROJECT_ID
@@ -93,6 +93,8 @@ public class ITNightlyBigQueryTest {
 
   @BeforeAll
   public static void beforeClass() throws SQLException {
+    DATASET = ITBase.getSharedDataset();
+    DATASET2 = ITBase.getSharedDataset2();
     bigQueryConnection = DriverManager.getConnection(connection_uri, new Properties());
     bigQueryStatement = bigQueryConnection.createStatement();
     bigQuery = BigQueryOptions.newBuilder().build().getService();
@@ -107,7 +109,6 @@ public class ITNightlyBigQueryTest {
   @Test
   public void testMergeInExecuteBatch() throws SQLException {
     Random random = new Random();
-    String DATASET = "JDBC_INTEGRATION_DATASET";
     String TABLE_NAME1 = "Inventory" + random.nextInt(9999);
     String TABLE_NAME2 = "DetailedInventory" + random.nextInt(9999);
 
@@ -577,7 +578,6 @@ public class ITNightlyBigQueryTest {
   @Test
   public void testPreparedStatementExecuteUpdate() throws SQLException {
     Random random = new Random();
-    String DATASET = "JDBC_INTEGRATION_DATASET";
     String TABLE_NAME1 = "Inventory" + random.nextInt(9999);
     String TABLE_NAME2 = "DetailedInventory" + random.nextInt(9999);
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITResultSetMetadataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITResultSetMetadataTest.java
@@ -36,18 +36,18 @@ public class ITResultSetMetadataTest {
   static Random random = new Random();
   static int randomNumber = random.nextInt(999);
   private static final String TABLE_NAME = "JDBC_RSMETADATA_TEST_TABLE" + randomNumber;
-  private static final String DATASET = "JDBC_RSMETADATA_TEST_DATASET";
+  private static String DATASET;
   private static ResultSetMetaData metaData;
 
   @BeforeClass
   public static void beforeClass() throws InterruptedException {
-    ITBase.setUpDataset(DATASET);
+    DATASET = ITBase.getSharedDataset();
     ITBase.setUpTable(DATASET, TABLE_NAME);
   }
 
   @AfterClass
   public static void afterClass() throws InterruptedException {
-    ITBase.cleanUp(DATASET);
+    // Shared dataset cleanup is handled by shutdown hook
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 public class ITStatementTest {
   private static final String DEFAULT_CATALOG = ServiceOptions.getDefaultProjectId();
-  private static final String DATASET = "JDBC_STATEMENT_TEST_DATASET";
+  private static String DATASET;
   private static String connectionUrl =
       "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId=%s;OAuthType=3;Timeout=3600;";
   private static Random random = new Random();
@@ -50,13 +50,13 @@ public class ITStatementTest {
 
   @BeforeClass
   public static void beforeClass() throws InterruptedException {
-    ITBase.setUpDataset(DATASET);
+    DATASET = ITBase.getSharedDataset();
     ITBase.setUpTable(DATASET, TABLE_NAME);
   }
 
   @AfterClass
   public static void afterClass() throws InterruptedException {
-    ITBase.cleanUp(DATASET);
+    // Shared dataset cleanup is handled by shutdown hook
   }
 
   @Test


### PR DESCRIPTION
Currently tests rely on existing datasets. Some of them also try to create tables without unique names (e.g. FakeTable) which results in failures if two integration tests are running concurrently.

This change eliminates dependency on `JDBC_INTEGRATION_DATASET` and `JDBC_INTEGRATION_DATASET_2` and relies on the new unique dataset that is removed up after the run.

This will also allow us not to rely on table cleanup as the entire dataset will be removed.