### PR TITLE
feat(bigquery-jdbc): add globalOtel support

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -216,6 +216,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   boolean enableGcpTraceExporter;
   boolean enableGcpLogExporter;
   OpenTelemetry customOpenTelemetry;
+  boolean useGlobalOpenTelemetry;
   private OpenTelemetry openTelemetry;
   private Context otelContext;
   Tracer tracer =
@@ -367,6 +368,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
       this.enableGcpTraceExporter = ds.getEnableGcpTraceExporter();
       this.enableGcpLogExporter = ds.getEnableGcpLogExporter();
       this.customOpenTelemetry = ds.getCustomOpenTelemetry();
+      this.useGlobalOpenTelemetry = ds.getUseGlobalOpenTelemetry();
       this.openTelemetry = getOpenTelemetryInstance();
       this.bigQuery = getBigQueryConnection();
     }
@@ -1048,22 +1050,27 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     OpenTelemetry openTelemetry =
         BigQueryJdbcOpenTelemetry.getOpenTelemetry(
+            this.useGlobalOpenTelemetry,
             this.enableGcpTraceExporter,
             this.enableGcpLogExporter,
             this.customOpenTelemetry,
             effectiveCredentials,
             effectiveProjectId);
 
+    boolean hasExternalOtel = this.customOpenTelemetry != null || this.useGlobalOpenTelemetry;
     Logging localLoggingClient = null;
-    if (this.enableGcpLogExporter && !hasCustomOtel) {
+    if (this.enableGcpLogExporter && !hasExternalOtel) {
       localLoggingClient =
           BigQueryJdbcOpenTelemetry.createLoggingClient(
               true, null, effectiveCredentials, effectiveProjectId, this.credentials);
     }
 
-    if (this.enableGcpLogExporter || hasCustomOtel) {
+    if (this.enableGcpLogExporter || hasExternalOtel) {
       BigQueryJdbcOpenTelemetry.registerConnection(
-          this.connectionId, openTelemetry, localLoggingClient, this.enableGcpLogExporter);
+          this.connectionId,
+          openTelemetry,
+          localLoggingClient,
+          this.enableGcpLogExporter && !hasExternalOtel);
     }
 
     return openTelemetry;
@@ -1128,7 +1135,9 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     if (this.httpTransportOptions != null) {
       bigQueryOptions.setTransportOptions(this.httpTransportOptions);
     }
-    if (this.enableGcpTraceExporter || this.customOpenTelemetry != null) {
+    if (this.enableGcpTraceExporter
+        || this.customOpenTelemetry != null
+        || this.useGlobalOpenTelemetry) {
       Tracer sdkTracer = this.openTelemetry.getTracer(BigQueryJdbcOpenTelemetry.BIGQUERY_NAMESPACE);
       bigQueryOptions.setOpenTelemetryTracer(sdkTracer);
       this.tracer =

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1040,7 +1040,6 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   }
 
   private OpenTelemetry getOpenTelemetryInstance() {
-    boolean hasCustomOtel = this.customOpenTelemetry != null;
 
     String effectiveProjectId =
         (this.gcpTelemetryProjectId != null) ? this.gcpTelemetryProjectId : this.catalog;

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -21,6 +21,7 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
 import com.google.common.hash.Hashing;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Span;
@@ -245,6 +246,7 @@ public class BigQueryJdbcOpenTelemetry {
    * customOpenTelemetry if provided; fallback to an auto-configured GCP exporter if requested.
    */
   public static OpenTelemetry getOpenTelemetry(
+      boolean useGlobalOpenTelemetry,
       boolean enableGcpTraceExporter,
       boolean enableGcpLogExporter,
       OpenTelemetry customOpenTelemetry,
@@ -253,6 +255,10 @@ public class BigQueryJdbcOpenTelemetry {
 
     if (customOpenTelemetry != null) {
       return customOpenTelemetry;
+    }
+
+    if (useGlobalOpenTelemetry) {
+      return GlobalOpenTelemetry.get();
     }
 
     // NOTE: Currently, tracing only fully supports Application Default Credentials (ADC).

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
@@ -168,6 +168,8 @@ final class BigQueryJdbcUrlUtility {
   static final boolean DEFAULT_ENABLE_GCP_TRACE_EXPORTER_VALUE = false;
   static final String ENABLE_GCP_LOG_EXPORTER_PROPERTY_NAME = "enableGcpLogExporter";
   static final boolean DEFAULT_ENABLE_GCP_LOG_EXPORTER_VALUE = false;
+  static final String USE_GLOBAL_OTEL_PROPERTY_NAME = "useGlobalOpenTelemetry";
+  static final boolean DEFAULT_USE_GLOBAL_OTEL_VALUE = false;
   private static final BigQueryJdbcCustomLogger LOG =
       new BigQueryJdbcCustomLogger(BigQueryJdbcUrlUtility.class.getName());
   static final String FILTER_TABLES_ON_DEFAULT_DATASET_PROPERTY_NAME =
@@ -638,6 +640,12 @@ final class BigQueryJdbcUrlUtility {
                   BigQueryConnectionProperty.newBuilder()
                       .setName(GCP_TELEMETRY_PROJECT_ID_PROPERTY_NAME)
                       .setDescription("GCP Project ID for OTel exporter.")
+                      .build(),
+                  BigQueryConnectionProperty.newBuilder()
+                      .setName(USE_GLOBAL_OTEL_PROPERTY_NAME)
+                      .setDescription(
+                          "Enables usage of the Global OpenTelemetry instance when true. Default is false.")
+                      .setDefaultValue(String.valueOf(DEFAULT_USE_GLOBAL_OTEL_VALUE))
                       .build())));
 
   private static final List<String> NETWORK_PROPERTIES =

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
@@ -123,6 +123,7 @@ public class DataSource implements javax.sql.DataSource {
   private boolean enableGcpLogExporter =
       BigQueryJdbcUrlUtility.DEFAULT_ENABLE_GCP_LOG_EXPORTER_VALUE;
   private OpenTelemetry customOpenTelemetry;
+  private boolean useGlobalOpenTelemetry = BigQueryJdbcUrlUtility.DEFAULT_USE_GLOBAL_OTEL_VALUE;
 
   // Make sure the JDBC driver class is loaded.
   static {
@@ -358,6 +359,12 @@ public class DataSource implements javax.sql.DataSource {
                   ds.setEnableGcpLogExporter(
                       BigQueryJdbcUrlUtility.convertIntToBoolean(
                           val, BigQueryJdbcUrlUtility.ENABLE_GCP_LOG_EXPORTER_PROPERTY_NAME)))
+          .put(
+              BigQueryJdbcUrlUtility.USE_GLOBAL_OTEL_PROPERTY_NAME,
+              (ds, val) ->
+                  ds.setUseGlobalOpenTelemetry(
+                      BigQueryJdbcUrlUtility.convertIntToBoolean(
+                          val, BigQueryJdbcUrlUtility.USE_GLOBAL_OTEL_PROPERTY_NAME)))
           .build();
 
   public static DataSource fromUrl(String url) {
@@ -675,6 +682,11 @@ public class DataSource implements javax.sql.DataSource {
           BigQueryJdbcUrlUtility.ENABLE_GCP_LOG_EXPORTER_PROPERTY_NAME,
           String.valueOf(this.enableGcpLogExporter));
     }
+    if (this.useGlobalOpenTelemetry) {
+      connectionProperties.setProperty(
+          BigQueryJdbcUrlUtility.USE_GLOBAL_OTEL_PROPERTY_NAME,
+          String.valueOf(this.useGlobalOpenTelemetry));
+    }
     return connectionProperties;
   }
 
@@ -830,6 +842,14 @@ public class DataSource implements javax.sql.DataSource {
 
   public void setCustomOpenTelemetry(OpenTelemetry customOpenTelemetry) {
     this.customOpenTelemetry = customOpenTelemetry;
+  }
+
+  public boolean getUseGlobalOpenTelemetry() {
+    return useGlobalOpenTelemetry;
+  }
+
+  public void setUseGlobalOpenTelemetry(boolean useGlobalOpenTelemetry) {
+    this.useGlobalOpenTelemetry = useGlobalOpenTelemetry;
   }
 
   public void setHighThroughputMinTableSize(Integer highThroughputMinTableSize) {

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -17,15 +17,25 @@
 package com.google.cloud.bigquery.jdbc;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.HeaderProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.QueryJobConfiguration.JobCreationMode;
 import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
+import com.google.cloud.logging.Logging;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
@@ -44,6 +54,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
 
@@ -520,6 +532,133 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
       assertFalse(logMessage.contains("secretAccessToken"));
     } finally {
       rootLogger.setLevel(originalLevel);
+    }
+  }
+
+  @ParameterizedTest(
+      name =
+          "Case {index}: custom={0}, global={1}, trace={2}, log={3} -> expectTrace={4}, expectLog={5}")
+  @CsvSource({
+    // hasCustom, useGlobal, enableTrace, enableLog, expectTrace,     expectLog
+    "true,        true,      true,       true,      CUSTOM,         CUSTOM",
+    "true,        false,     true,       true,      CUSTOM,         CUSTOM",
+    "false,       true,      true,       true,      GLOBAL,         GLOBAL",
+    "false,       true,      false,      false,     GLOBAL,         GLOBAL",
+    "false,       false,     true,       false,     DRIVER_MANAGED, NONE",
+    "false,       false,     false,      true,      NONE,           DRIVER_MANAGED",
+    "false,       false,     true,       true,      DRIVER_MANAGED, DRIVER_MANAGED",
+    "false,       false,     false,      false,     NONE,           NONE"
+  })
+  public void testOpenTelemetryPrecedenceHierarchy(
+      boolean hasCustom,
+      boolean useGlobal,
+      boolean enableTrace,
+      boolean enableLog,
+      String expectTrace,
+      String expectLog)
+      throws Exception {
+
+    DataSource ds = DataSource.fromUrl(BASE_URL);
+    ds.setUseGlobalOpenTelemetry(useGlobal);
+    ds.setEnableGcpTraceExporter(enableTrace);
+    ds.setEnableGcpLogExporter(enableLog);
+
+    OpenTelemetry mockCustomOtel = mock(OpenTelemetry.class);
+    OpenTelemetry mockGlobalOtel = mock(OpenTelemetry.class);
+    OpenTelemetry mockDriverManagedOtel = mock(OpenTelemetry.class);
+    Logging mockLogging = mock(Logging.class);
+
+    if (hasCustom) {
+      ds.setCustomOpenTelemetry(mockCustomOtel);
+    }
+
+    try (MockedStatic<BigQueryJdbcOpenTelemetry> mockedOtel =
+            Mockito.mockStatic(BigQueryJdbcOpenTelemetry.class);
+        MockedStatic<BigQueryJdbcOAuthUtility> mockedAuth =
+            Mockito.mockStatic(BigQueryJdbcOAuthUtility.class);
+        MockedStatic<GoogleCredentials> mockedCreds = Mockito.mockStatic(GoogleCredentials.class)) {
+
+      mockedCreds
+          .when(GoogleCredentials::getApplicationDefault)
+          .thenReturn(mock(GoogleCredentials.class));
+
+      // Mock parseOAuthProperties to always return ADC type to bypass validation
+      mockedAuth
+          .when(() -> BigQueryJdbcOAuthUtility.parseOAuthProperties(any(), anyString()))
+          .thenAnswer(
+              invocation -> {
+                java.util.Map<String, String> props = new java.util.HashMap<>();
+                props.put(
+                    BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME,
+                    "APPLICATION_DEFAULT_CREDENTIALS");
+                return props;
+              });
+
+      mockedAuth
+          .when(() -> BigQueryJdbcOAuthUtility.getCredentials(any(), any(), any(), any()))
+          .thenReturn(mock(GoogleCredentials.class));
+
+      mockedOtel
+          .when(
+              () ->
+                  BigQueryJdbcOpenTelemetry.createLoggingClient(
+                      anyBoolean(), any(), any(), any(), any()))
+          .thenReturn(mockLogging);
+
+      // Stub getOpenTelemetry to return the expected mock based on inputs
+      mockedOtel
+          .when(
+              () ->
+                  BigQueryJdbcOpenTelemetry.getOpenTelemetry(
+                      eq(useGlobal),
+                      eq(enableTrace),
+                      eq(enableLog),
+                      hasCustom ? eq(mockCustomOtel) : isNull(),
+                      any(),
+                      any()))
+          .thenAnswer(
+              invocation -> {
+                if (hasCustom) return mockCustomOtel;
+                if (useGlobal) return mockGlobalOtel;
+                if (enableTrace || enableLog) return mockDriverManagedOtel;
+                return OpenTelemetry.noop();
+              });
+
+      BigQueryConnection connection = new BigQueryConnection(BASE_URL, ds);
+
+      boolean shouldBeRegistered = enableLog || hasCustom || useGlobal;
+
+      if (!shouldBeRegistered) {
+        mockedOtel.verify(
+            () ->
+                BigQueryJdbcOpenTelemetry.registerConnection(
+                    anyString(), any(), any(), anyBoolean()),
+            never());
+      } else {
+        final OpenTelemetry expectedOtelInstance;
+        if ("CUSTOM".equals(expectTrace) || "CUSTOM".equals(expectLog)) {
+          expectedOtelInstance = mockCustomOtel;
+        } else if ("GLOBAL".equals(expectTrace) || "GLOBAL".equals(expectLog)) {
+          expectedOtelInstance = mockGlobalOtel;
+        } else if ("DRIVER_MANAGED".equals(expectTrace) || "DRIVER_MANAGED".equals(expectLog)) {
+          expectedOtelInstance = mockDriverManagedOtel;
+        } else {
+          expectedOtelInstance = OpenTelemetry.noop();
+        }
+
+        boolean expectUseDirectGcp = "DRIVER_MANAGED".equals(expectLog);
+        Logging expectedLogClient = expectUseDirectGcp ? mockLogging : null;
+
+        mockedOtel.verify(
+            () ->
+                BigQueryJdbcOpenTelemetry.registerConnection(
+                    anyString(),
+                    eq(expectedOtelInstance),
+                    eq(expectedLogClient),
+                    eq(expectUseDirectGcp)));
+      }
+
+      connection.close();
     }
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -23,7 +23,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.HeaderProvider;
@@ -55,7 +57,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
 
@@ -567,20 +568,19 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
     OpenTelemetry mockGlobalOtel = mock(OpenTelemetry.class);
     OpenTelemetry mockDriverManagedOtel = mock(OpenTelemetry.class);
     Logging mockLogging = mock(Logging.class);
-    org.mockito.Mockito.when(mockCustomOtel.getTracer(anyString())).thenReturn(mock(Tracer.class));
-    org.mockito.Mockito.when(mockGlobalOtel.getTracer(anyString())).thenReturn(mock(Tracer.class));
-    org.mockito.Mockito.when(mockDriverManagedOtel.getTracer(anyString()))
-        .thenReturn(mock(Tracer.class));
+    when(mockCustomOtel.getTracer(anyString())).thenReturn(mock(Tracer.class));
+    when(mockGlobalOtel.getTracer(anyString())).thenReturn(mock(Tracer.class));
+    when(mockDriverManagedOtel.getTracer(anyString())).thenReturn(mock(Tracer.class));
 
     if (hasCustom) {
       ds.setCustomOpenTelemetry(mockCustomOtel);
     }
 
     try (MockedStatic<BigQueryJdbcOpenTelemetry> mockedOtel =
-            Mockito.mockStatic(BigQueryJdbcOpenTelemetry.class);
+            mockStatic(BigQueryJdbcOpenTelemetry.class);
         MockedStatic<BigQueryJdbcOAuthUtility> mockedAuth =
-            Mockito.mockStatic(BigQueryJdbcOAuthUtility.class);
-        MockedStatic<GoogleCredentials> mockedCreds = Mockito.mockStatic(GoogleCredentials.class)) {
+            mockStatic(BigQueryJdbcOAuthUtility.class);
+        MockedStatic<GoogleCredentials> mockedCreds = mockStatic(GoogleCredentials.class)) {
 
       mockedCreds
           .when(GoogleCredentials::getApplicationDefault)

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -567,6 +567,10 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
     OpenTelemetry mockGlobalOtel = mock(OpenTelemetry.class);
     OpenTelemetry mockDriverManagedOtel = mock(OpenTelemetry.class);
     Logging mockLogging = mock(Logging.class);
+    org.mockito.Mockito.when(mockCustomOtel.getTracer(anyString())).thenReturn(mock(Tracer.class));
+    org.mockito.Mockito.when(mockGlobalOtel.getTracer(anyString())).thenReturn(mock(Tracer.class));
+    org.mockito.Mockito.when(mockDriverManagedOtel.getTracer(anyString()))
+        .thenReturn(mock(Tracer.class));
 
     if (hasCustom) {
       ds.setCustomOpenTelemetry(mockCustomOtel);

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -628,41 +628,40 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
                 return OpenTelemetry.noop();
               });
 
-      BigQueryConnection connection = new BigQueryConnection(BASE_URL, ds);
+      try (BigQueryConnection connection = new BigQueryConnection(BASE_URL, ds)) {
 
-      boolean shouldBeRegistered = enableLog || hasCustom || useGlobal;
+        boolean shouldBeRegistered = enableLog || hasCustom || useGlobal;
 
-      if (!shouldBeRegistered) {
-        mockedOtel.verify(
-            () ->
-                BigQueryJdbcOpenTelemetry.registerConnection(
-                    anyString(), any(), any(), anyBoolean()),
-            never());
-      } else {
-        final OpenTelemetry expectedOtelInstance;
-        if ("CUSTOM".equals(expectTrace) || "CUSTOM".equals(expectLog)) {
-          expectedOtelInstance = mockCustomOtel;
-        } else if ("GLOBAL".equals(expectTrace) || "GLOBAL".equals(expectLog)) {
-          expectedOtelInstance = mockGlobalOtel;
-        } else if ("DRIVER_MANAGED".equals(expectTrace) || "DRIVER_MANAGED".equals(expectLog)) {
-          expectedOtelInstance = mockDriverManagedOtel;
+        if (!shouldBeRegistered) {
+          mockedOtel.verify(
+              () ->
+                  BigQueryJdbcOpenTelemetry.registerConnection(
+                      anyString(), any(), any(), anyBoolean()),
+              never());
         } else {
-          expectedOtelInstance = OpenTelemetry.noop();
+          final OpenTelemetry expectedOtelInstance;
+          if ("CUSTOM".equals(expectTrace) || "CUSTOM".equals(expectLog)) {
+            expectedOtelInstance = mockCustomOtel;
+          } else if ("GLOBAL".equals(expectTrace) || "GLOBAL".equals(expectLog)) {
+            expectedOtelInstance = mockGlobalOtel;
+          } else if ("DRIVER_MANAGED".equals(expectTrace) || "DRIVER_MANAGED".equals(expectLog)) {
+            expectedOtelInstance = mockDriverManagedOtel;
+          } else {
+            expectedOtelInstance = OpenTelemetry.noop();
+          }
+
+          boolean expectUseDirectGcp = "DRIVER_MANAGED".equals(expectLog);
+          Logging expectedLogClient = expectUseDirectGcp ? mockLogging : null;
+
+          mockedOtel.verify(
+              () ->
+                  BigQueryJdbcOpenTelemetry.registerConnection(
+                      anyString(),
+                      eq(expectedOtelInstance),
+                      eq(expectedLogClient),
+                      eq(expectUseDirectGcp)));
         }
-
-        boolean expectUseDirectGcp = "DRIVER_MANAGED".equals(expectLog);
-        Logging expectedLogClient = expectUseDirectGcp ? mockLogging : null;
-
-        mockedOtel.verify(
-            () ->
-                BigQueryJdbcOpenTelemetry.registerConnection(
-                    anyString(),
-                    eq(expectedOtelInstance),
-                    eq(expectedLogClient),
-                    eq(expectUseDirectGcp)));
       }
-
-      connection.close();
     }
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetryTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;
 import org.junit.jupiter.api.AfterEach;
@@ -50,7 +51,7 @@ public class BigQueryJdbcOpenTelemetryTest {
     OpenTelemetry mockCustomOtel = mock(OpenTelemetry.class);
 
     OpenTelemetry result =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, mockCustomOtel, null, null);
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, false, mockCustomOtel, null, null);
 
     assertThat(result).isSameInstanceAs(mockCustomOtel);
   }
@@ -61,7 +62,7 @@ public class BigQueryJdbcOpenTelemetryTest {
 
     // Custom SDK always takes precedence over individual flags
     OpenTelemetry result =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, true, mockCustomOtel, null, null);
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, true, mockCustomOtel, null, null);
 
     assertThat(result).isSameInstanceAs(mockCustomOtel);
   }
@@ -69,7 +70,7 @@ public class BigQueryJdbcOpenTelemetryTest {
   @Test
   public void testGetOpenTelemetry_noFlags_returnsNoop() {
     OpenTelemetry result =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, null, null, null);
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, false, null, null, null);
 
     assertThat(result).isSameInstanceAs(OpenTelemetry.noop());
   }
@@ -84,9 +85,9 @@ public class BigQueryJdbcOpenTelemetryTest {
   @Test
   public void testGetOpenTelemetry_cachesSdkInstances() {
     OpenTelemetry result1 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, false, null, null, "project1");
     OpenTelemetry result2 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, false, null, null, "project1");
 
     assertThat(result1).isSameInstanceAs(result2);
   }
@@ -94,9 +95,9 @@ public class BigQueryJdbcOpenTelemetryTest {
   @Test
   public void testGetOpenTelemetry_createsNewInstanceForDifferentKey() {
     OpenTelemetry result1 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, false, null, null, "project1");
     OpenTelemetry result2 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project2");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, false, null, null, "project2");
 
     assertThat(result1).isNotSameInstanceAs(result2);
   }
@@ -104,9 +105,9 @@ public class BigQueryJdbcOpenTelemetryTest {
   @Test
   public void testGetOpenTelemetry_createsNewInstanceForDifferentTraceFlag() {
     OpenTelemetry result1 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, true, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, true, null, null, "project1");
     OpenTelemetry result2 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, false, true, null, null, "project1");
 
     assertThat(result1).isNotSameInstanceAs(result2);
   }
@@ -114,10 +115,18 @@ public class BigQueryJdbcOpenTelemetryTest {
   @Test
   public void testGetOpenTelemetry_ignoresEnableLogFlagInCacheKey() {
     OpenTelemetry result1 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, true, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, true, null, null, "project1");
     OpenTelemetry result2 =
-        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, null, null, "project1");
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(false, true, false, null, null, "project1");
 
     assertThat(result1).isSameInstanceAs(result2);
+  }
+
+  @Test
+  public void testGetOpenTelemetry_withUseGlobalOTel_returnsGlobal() {
+    OpenTelemetry result =
+        BigQueryJdbcOpenTelemetry.getOpenTelemetry(true, false, false, null, null, null);
+
+    assertThat(result).isSameInstanceAs(GlobalOpenTelemetry.get());
   }
 }


### PR DESCRIPTION
b/517124136

This PR introduces support for opting into the global OpenTelemetry instance via connection properties in the BigQuery JDBC driver. It also establishes a clear hierarchy of precedence for various OpenTelemetry configuration flags to ensure predictable behavior

## Key Changes

### 1. Global OpenTelemetry Support
*   Added a new connection property `useGlobalOpenTelemetry` (default: `false`).
*   When set to `true`, the driver will explicitly use the globally registered OpenTelemetry instance (`GlobalOpenTelemetry.get()`) for both tracing and logging.

### 2. Precedence Rules for Telemetry Flags
Implemented the following hierarchy of precedence in `BigQueryConnection`:
1.  **`customOpenTelemetry`** (Provided via `DataSource`): Highest precedence. Overrides everything else.
2.  **`useGlobalOpenTelemetry`**: Second precedence. Overrides driver-managed GCP fallback flags.
3.  **`enableGcpTraceExporter` / `enableGcpLogExporter`**: Lowest precedence. Used only if above are false/null.

### 3. Code Modifications
*   **`BigQueryJdbcUrlUtility.java`**: Added property definition and added it to valid properties.
*   **`DataSource.java`**: Added field, getter/setter, and URL parsing support for the new property.
*   **`BigQueryConnection.java`**: Updated constructor to read the new property and implemented the precedence logic for both tracer initialization and logging client registration.
*   **`BigQueryJdbcOpenTelemetry.java`**: Updated `getOpenTelemetry()` to handle the `useGlobalOpenTelemetry` flag.

### 4. Testing
*   **`BigQueryJdbcOpenTelemetryTest.java`**: Added unit test to verify that `useGlobalOpenTelemetry` returns the global instance.
*   **`BigQueryConnectionTest.java`**: Added a comprehensive parameterized test (`testOpenTelemetryPrecedenceHierarchy`) covering all 8 combinations of the 4 flags to verify the correct behavior of `OpenTelemetry` resolution and logging client creation.