### PR TITLE
feat: regenerate module for networksecurity

### DIFF
--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1885,10 +1885,11 @@ libraries:
   - proto_path: google/cloud/networkmanagement/v1beta1
 - api_shortname: networksecurity
   name_pretty: Network Security API
-  product_documentation: https://cloud.google.com/traffic-director/docs/reference/network-security/rest
-  api_description: n/a
+  product_documentation: https://cloud.google.com/products/networking
+  api_description: The Network Security API provides resources for configuring and managing network security.
   library_name: network-security
   release_level: stable
+  googleapis_commitish: 29c6482ccb75b302c33665d8c7d7a38d3698be53
   GAPICs:
   - proto_path: google/cloud/networksecurity/v1
   - proto_path: google/cloud/networksecurity/v1beta1


### PR DESCRIPTION
Command used:

python3 generation/new_client_hermetic_build/add-new-client-config.py add-new-library \
  --api-shortname="networksecurity" \
  --name-pretty="Network Security API" \
  --proto-path="google/cloud/networksecurity/v1" \
  --product-docs="https://cloud.google.com/products/networking" \
  --api-description="The Network Security API provides resources for configuring and managing network security." \
  --googleapis-committish="29c6482ccb75b302c33665d8c7d7a38d3698be53" \
  --library-name="network-security" \
  --release-level="stable"
