### PR TITLE
chore(ci): ci to skip when changes are limited to workflow config files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,30 +20,8 @@ on:
   pull_request:
 name: ci
 jobs:
-  filter:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      runnable: ${{ fromJSON(steps.filter.outputs.all_count) > fromJSON(steps.filter.outputs.workflows_count) }}
-    steps:
-    - uses: actions/checkout@v6
-      # Use this action, rather than a file filter so that we can make this
-      # mandatory.
-      # See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-branches
-      # for more details.
-    - uses: dorny/paths-filter@v4
-      id: filter
-      with:
-        filters: |
-          all:
-            - '**'
-          workflows:
-            - '.github/workflows/**'
   # detect whether or note we should run "bulk" (non-handwritten) unit tests
   bulk-filter:
-    needs: filter
-    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -51,12 +29,22 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
       ci: ${{ steps.filter.outputs.ci }}
+      # runnable is true if there are changes outside the .github/workflows directory OR if ci.yaml itself (or kokoro scripts) is modified.
+      runnable: ${{ fromJSON(steps.filter.outputs.all_count) > fromJSON(steps.filter.outputs.workflows_count) || fromJSON(steps.filter.outputs.ci_count) > 0 }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+      # Use this action, rather than a file filter so that we can make this
+      # mandatory.
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-branches
+      # for more details.
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
         filters: |
+          all:
+            - '**'
+          workflows:
+            - '.github/workflows/**'
           src:
             - '!(google-auth-library-java|grpc-gcp-java|java-bigquery|java-bigquery-jdbc|java-bigquerystorage|java-bigtable|java-datastore|java-firestore|java-logging|java-logging-logback|java-pubsub|java-spanner|java-storage)/**/*.java'
             - '!(google-auth-library-java|grpc-gcp-java|java-bigquery|java-bigquery-jdbc|java-bigquerystorage|java-bigtable|java-datastore|java-firestore|java-logging|java-logging-logback|java-pubsub|java-spanner|java-storage)/**/pom.xml'
@@ -68,6 +56,7 @@ jobs:
   units:
     runs-on: ubuntu-latest
     needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +84,7 @@ jobs:
   units-8-runtime:
     runs-on: ubuntu-latest
     needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     name: "units (8)"
     steps:
     - name: Get current week within the year
@@ -128,15 +118,15 @@ jobs:
         JOB_NAME: units-8-runtime-${{matrix.java}}
   # detect which libraries have changed
   changes:
-    needs: filter
-    if: ${{ needs.filter.outputs.runnable == 'true' }}
+    needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
     outputs:
       packages: ${{ steps.filter.outputs.changes }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
       id: filter
       with:
@@ -326,7 +316,7 @@ jobs:
       env:
         BUILD_SUBDIR: ${{matrix.package}}
   required:
-    needs: [ filter, changes, split-units, split-clirr, split-dependencies ]
+    needs: [ bulk-filter, changes, split-units, split-clirr, split-dependencies ]
     name: conditional-required-check
     if: ${{ always() }} # Always run even if any "needs" jobs fail
     runs-on: ubuntu-22.04
@@ -337,8 +327,8 @@ jobs:
       - name: Success otherwise
         run: echo "Success!"
   windows:
-    needs: filter
-    if: ${{ needs.filter.outputs.runnable == 'true' }}
+    needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: windows-latest
     steps:
     - name: Support longpaths
@@ -355,8 +345,8 @@ jobs:
         JOB_TYPE: test
         JOB_NAME: windows-units
   lint:
-    needs: filter
-    if: ${{ needs.filter.outputs.runnable == 'true' }}
+    needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -373,8 +363,8 @@ jobs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
   enforcer:
-    needs: filter
-    if: ${{ needs.filter.outputs.runnable == 'true' }}
+    needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Get current week within the year
@@ -394,8 +384,8 @@ jobs:
     - run: java -version
     - run: mvn -B -ntp enforcer:enforce@enforce -T 1C
   gapic-libraries-bom:
-    needs: filter
-    if: ${{ needs.filter.outputs.runnable == 'true' }}
+    needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -413,8 +403,8 @@ jobs:
       with:
         bom-path: gapic-libraries-bom/pom.xml
   generation-config-check:
-    needs: filter
-    if: ${{ needs.filter.outputs.runnable == 'true' }}
+    needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,33 @@ on:
   push:
     branches:
     - main
-    paths-ignore:
-    - '.github/workflows/**'
   pull_request:
-    paths-ignore:
-    - '.github/workflows/**'
 name: ci
 jobs:
+  filter:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      runnable: ${{ steps.filter.outputs.runnable }}
+    steps:
+    - uses: actions/checkout@v6
+      # Use this action, rather than a file filter so that we can make this
+      # mandatory.
+      # See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-including-branches
+      # for more details.
+    - uses: dorny/paths-filter@v4
+      id: filter
+      with:
+        filters: |
+          runnable:
+            - '**'
+            - '!.github/workflows/**'
+
   # detect whether or note we should run "bulk" (non-handwritten) unit tests
   bulk-filter:
+    needs: filter
+    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -110,6 +128,8 @@ jobs:
         JOB_NAME: units-8-runtime-${{matrix.java}}
   # detect which libraries have changed
   changes:
+    needs: filter
+    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
@@ -306,7 +326,7 @@ jobs:
       env:
         BUILD_SUBDIR: ${{matrix.package}}
   required:
-    needs: [ changes, split-units, split-clirr, split-dependencies ]
+    needs: [ filter, changes, split-units, split-clirr, split-dependencies ]
     name: conditional-required-check
     if: ${{ always() }} # Always run even if any "needs" jobs fail
     runs-on: ubuntu-22.04
@@ -317,6 +337,8 @@ jobs:
       - name: Success otherwise
         run: echo "Success!"
   windows:
+    needs: filter
+    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: windows-latest
     steps:
     - name: Support longpaths
@@ -333,6 +355,8 @@ jobs:
         JOB_TYPE: test
         JOB_NAME: windows-units
   lint:
+    needs: filter
+    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -349,6 +373,8 @@ jobs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
   enforcer:
+    needs: filter
+    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Get current week within the year
@@ -368,6 +394,8 @@ jobs:
     - run: java -version
     - run: mvn -B -ntp enforcer:enforce@enforce -T 1C
   gapic-libraries-bom:
+    needs: filter
+    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -385,6 +413,8 @@ jobs:
       with:
         bom-path: gapic-libraries-bom/pom.xml
   generation-config-check:
+    needs: filter
+    if: ${{ needs.filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,11 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - '.github/workflows/**'
   pull_request:
+    paths-ignore:
+    - '.github/workflows/**'
 name: ci
 jobs:
   # detect whether or note we should run "bulk" (non-handwritten) unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      runnable: ${{ steps.filter.outputs.runnable }}
+      runnable: ${{ fromJSON(steps.filter.outputs.all_count) > fromJSON(steps.filter.outputs.workflows_count) }}
     steps:
     - uses: actions/checkout@v6
       # Use this action, rather than a file filter so that we can make this
@@ -36,10 +36,10 @@ jobs:
       id: filter
       with:
         filters: |
-          runnable:
+          all:
             - '**'
-            - '!.github/workflows/**'
-
+          workflows:
+            - '.github/workflows/**'
   # detect whether or note we should run "bulk" (non-handwritten) unit tests
   bulk-filter:
     needs: filter


### PR DESCRIPTION
Changes to ci.yaml to skip tests when only other .github/workflow files are changed.
This should not affect existing filtering behavior for split repo tests, but skips tests like enforcer, lint, unit for other workflow file changes. They are not skipped for changes in ci.yaml and .kokoro files.