### PR TITLE
chore(bigquery-jdbc): link OpenTelemetry instrumentation with underlying SDK

### DIFF
--- a/java-bigquery-jdbc/pom.xml
+++ b/java-bigquery-jdbc/pom.xml
@@ -320,6 +320,16 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-opentelemetry</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opentelemetry</groupId>
+          <artifactId>opentelemetry-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.arrow</groupId>

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -44,6 +44,7 @@ import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.logging.Logging;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedSet;
+import io.grpc.opentelemetry.GrpcOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
 import io.opentelemetry.api.trace.Tracer;
@@ -1139,6 +1140,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
         || this.useGlobalOpenTelemetry) {
       Tracer sdkTracer = this.openTelemetry.getTracer(BigQueryJdbcOpenTelemetry.BIGQUERY_NAMESPACE);
       bigQueryOptions.setOpenTelemetryTracer(sdkTracer);
+      bigQueryOptions.setEnableOpenTelemetryTracing(true);
       this.tracer =
           this.openTelemetry.getTracer(BigQueryJdbcOpenTelemetry.INSTRUMENTATION_SCOPE_NAME);
     }
@@ -1176,7 +1178,20 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     }
     TransportChannelProvider activeProvider = this.transportChannelProvider;
     if (activeProvider == null) {
-      activeProvider = BigQueryReadSettings.defaultGrpcTransportProviderBuilder().build();
+      InstantiatingGrpcChannelProvider.Builder builder =
+          BigQueryReadSettings.defaultGrpcTransportProviderBuilder();
+      if (this.enableGcpTraceExporter
+          || this.customOpenTelemetry != null
+          || this.useGlobalOpenTelemetry) {
+        GrpcOpenTelemetry grpcOpenTelemetry =
+            GrpcOpenTelemetry.newBuilder().sdk(this.openTelemetry).build();
+        builder.setChannelConfigurator(
+            b -> {
+              grpcOpenTelemetry.configureChannelBuilder(b);
+              return b;
+            });
+      }
+      activeProvider = builder.build();
     }
 
     if (activeProvider instanceof InstantiatingGrpcChannelProvider) {
@@ -1191,8 +1206,11 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
     bigQueryReadSettings.setTransportChannelProvider(activeProvider);
 
-    if (this.enableGcpTraceExporter || this.customOpenTelemetry != null) {
+    if (this.enableGcpTraceExporter
+        || this.customOpenTelemetry != null
+        || this.useGlobalOpenTelemetry) {
       bigQueryReadSettings.setOpenTelemetryTracerProvider(this.openTelemetry.getTracerProvider());
+      bigQueryReadSettings.setEnableOpenTelemetryTracing(true);
     }
 
     return BigQueryReadClient.create(bigQueryReadSettings.build());

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -44,6 +44,7 @@ import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.logging.Logging;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedSet;
+import io.grpc.ManagedChannelBuilder;
 import io.grpc.opentelemetry.GrpcOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.baggage.Baggage;
@@ -1187,7 +1188,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
             GrpcOpenTelemetry.newBuilder().sdk(this.openTelemetry).build();
         builder.setChannelConfigurator(
             b -> {
-              grpcOpenTelemetry.configureChannelBuilder(b);
+              grpcOpenTelemetry.configureChannelBuilder((ManagedChannelBuilder) b);
               return b;
             });
       }


### PR DESCRIPTION
b/517588332

This PR completes the linkage between the JDBC driver's OpenTelemetry instrumentation and the underlying BigQuery SDK to ensure full end-to-end traces.

## Key Changes
- **Dependency**: Added `io.grpc:grpc-opentelemetry` to intercept low-level gRPC network spans for the Storage API.
- **REST API**: Enabled `setEnableOpenTelemetryTracing(true)` in `BigQueryOptions` to unlock SDK-level tracing for standard queries.
- **HTAPI (Storage API)**: Enabled `setEnableOpenTelemetryTracing(true)` in `BigQueryReadSettings` and wired the `GrpcOpenTelemetry` interceptor to the channel builder.
- **Global OTel**: Ensured the `useGlobalOpenTelemetry` flag is respected when configuring the Storage API client.
