### PR TITLE
chore(ci): fix permission for update_librarian_googleapis workflow

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -33,7 +33,7 @@ jobs:
         repository: googleapis/google-cloud-java
         path: google-cloud-java
         fetch-depth: 0
-        token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+        persist-credentials: false
     - name: Check for Open PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -33,6 +33,7 @@ jobs:
         repository: googleapis/google-cloud-java
         path: google-cloud-java
         fetch-depth: 0
+        token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
     - name: Check for Open PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Prevent the checkout step from saving the read-only default GITHUB_TOKEN  on the runner. This should let "Commit and Create PR" step to use CLOUD_JAVA_BOT_GITHUB_TOKEN explicitly listed.  Because the checkout step didn't save any credentials, Git has no cached headers to override the URL.

This is in attempt to fix permission denied failure at Create PR step in this workflow, see [full log](https://github.com/googleapis/google-cloud-java/actions/runs/26617952296/job/78437554735). 

For https://github.com/googleapis/librarian/issues/5435

