### PR TITLE
chore(ci): add daily librarian workflow to update googleapis commitish

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -17,6 +17,9 @@ on:
   schedule:
   - cron: '0 3 * * *' # Run once a day at 3:00 AM UTC
   workflow_dispatch: # Allow manual trigger
+  pull_request: # Run in dry-run mode to test changes to this workflow itself
+    paths:
+      - '.github/workflows/update_librarian_googleapis.yaml'
 jobs:
   update-librarian-googleapis:
     runs-on: ubuntu-24.04
@@ -37,13 +40,17 @@ jobs:
         set -x
         current_branch="update-librarian-googleapis-main"
         
-        # Try to find an open pull request associated with the branch
-        pr_num=$(gh pr list -s open -H "${current_branch}" -q . --json number | jq ".[] | .number")
-        
-        if [ -n "${pr_num}" ]; then
-          echo "Error: An open Pull Request already exists for this update: PR #${pr_num}."
-          echo "Please merge or close the existing PR before running this workflow again."
-          exit 1 # Fails this step and the workflow
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "PR Test: Skipping open PR check."
+        else
+          # Try to find an open pull request associated with the branch
+          pr_num=$(gh pr list -s open -H "${current_branch}" -q . --json number | jq ".[] | .number")
+          
+          if [ -n "${pr_num}" ]; then
+            echo "Error: An open Pull Request already exists for this update: PR #${pr_num}."
+            echo "Please merge or close the existing PR before running this workflow again."
+            exit 1 # Fails this step and the workflow
+          fi
         fi
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -84,6 +91,15 @@ jobs:
         PR_BODY: ${{ steps.detect.outputs.body }}
       run: |
         set -x
+        
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo "=== PR Test: DRY RUN MODE ACTIVE ==="
+          echo "Would have checked out branch: update-librarian-googleapis-main"
+          echo "Would have committed with title: $PR_TITLE"
+          echo "Would have pushed branch and created PR."
+          exit 0
+        fi
+        
         [ -z "$(git config user.email)" ] && git config --global user.email "cloud-java-bot@google.com"
         [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
         

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -60,6 +60,13 @@ jobs:
       run: |
         version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
         go run "github.com/googleapis/librarian/cmd/librarian@${version}" update sources.googleapis
+    - name: Get latest commit
+      id: commit
+      run: |
+        version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+        new_commit=$(go run "github.com/googleapis/librarian/cmd/librarian@${version}" config get sources.googleapis.commit)
+        echo "new_commit=${new_commit}" >> $GITHUB_OUTPUT
+        echo "short_commit=${new_commit:0:7}" >> $GITHUB_OUTPUT
     - name: Detect Changes
       id: detect
       run: |
@@ -70,25 +77,13 @@ jobs:
           echo "No changes in librarian.yaml"
         else
           echo "has_changes=true" >> $GITHUB_OUTPUT
-          
-          # Get the new commit hash
-          new_commit=$(git diff --cached librarian.yaml | grep -E '^\+    commit:' | head -n 1 | awk '{print $3}')
-          echo "new_commit=${new_commit}" >> $GITHUB_OUTPUT
-          
-          if [ -n "${new_commit}" ]; then
-            echo "title=chore: update googleapis commitish to ${new_commit:0:7}" >> $GITHUB_OUTPUT
-            echo "body=Updated googleapis commitish in librarian.yaml to https://github.com/googleapis/googleapis/commit/${new_commit}" >> $GITHUB_OUTPUT
-          else
-            echo "title=chore: update googleapis commitish in librarian.yaml" >> $GITHUB_OUTPUT
-            echo "body=Updated googleapis commitish in librarian.yaml to the latest version." >> $GITHUB_OUTPUT
-          fi
         fi
     - name: Commit and Create PR
       if: steps.detect.outputs.has_changes == 'true'
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
-        PR_TITLE: ${{ steps.detect.outputs.title }}
-        PR_BODY: ${{ steps.detect.outputs.body }}
+        PR_TITLE: "chore: update googleapis commitish to ${{ steps.commit.outputs.short_commit }}"
+        PR_BODY: "Updated googleapis commitish in librarian.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}"
       run: |
         set -x
         

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -1,0 +1,105 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Update librarian googleapis commitish
+on:
+  schedule:
+  - cron: '0 3 * * *' # Run once a day at 3:00 AM UTC
+  workflow_dispatch: # Allow manual trigger
+jobs:
+  update-librarian-googleapis:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: google-cloud-java
+    steps:
+    - name: Checkout google-cloud-java
+      uses: actions/checkout@v6
+      with:
+        repository: googleapis/google-cloud-java
+        path: google-cloud-java
+        fetch-depth: 0
+    - name: Check for Open PR
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -x
+        current_branch="update-librarian-googleapis-main"
+        
+        # Try to find an open pull request associated with the branch
+        pr_num=$(gh pr list -s open -H "${current_branch}" -q . --json number | jq ".[] | .number")
+        
+        if [ -n "${pr_num}" ]; then
+          echo "Error: An open Pull Request already exists for this update: PR #${pr_num}."
+          echo "Please merge or close the existing PR before running this workflow again."
+          exit 1 # Fails this step and the workflow
+        fi
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '>=1.20.2'
+    - name: Run librarian update
+      run: |
+        version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+        go run "github.com/googleapis/librarian/cmd/librarian@${version}" update sources.googleapis
+    - name: Detect Changes
+      id: detect
+      run: |
+        git add librarian.yaml
+        changed_files=$(git diff --cached --name-only)
+        if [[ "${changed_files}" == "" ]]; then
+          echo "has_changes=false" >> $GITHUB_OUTPUT
+          echo "No changes in librarian.yaml"
+        else
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          
+          # Get the new commit hash
+          new_commit=$(git diff --cached librarian.yaml | grep -E '^\+    commit:' | head -n 1 | awk '{print $3}')
+          echo "new_commit=${new_commit}" >> $GITHUB_OUTPUT
+          
+          if [ -n "${new_commit}" ]; then
+            echo "title=chore: update googleapis commitish to ${new_commit:0:7}" >> $GITHUB_OUTPUT
+            echo "body=Updated googleapis commitish in librarian.yaml to https://github.com/googleapis/googleapis/commit/${new_commit}" >> $GITHUB_OUTPUT
+          else
+            echo "title=chore: update googleapis commitish in librarian.yaml" >> $GITHUB_OUTPUT
+            echo "body=Updated googleapis commitish in librarian.yaml to the latest version." >> $GITHUB_OUTPUT
+          fi
+        fi
+    - name: Commit and Create PR
+      if: steps.detect.outputs.has_changes == 'true'
+      env:
+        GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+        PR_TITLE: ${{ steps.detect.outputs.title }}
+        PR_BODY: ${{ steps.detect.outputs.body }}
+      run: |
+        set -x
+        [ -z "$(git config user.email)" ] && git config --global user.email "cloud-java-bot@google.com"
+        [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
+        
+        base_branch="main"
+        current_branch="update-librarian-googleapis-${base_branch}"
+        
+        # Create and switch to the branch (force checkout -B to discard any local state on this branch name if it existed)
+        git checkout -B "${current_branch}"
+        
+        # Commit the changes (they are already staged by the Detect Changes step!)
+        git commit -m "${PR_TITLE}"
+        
+        # Push to remote (force push to overwrite any stale branch on remote)
+        git remote add remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${{ github.repository }}.git" || git remote set-url remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${{ github.repository }}.git"
+        git fetch -q remote_repo
+        git push -f remote_repo "${current_branch}"
+        
+        # Create the PR
+        gh pr create --title "${PR_TITLE}" --head "${current_branch}" --body "${PR_BODY}" --base "${base_branch}"


### PR DESCRIPTION
Added workflow to update sources.googleapis in librarian.yaml, scheduled to run daily, can be triggered manually.
In case of there is already an open PR for it, simply let the workflow fail. 

The workflow also triggers a dry-run mode on PR for this workflow.

Test run succeeded: https://github.com/googleapis/google-cloud-java/actions/runs/26598366465/job/78375192026?pr=13292

Fixes https://github.com/googleapis/librarian/issues/5435