### PR TITLE
build (deps): upgrade opentelemetry to 1.62.0 to patch CVE-2026-45292

### DIFF
--- a/grpc-gcp-java/pom.xml
+++ b/grpc-gcp-java/pom.xml
@@ -73,7 +73,7 @@
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.13.2</junit.version>
     <opencensus.version>0.31.1</opencensus.version>
-    <opentelemetry.version>1.57.0</opentelemetry.version>
+    <opentelemetry.version>1.62.0</opentelemetry.version>
     <spanner.version>6.118.0-SNAPSHOT</spanner.version><!-- {x-version-update:google-cloud-spanner:current} -->
     <truth.version>1.4.5</truth.version>
     <mockito.version>4.11.0</mockito.version>

--- a/java-bigquery/samples/install-without-bom/pom.xml
+++ b/java-bigquery/samples/install-without-bom/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <opentelemetry.version>1.57.0</opentelemetry.version>
+    <opentelemetry.version>1.62.0</opentelemetry.version>
   </properties>
 
 

--- a/java-spanner/benchmarks/pom.xml
+++ b/java-spanner/benchmarks/pom.xml
@@ -34,7 +34,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <junixsocket.version>2.10.1</junixsocket.version>
-    <opentelemetry.version>1.59.0</opentelemetry.version>
     <google.cloud.monitoring.version>3.85.0</google.cloud.monitoring.version>
   </properties>
 
@@ -65,22 +64,18 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk</artifactId>
-      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-metrics</artifactId>
-      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-trace</artifactId>
-      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-testing</artifactId>
-      <version>${opentelemetry.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.re2j</groupId>

--- a/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
+++ b/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
@@ -31,7 +31,7 @@
     <gson.version>2.13.2</gson.version>
     <guava.version>33.5.0-jre</guava.version>
     <protobuf.version>4.33.2</protobuf.version>
-    <opentelemetry.version>1.57.0</opentelemetry.version>
+    <opentelemetry.version>1.62.0</opentelemetry.version>
     <errorprone.version>2.48.0</errorprone.version>
     <j2objc-annotations.version>3.1</j2objc-annotations.version>
     <threetenbp.version>1.7.0</threetenbp.version>

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/logging/LoggingUtils.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/logging/LoggingUtils.java
@@ -46,7 +46,6 @@ public class LoggingUtils {
    * @return true if logging is enabled, false otherwise.
    */
   public static boolean isLoggingEnabled() {
-    // Dummy comment to trigger CI pipeline
     return loggingEnabled;
   }
 

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/logging/LoggingUtils.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/logging/LoggingUtils.java
@@ -46,6 +46,7 @@ public class LoggingUtils {
    * @return true if logging is enabled, false otherwise.
    */
   public static boolean isLoggingEnabled() {
+    // Dummy comment to trigger CI pipeline
     return loggingEnabled;
   }
 


### PR DESCRIPTION
Upgrades opentelemetry.version to 1.62.0 to address CVE-2026-45292 (GHSA-rcgg-9c38-7xpx). This repo is actually NOT affected by this vulnerability but it is a good practice to upgrade it so it does not show up in customers' reports. 

Separately, removed unnecessary version declaration of opentelemetry in Spanner.       