### PR TITLE
chore: revert formatting change in spanner

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -271,7 +271,8 @@ public class ConnectionProperties {
   static final ConnectionProperty<SpannerOptions.InstanceType> TYPE =
       create(
           TYPE_PROPERTY_NAME,
-          "Specifies the type of Spanner instance to connect to (cloud or omni). Setting it to omni is mandatory when connecting to a Spanner Omni instance.",
+          "Specifies the type of Spanner instance to connect to (cloud or omni). Setting it to omni"
+              + " is mandatory when connecting to a Spanner Omni instance.",
           DEFAULT_TYPE,
           new SpannerOptions.InstanceType[] {
             SpannerOptions.InstanceType.CLOUD, SpannerOptions.InstanceType.OMNI,


### PR DESCRIPTION
In https://github.com/googleapis/google-cloud-java/pull/13236, a formatting change caused a diff between what is generated by librarian and what actually exists. This blocks https://github.com/googleapis/google-cloud-java/pull/13284, because there is a diff. This PR fixes the formatting issue. Then once we merge that presubmit check, we can make sure these changes don't occur ad hoc.
