### PR TITLE
chore: add librarian team to librarian.yaml CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,4 @@
 /java-pubsub/ @googleapis/pubsub-team @googleapis/cloud-sdk-java-team
 /java-bigtable/ @googleapis/bigtable-team @googleapis/cloud-sdk-java-team
 /java-firestore/ @googleapis/firestore-team @googleapis/cloud-sdk-java-team
+/librarian.yaml @googleapis/cloud-sdk-java-team @googleapis/cloud-sdk-librarian-team


### PR DESCRIPTION
Give Librarian team CODEOWNERS on librarian.yaml. This will both notify the team of changes to this file and expedite review of librarian.yaml only changes that do not produce a diff e.g. config refactor or version update without a regen diff.
During migration while hermetic build is still used, this also allows us to expedite updates to librarian.yaml when generation_config.yaml changes.