### PR TITLE
chore: sync librarian.yaml with generation_config.yaml 

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -55,11 +55,9 @@ libraries:
     version: 2.94.0-SNAPSHOT
     apis:
       - path: google/cloud/accessapproval/v1
-    keep:
-      - google-cloud-accessapproval/src/main/java/com/google/cloud/accessapproval/v1/stub/Version.java
-      - google-cloud-accessapproval/src/test/java/com/google/cloud/accessapproval/v1/it/ITAccessApprovalTest.java
     java:
       api_description_override: enables controlling access to your organization's data by Google personnel.
+      released_version: 2.93.0
       name_pretty_override: Access Approval
       product_documentation_override: https://cloud.google.com/access-approval/docs/
   - name: accesscontextmanager
@@ -73,25 +71,23 @@ libraries:
           generate_grpc: false
           generate_resource_names: false
           samples: false
-    keep:
-      - google-identity-accesscontextmanager/src/main/java/com/google/identity/accesscontextmanager/v1/stub/Version.java
     java:
       api_description_override: n/a
       artifact_id: google-identity-accesscontextmanager
+      released_version: 1.93.0
       name_pretty_override: Identity Access Context Manager
       product_documentation_override: n/a
   - name: admanager
     version: 0.52.0-SNAPSHOT
     apis:
       - path: google/ads/admanager/v1
-    keep:
-      - ad-manager/src/main/java/com/google/ads/admanager/v1/stub/Version.java
     java:
       api_id_override: admanager.googleapis.com
       api_description_override: The Ad Manager API enables an app to integrate with Google Ad Manager. You can read Ad Manager data and run reports using the API.
       artifact_id: ad-manager
       client_documentation_override: https://cloud.google.com/java/docs/reference/ad-manager/latest/overview
       group_id: com.google.api-ads
+      released_version: 0.51.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Google Ad Manager API
       product_documentation_override: https://developers.google.com/ad-manager/api/beta
@@ -101,10 +97,9 @@ libraries:
       - path: google/cloud/advisorynotifications/v1
         java:
           omit_common_resources: true
-    keep:
-      - google-cloud-advisorynotifications/src/main/java/com/google/cloud/advisorynotifications/v1/stub/Version.java
     java:
       api_description_override: An API for accessing Advisory Notifications in Google Cloud.
+      released_version: 0.81.0
       name_pretty_override: Advisory Notifications API
       product_documentation_override: https://cloud.google.com/advisory-notifications/
   - name: aiplatform
@@ -135,6 +130,7 @@ libraries:
       - google-cloud-aiplatform/src/test/java/com/google/iam/v1/MockIAMPolicyImpl.java
     java:
       api_description_override: is an integrated suite of machine learning tools and services for building and using ML models with AutoML or custom code. It offers both novices and experts the best workbench for the entire machine learning development lifecycle.
+      released_version: 3.93.0
       name_pretty_override: Vertex AI
       product_documentation_override: https://cloud.google.com/vertex-ai/docs
       rest_documentation: https://cloud.google.com/vertex-ai/docs/reference/rest
@@ -157,12 +153,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-alloydb/src/main/java/com/google/cloud/alloydb/v1/stub/Version.java
-      - google-cloud-alloydb/src/main/java/com/google/cloud/alloydb/v1alpha/stub/Version.java
-      - google-cloud-alloydb/src/main/java/com/google/cloud/alloydb/v1beta/stub/Version.java
     java:
       api_description_override: AlloyDB is a fully managed, PostgreSQL-compatible database service with industry-leading performance, availability, and scale.
+      released_version: 0.81.0
       name_pretty_override: AlloyDB
       product_documentation_override: https://cloud.google.com/alloydb/
       rest_documentation: https://cloud.google.com/alloydb/docs/reference/rest
@@ -193,6 +186,7 @@ libraries:
     java:
       api_id_override: connectors.googleapis.com
       api_description_override: AlloyDB is a fully-managed, PostgreSQL-compatible database for demanding transactional workloads. It provides enterprise-grade performance and availability while maintaining 100% compatibility with open-source PostgreSQL.
+      released_version: 0.70.0
       name_pretty_override: AlloyDB connectors
       product_documentation_override: https://cloud.google.com/alloydb/docs
       rest_documentation: https://cloud.google.com/alloydb/docs/reference/rest
@@ -202,14 +196,12 @@ libraries:
     apis:
       - path: google/analytics/admin/v1beta
       - path: google/analytics/admin/v1alpha
-    keep:
-      - google-analytics-admin/src/main/java/com/google/analytics/admin/v1alpha/stub/Version.java
-      - google-analytics-admin/src/main/java/com/google/analytics/admin/v1beta/stub/Version.java
     java:
       api_description_override: allows you to manage Google Analytics accounts and properties.
       artifact_id: google-analytics-admin
       codeowner_team: '@googleapis/analytics-dpe'
       group_id: com.google.analytics
+      released_version: 0.102.0
       name_pretty_override: Analytics Admin
       product_documentation_override: https://developers.google.com/analytics
   - name: analytics-data
@@ -217,36 +209,32 @@ libraries:
     apis:
       - path: google/analytics/data/v1beta
       - path: google/analytics/data/v1alpha
-    keep:
-      - google-analytics-data/src/main/java/com/google/analytics/data/v1alpha/stub/Version.java
-      - google-analytics-data/src/main/java/com/google/analytics/data/v1beta/stub/Version.java
     java:
       api_id_override: analytics-data.googleapis.com
       api_description_override: provides programmatic methods to access report data in Google Analytics App+Web properties.
       artifact_id: google-analytics-data
       codeowner_team: '@googleapis/analytics-dpe'
       group_id: com.google.analytics
+      released_version: 0.103.0
       name_pretty_override: Analytics Data
       product_documentation_override: https://developers.google.com/analytics/trusted-testing/analytics-data
   - name: analyticshub
     version: 0.90.0-SNAPSHOT
     apis:
       - path: google/cloud/bigquery/analyticshub/v1
-    keep:
-      - google-cloud-analyticshub/src/main/java/com/google/cloud/bigquery/analyticshub/v1/stub/Version.java
     java:
       api_description_override: TBD
+      released_version: 0.89.0
       name_pretty_override: Analytics Hub API
       product_documentation_override: https://cloud.google.com/bigquery/TBD
   - name: api-gateway
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/cloud/apigateway/v1
-    keep:
-      - google-cloud-api-gateway/src/main/java/com/google/cloud/apigateway/v1/stub/Version.java
     java:
       api_id_override: apigateway.googleapis.com
       api_description_override: enables you to provide secure access to your backend services through a well-defined REST API that is consistent across all of your services, regardless of the service implementation. Clients consume your REST APIS to implement standalone apps for a mobile device or tablet, through apps running in a browser, or through any other type of app that can make a request to an HTTP endpoint.
+      released_version: 2.92.0
       name_pretty_override: API Gateway
       product_documentation_override: https://cloud.google.com/api-gateway/docs
       rest_documentation: https://cloud.google.com/api-gateway/docs/reference/rest
@@ -254,10 +242,9 @@ libraries:
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/cloud/apigeeconnect/v1
-    keep:
-      - google-cloud-apigee-connect/src/main/java/com/google/cloud/apigeeconnect/v1/stub/Version.java
     java:
       api_description_override: allows the Apigee hybrid management plane to connect securely to the MART service in the runtime plane without requiring you to expose the MART endpoint on the internet.
+      released_version: 2.92.0
       name_pretty_override: Apigee Connect
       product_documentation_override: https://cloud.google.com/apigee/docs/hybrid/v1.3/apigee-connect/
   - name: apigee-registry
@@ -268,12 +255,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-apigee-registry/src/main/java/com/google/cloud/apigeeregistry/v1/stub/Version.java
     java:
       api_id_override: apigeeregistry.googleapis.com
       api_description_override: allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.
       api_shortname_override: apigee-registry
+      released_version: 0.92.0
       name_pretty_override: Registry API
       product_documentation_override: https://cloud.google.com/apigee/docs/api-hub/get-started-registry-api
   - name: apihub
@@ -283,12 +269,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-apihub/src/main/java/com/google/cloud/apihub/v1/stub/Version.java
     java:
       api_id_override: apihub.googleapis.com
       api_description_override: API hub lets you consolidate and organize information about all of the APIs     of interest to your organization. API hub lets you capture critical information about APIs that allows developers to discover and evaluate     them easily and leverage the work of other teams wherever possible. API     platform teams can use API hub to have visibility into and manage their portfolio of APIs.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-apihub/latest/overview
+      released_version: 0.45.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: API hub API
       product_documentation_override: https://cloud.google.com/apigee/docs/apihub/what-is-api-hub
@@ -296,21 +281,19 @@ libraries:
     version: 0.91.0-SNAPSHOT
     apis:
       - path: google/api/apikeys/v2
-    keep:
-      - google-cloud-apikeys/src/main/java/com/google/api/apikeys/v2/stub/Version.java
     java:
       api_description_override: API Keys lets you create and manage your API keys for your projects.
+      released_version: 0.90.0
       name_pretty_override: API Keys API
       product_documentation_override: https://cloud.google.com/api-keys/
   - name: appengine-admin
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/appengine/v1
-    keep:
-      - google-cloud-appengine-admin/src/main/java/com/google/appengine/v1/stub/Version.java
     java:
       api_description_override: you to manage your App Engine applications.
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 2.92.0
       name_pretty_override: App Engine Admin API
       product_documentation_override: https://cloud.google.com/appengine/docs/admin-api/
   - name: apphub
@@ -321,10 +304,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-apphub/src/main/java/com/google/cloud/apphub/v1/stub/Version.java
     java:
       api_description_override: App Hub simplifies the process of building, running, and managing applications on Google Cloud.
+      released_version: 0.56.0
       name_pretty_override: App Hub API
       product_documentation_override: https://cloud.google.com/app-hub/docs/overview
       rpc_documentation: https://cloud.google.com/app-hub/docs/reference/rpc
@@ -335,12 +317,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-appoptimize/src/main/java/com/google/cloud/appoptimize/v1beta/stub/Version.java
     java:
       api_id_override: appoptimize.googleapis.com
       api_description_override: The App Optimize API provides developers and platform teams with tools to monitor, analyze, and improve the performance and cost-efficiency of their cloud applications.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-appoptimize/latest/overview
+      released_version: 0.2.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: App Optimize API
       product_documentation_override: https://docs.cloud.google.com/app-optimize/overview
@@ -348,12 +329,11 @@ libraries:
     version: 0.97.0-SNAPSHOT
     apis:
       - path: google/area120/tables/v1alpha1
-    keep:
-      - google-area120-tables/src/main/java/com/google/area120/tables/v1alpha/stub/Version.java
     java:
       api_description_override: provides programmatic methods to the Area 120 Tables API.
       artifact_id: google-area120-tables
       group_id: com.google.area120
+      released_version: 0.96.0
       name_pretty_override: Area 120 Tables
       product_documentation_override: https://area120.google.com/
   - name: artifact-registry
@@ -367,12 +347,10 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-artifact-registry/src/main/java/com/google/devtools/artifactregistry/v1/stub/Version.java
-      - google-cloud-artifact-registry/src/main/java/com/google/devtools/artifactregistry/v1beta2/stub/Version.java
     java:
       api_description_override: provides a single place for your organization to manage container images and language packages (such as Maven and npm). It is fully integrated with Google Cloud's tooling and runtimes and comes with support for native artifact protocols. This makes it simple to integrate it with your CI/CD tooling to set up automated pipelines.
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 1.91.0
       name_pretty_override: Artifact Registry
       product_documentation_override: https://cloud.google.com/artifact-registry
       rest_documentation: https://cloud.google.com/artifact-registry/docs/reference/rest
@@ -386,17 +364,13 @@ libraries:
       - path: google/cloud/asset/v1p2beta1
       - path: google/cloud/asset/v1p1beta1
     keep:
-      - google-cloud-asset/src/main/java/com/google/cloud/asset/v1/stub/Version.java
-      - google-cloud-asset/src/main/java/com/google/cloud/asset/v1p1beta1/stub/Version.java
-      - google-cloud-asset/src/main/java/com/google/cloud/asset/v1p2beta1/stub/Version.java
-      - google-cloud-asset/src/main/java/com/google/cloud/asset/v1p5beta1/stub/Version.java
-      - google-cloud-asset/src/main/java/com/google/cloud/asset/v1p7beta1/stub/Version.java
       - google-cloud-asset/src/test/java/com/google/cloud/asset/it/ITSystemTest.java
       - proto-google-cloud-asset-v1/src/main/java/com/google/cloud/asset/v1/ProjectName.java
     java:
       api_reference: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
       api_description_override: provides inventory services based on a time series database. This database keeps a five week history of Google Cloud asset metadata. The Cloud Asset Inventory export service allows you to export all asset metadata at a certain timestamp or export event change history during a timeframe.
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=187210
+      released_version: 3.96.0
       name_pretty_override: Cloud Asset Inventory
       product_documentation_override: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
   - name: assured-workloads
@@ -404,11 +378,9 @@ libraries:
     apis:
       - path: google/cloud/assuredworkloads/v1
       - path: google/cloud/assuredworkloads/v1beta1
-    keep:
-      - google-cloud-assured-workloads/src/main/java/com/google/cloud/assuredworkloads/v1/stub/Version.java
-      - google-cloud-assured-workloads/src/main/java/com/google/cloud/assuredworkloads/v1beta1/stub/Version.java
     java:
       api_description_override: allows you to secure your government workloads and accelerate your path to running compliant workloads on Google Cloud with Assured Workloads for Government.
+      released_version: 2.92.0
       name_pretty_override: Assured Workloads for Government
       product_documentation_override: https://cloud.google.com/assured-workloads/
       rest_documentation: https://cloud.google.com/assured-workloads/docs/reference/rest
@@ -419,12 +391,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-auditmanager/src/main/java/com/google/cloud/auditmanager/v1/stub/Version.java
     java:
       api_id_override: auditmanager.googleapis.com
       api_description_override: Lists information about the supported locations for this service.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-auditmanager/latest/overview
+      released_version: 0.10.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Audit Manager API
       product_documentation_override: https://cloud.google.com/audit-manager/docs
@@ -433,12 +404,10 @@ libraries:
     apis:
       - path: google/cloud/automl/v1
       - path: google/cloud/automl/v1beta1
-    keep:
-      - google-cloud-automl/src/main/java/com/google/cloud/automl/v1/stub/Version.java
-      - google-cloud-automl/src/main/java/com/google/cloud/automl/v1beta1/stub/Version.java
     java:
       api_description_override: makes the power of machine learning available to you even if you have limited knowledge of machine learning. You can use AutoML to build on Google's machine learning capabilities to create your own custom machine learning models that are tailored to your business needs, and then integrate those models into your applications and web sites.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559744
+      released_version: 2.92.0
       name_pretty_override: Cloud Auto ML
       product_documentation_override: https://cloud.google.com/automl/docs/
       rest_documentation: https://cloud.google.com/automl/docs/reference/rest
@@ -451,12 +420,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-backupdr/src/main/java/com/google/cloud/backupdr/v1/stub/Version.java
     java:
       api_id_override: backupdr.googleapis.com
       api_description_override: 'Backup and DR Service is a powerful, centralized, cloud-first backup and disaster recovery solution for cloud-based and hybrid workloads. '
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-backupdr/latest/overview
+      released_version: 0.51.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Backup and DR Service API
       product_documentation_override: https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr
@@ -468,10 +436,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-bare-metal-solution/src/main/java/com/google/cloud/baremetalsolution/v2/stub/Version.java
     java:
       api_description_override: Bring your Oracle workloads to Google Cloud with Bare Metal Solution and jumpstart your cloud journey with minimal risk.
+      released_version: 0.92.0
       name_pretty_override: Bare Metal Solution
       product_documentation_override: https://cloud.google.com/bare-metal/docs
       rest_documentation: https://cloud.google.com/bare-metal/docs/reference/rest
@@ -488,11 +455,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-batch/src/main/java/com/google/cloud/batch/v1/stub/Version.java
-      - google-cloud-batch/src/main/java/com/google/cloud/batch/v1alpha/stub/Version.java
     java:
       api_description_override: n/a
+      released_version: 0.92.0
       name_pretty_override: Cloud Batch
       product_documentation_override: https://cloud.google.com/
   - name: beyondcorp-appconnections
@@ -503,11 +468,10 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-beyondcorp-appconnections/src/main/java/com/google/cloud/beyondcorp/appconnections/v1/stub/Version.java
     java:
       api_description_override: is Google's implementation of the zero trust model. It builds upon a decade of experience at Google, combined with ideas and best practices from the community. By shifting access controls from the network perimeter to individual users, BeyondCorp enables secure work from virtually any location without the need for a traditional VPN.
       api_shortname_override: beyondcorp-appconnections
+      released_version: 0.90.0
       name_pretty_override: BeyondCorp AppConnections
       product_documentation_override: https://cloud.google.com/beyondcorp-enterprise/
   - name: beyondcorp-appconnectors
@@ -518,11 +482,10 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-beyondcorp-appconnectors/src/main/java/com/google/cloud/beyondcorp/appconnectors/v1/stub/Version.java
     java:
       api_description_override: provides methods to manage (create/read/update/delete) BeyondCorp AppConnectors.
       api_shortname_override: beyondcorp-appconnectors
+      released_version: 0.90.0
       name_pretty_override: BeyondCorp AppConnectors
       product_documentation_override: cloud.google.com/beyondcorp-enterprise/
   - name: beyondcorp-appgateways
@@ -533,12 +496,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-beyondcorp-appgateways/src/main/java/com/google/cloud/beyondcorp/appgateways/v1/stub/Version.java
     java:
       api_id_override: beyondcorp.googleapis.com
       api_description_override: A zero trust solution that enables secure access to applications and resources, and offers integrated threat and data protection.
       api_shortname_override: beyondcorp-appgateways
+      released_version: 0.90.0
       name_pretty_override: BeyondCorp AppGateways
       product_documentation_override: https://cloud.google.com/beyondcorp-enterprise/
   - name: beyondcorp-clientconnectorservices
@@ -549,12 +511,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-beyondcorp-clientconnectorservices/src/main/java/com/google/cloud/beyondcorp/clientconnectorservices/v1/stub/Version.java
     java:
       api_id_override: beyondcorp.googleapis.com
       api_description_override: A zero trust solution that enables secure access to applications and resources, and offers integrated threat and data protection.
       api_shortname_override: beyondcorp-clientconnectorservices
+      released_version: 0.90.0
       name_pretty_override: BeyondCorp ClientConnectorServices
       product_documentation_override: https://cloud.google.com/beyondcorp-enterprise/
   - name: beyondcorp-clientgateways
@@ -565,12 +526,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-beyondcorp-clientgateways/src/main/java/com/google/cloud/beyondcorp/clientgateways/v1/stub/Version.java
     java:
       api_id_override: beyondcorp.googleapis.com
       api_description_override: A zero trust solution that enables secure access to applications and resources, and offers integrated threat and data protection.
       api_shortname_override: beyondcorp-clientgateways
+      released_version: 0.90.0
       name_pretty_override: BeyondCorp ClientGateways
       product_documentation_override: https://cloud.google.com/beyondcorp-enterprise/
   - name: biglake
@@ -580,13 +540,9 @@ libraries:
       - path: google/cloud/bigquery/biglake/v1
       - path: google/cloud/biglake/hive/v1beta
       - path: google/cloud/bigquery/biglake/v1alpha1
-    keep:
-      - google-cloud-biglake/src/main/java/com/google/cloud/biglake/hive/v1beta/stub/Version.java
-      - google-cloud-biglake/src/main/java/com/google/cloud/biglake/v1/stub/Version.java
-      - google-cloud-biglake/src/main/java/com/google/cloud/bigquery/biglake/v1/stub/Version.java
-      - google-cloud-biglake/src/main/java/com/google/cloud/bigquery/biglake/v1alpha1/stub/Version.java
     java:
       api_description_override: The BigLake API provides access to BigLake Metastore, a serverless, fully managed, and highly available metastore for open-source data that can be used for querying Apache Iceberg tables in BigQuery.
+      released_version: 0.80.0
       name_pretty_override: BigLake
       product_documentation_override: https://cloud.google.com/biglake
   - name: bigquery-data-exchange
@@ -596,10 +552,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-bigquery-data-exchange/src/main/java/com/google/cloud/bigquery/dataexchange/v1beta1/stub/Version.java
     java:
       api_description_override: is a data exchange that allows you to efficiently and securely exchange data assets across organizations to address challenges of data reliability and cost.
+      released_version: 2.87.0
       name_pretty_override: Analytics Hub
       product_documentation_override: https://cloud.google.com/analytics-hub
   - name: bigqueryconnection
@@ -607,12 +562,10 @@ libraries:
     apis:
       - path: google/cloud/bigquery/connection/v1
       - path: google/cloud/bigquery/connection/v1beta1
-    keep:
-      - google-cloud-bigqueryconnection/src/main/java/com/google/cloud/bigquery/connection/v1beta1/stub/Version.java
-      - google-cloud-bigqueryconnection/src/main/java/com/google/cloud/bigqueryconnection/v1/stub/Version.java
     java:
       api_description_override: allows users to manage BigQuery connections to external data sources.
       client_documentation_override: https://cloud.google.com/bigquery/docs/reference/reservations/rpc/google.cloud.bigquery.reservation.v1beta1
+      released_version: 2.94.0
       name_pretty_override: Cloud BigQuery Connection
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/bigqueryconnection/rest
   - name: bigquerydatapolicy
@@ -622,13 +575,9 @@ libraries:
       - path: google/cloud/bigquery/datapolicies/v1
       - path: google/cloud/bigquery/datapolicies/v2beta1
       - path: google/cloud/bigquery/datapolicies/v1beta1
-    keep:
-      - google-cloud-bigquerydatapolicy/src/main/java/com/google/cloud/bigquery/datapolicies/v1/stub/Version.java
-      - google-cloud-bigquerydatapolicy/src/main/java/com/google/cloud/bigquery/datapolicies/v1beta1/stub/Version.java
-      - google-cloud-bigquerydatapolicy/src/main/java/com/google/cloud/bigquery/datapolicies/v2/stub/Version.java
-      - google-cloud-bigquerydatapolicy/src/main/java/com/google/cloud/bigquery/datapolicies/v2beta1/stub/Version.java
     java:
       api_description_override: Allows users to manage BigQuery data policies.
+      released_version: 0.89.0
       name_pretty_override: BigQuery DataPolicy API
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/datapolicy/
   - name: bigquerydatatransfer
@@ -640,10 +589,10 @@ libraries:
             - path: google/cloud/location/locations.proto
     keep:
       - google-cloud-bigquerydatatransfer/src/main/java/com/google/cloud/bigquery/datatransfer/v1/SampleApp.java
-      - google-cloud-bigquerydatatransfer/src/main/java/com/google/cloud/bigquery/datatransfer/v1/stub/Version.java
     java:
       api_description_override: transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
+      released_version: 2.92.0
       name_pretty_override: BigQuery Data Transfer Service
       product_documentation_override: https://cloud.google.com/bigquery/transfer/
   - name: bigquerymigration
@@ -651,11 +600,9 @@ libraries:
     apis:
       - path: google/cloud/bigquery/migration/v2
       - path: google/cloud/bigquery/migration/v2alpha
-    keep:
-      - google-cloud-bigquerymigration/src/main/java/com/google/cloud/bigquery/migration/v2/stub/Version.java
-      - google-cloud-bigquerymigration/src/main/java/com/google/cloud/bigquery/migration/v2alpha/stub/Version.java
     java:
       api_description_override: BigQuery Migration API
+      released_version: 0.95.0
       name_pretty_override: BigQuery Migration
       product_documentation_override: https://cloud.google.com/bigquery/docs
       rest_documentation: https://cloud.google.com/bigquery/docs/reference/rest
@@ -663,10 +610,9 @@ libraries:
     version: 2.94.0-SNAPSHOT
     apis:
       - path: google/cloud/bigquery/reservation/v1
-    keep:
-      - google-cloud-bigqueryreservation/src/main/java/com/google/cloud/bigquery/reservation/v1/stub/Version.java
     java:
       api_description_override: allows users to manage their flat-rate BigQuery reservations.
+      released_version: 2.93.0
       name_pretty_override: Cloud BigQuery Reservation
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/reservations/rpc
   - name: bigquerystorage
@@ -713,19 +659,15 @@ libraries:
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/BigQueryReadStubSettings.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStub.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStubSettings.java
-      - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/Version.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/readrows/ApiResultRetryAlgorithm.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/readrows/ReadRowsAttemptCallable.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/readrows/ReadRowsResumptionStrategy.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/readrows/ReadRowsRetryingCallable.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1/stub/readrows/package-info.java
-      - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1alpha/stub/Version.java
-      - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta/stub/Version.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/BigQueryStorageClient.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/BigQueryStorageSettings.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/EnhancedBigQueryStorageStub.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/EnhancedBigQueryStorageStubSettings.java
-      - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/Version.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/readrows/ApiResultRetryAlgorithm.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/readrows/ReadRowsAttemptCallable.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta1/stub/readrows/ReadRowsResumptionStrategy.java
@@ -745,7 +687,6 @@ libraries:
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/BigQueryReadStubSettings.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/EnhancedBigQueryReadStub.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/EnhancedBigQueryReadStubSettings.java
-      - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/Version.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/readrows/ApiResultRetryAlgorithm.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/readrows/ReadRowsAttemptCallable.java
       - google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2/stub/readrows/ReadRowsResumptionStrategy.java
@@ -768,13 +709,6 @@ libraries:
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/ProtoSchemaConverterTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/RequestProfilerTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/StreamWriterTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryBigDecimalByteStringEncoderTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageLongRunningTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageReadClientTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageWriteClientTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryTimeEncoderTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteNonQuotaRetryTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteQuotaRetryTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/BigQueryResource.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/Helper.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/SimpleRowReaderArrow.java
@@ -785,8 +719,6 @@ libraries:
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/stub/WriteHeaderTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/stub/readrows/ReadRowsRetryTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/BigQueryStorageClientTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/it/ITBigQueryStorageLongRunningTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/it/ITBigQueryStorageTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/it/SimpleRowReader.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/stub/EnhancedBigQueryStorageStubSettingsTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/stub/ResourceHeaderTest.java
@@ -794,8 +726,6 @@ libraries:
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/BigDecimalByteStringEncoderTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/BigQueryReadClientTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/BigQueryResource.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryStorageLongRunningTest.java
-      - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryStorageTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/SimpleRowReader.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/stub/EnhancedBigQueryReadStubSettingsTest.java
       - google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/stub/ResourceHeaderTest.java
@@ -810,6 +740,7 @@ libraries:
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/history
       codeowner_team: '@googleapis/bigquery-team'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
+      released_version: 3.28.0
       library_type_override: GAPIC_COMBO
       name_pretty_override: BigQuery Storage
       product_documentation_override: https://cloud.google.com/bigquery/docs/reference/storage/
@@ -827,9 +758,6 @@ libraries:
           grpc_artifact_id_override: grpc-google-cloud-bigtable-admin-v2
           proto_artifact_id_override: proto-google-cloud-bigtable-admin-v2
           samples: false
-    keep:
-      - google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/admin/v2/stub/Version.java
-      - google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/Version.java
     java:
       api_id_override: bigtable.googleapis.com
       api_description_override: API for reading and writing the contents of Bigtables associated with a cloud project.
@@ -839,6 +767,7 @@ libraries:
         - google-cloud-bigtable-bom
       extra_versioned_modules: google-cloud-bigtable-emulator,google-cloud-bigtable-emulator-core
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559777
+      released_version: 2.78.1
       library_type_override: GAPIC_COMBO
       name_pretty_override: Cloud Bigtable
       product_documentation_override: https://cloud.google.com/bigtable
@@ -850,11 +779,11 @@ libraries:
         java:
           omit_common_resources: true
     keep:
-      - google-cloud-billing/src/main/java/com/google/cloud/billing/v1/stub/Version.java
       - google-cloud-billing/src/test/java/com/google/cloud/billing/v1/CloudBillingClientHttpJsonTest.java
     java:
       api_description_override: allows developers to manage their billing accounts or browse the catalog of SKUs and pricing.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559770
+      released_version: 2.92.0
       name_pretty_override: Cloud Billing
       product_documentation_override: https://cloud.google.com/billing/docs
       rest_documentation: https://cloud.google.com/billing/docs/reference/rest
@@ -864,11 +793,9 @@ libraries:
     apis:
       - path: google/cloud/billing/budgets/v1
       - path: google/cloud/billing/budgets/v1beta1
-    keep:
-      - google-cloud-billingbudgets/src/main/java/com/google/cloud/billing/budgets/v1/stub/Version.java
-      - google-cloud-billingbudgets/src/main/java/com/google/cloud/billing/budgets/v1beta1/stub/Version.java
     java:
       api_description_override: allows you to avoid surprises on your bill by creating budgets to monitor all your Google Cloud charges in one place.
+      released_version: 2.92.0
       name_pretty_override: Cloud Billing Budgets
       product_documentation_override: https://cloud.google.com/billing/docs/how-to/budgets
   - name: binary-authorization
@@ -876,13 +803,11 @@ libraries:
     apis:
       - path: google/cloud/binaryauthorization/v1
       - path: google/cloud/binaryauthorization/v1beta1
-    keep:
-      - google-cloud-binary-authorization/src/main/java/com/google/cloud/binaryauthorization/v1beta1/stub/Version.java
-      - google-cloud-binary-authorization/src/main/java/com/google/protos/google/cloud/binaryauthorization/v1/stub/Version.java
     java:
       api_id_override: binaryauthorization.googleapis.com
       api_description_override: ' is a service on Google Cloud that provides centralized software supply-chain security for applications that run on Google Kubernetes Engine (GKE) and Anthos clusters on VMware'
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 1.91.0
       name_pretty_override: Binary Authorization
       product_documentation_override: https://cloud.google.com/binary-authorization/docs
       rest_documentation: https://cloud.google.com/binary-authorization/docs/reference/rest
@@ -891,12 +816,11 @@ libraries:
     version: 0.16.0-SNAPSHOT
     apis:
       - path: google/cloud/capacityplanner/v1beta
-    keep:
-      - google-cloud-capacityplanner/src/main/java/com/google/cloud/capacityplanner/v1beta/stub/Version.java
     java:
       api_id_override: capacityplanner.googleapis.com
       api_description_override: Provides programmatic access to Capacity Planner features.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-capacityplanner/latest/overview
+      released_version: 0.15.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Capacity Planner API
       product_documentation_override: https://cloud.google.com/capacity-planner/docs
@@ -907,11 +831,10 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-certificate-manager/src/main/java/com/google/cloud/certificatemanager/v1/stub/Version.java
     java:
       api_id_override: certificatemanager.googleapis.com
       api_description_override: lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing.
+      released_version: 0.95.0
       name_pretty_override: Certificate Manager
       product_documentation_override: https://cloud.google.com/certificate-manager/docs
   - name: ces
@@ -925,13 +848,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-ces/src/main/java/com/google/cloud/ces/v1/stub/Version.java
-      - google-cloud-ces/src/main/java/com/google/cloud/ces/v1beta/stub/Version.java
     java:
       api_id_override: ces.googleapis.com
       api_description_override: Customer Experience Agent Studio (CX Agent Studio) is a minimal code conversational agent builder.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-ces/latest/overview
+      released_version: 0.8.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Gemini Enterprise for Customer Experience API
       product_documentation_override: https://docs.cloud.google.com/customer-engagement-ai/conversational-agents/ps
@@ -940,10 +861,9 @@ libraries:
     version: 3.97.0-SNAPSHOT
     apis:
       - path: google/cloud/channel/v1
-    keep:
-      - google-cloud-channel/src/main/java/com/google/cloud/channel/v1/stub/Version.java
     java:
       api_description_override: With Channel Services, Google Cloud partners and resellers have a single unified resale platform, with a unified resale catalog, customer management, order management, billing management, policy and authorization management, and cost management.
+      released_version: 3.96.0
       name_pretty_override: Channel Services
       product_documentation_override: https://cloud.google.com/channel/docs
       rest_documentation: https://cloud.google.com/channel/docs/reference/rest
@@ -952,10 +872,9 @@ libraries:
     version: 0.57.0-SNAPSHOT
     apis:
       - path: google/chat/v1
-    keep:
-      - google-cloud-chat/src/main/java/com/google/chat/v1/stub/Version.java
     java:
       api_description_override: The Google Chat API lets you build Chat apps to integrate your services with Google Chat and manage Chat resources such as spaces, members, and messages.
+      released_version: 0.56.0
       name_pretty_override: Google Chat API
       product_documentation_override: https://developers.google.com/chat/concepts
       rest_documentation: https://developers.google.com/chat/api/reference/rest
@@ -963,12 +882,11 @@ libraries:
     version: 0.31.0-SNAPSHOT
     apis:
       - path: google/cloud/chronicle/v1
-    keep:
-      - google-cloud-chronicle/src/main/java/com/google/cloud/chronicle/v1/stub/Version.java
     java:
       api_id_override: chronicle.googleapis.com
       api_description_override: The Google Cloud Security Operations API, popularly known as the Chronicle API, serves endpoints that enable security analysts to analyze and mitigate a security threat throughout its lifecycle
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-chronicle/latest/overview
+      released_version: 0.30.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Chronicle API
       product_documentation_override: https://cloud.google.com/chronicle/docs/secops/secops-overview
@@ -983,13 +901,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-cloudapiregistry/src/main/java/com/google/cloud/apiregistry/v1/stub/Version.java
-      - google-cloud-cloudapiregistry/src/main/java/com/google/cloud/apiregistry/v1beta/stub/Version.java
     java:
       api_id_override: cloudapiregistry.googleapis.com
       api_description_override: Cloud API Registry lets you discover, govern, use, and monitor Model Context Protocol (MCP) servers and tools provided by Google, or by your organization through Apigee API hub.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-cloudapiregistry/latest/overview
+      released_version: 0.11.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Cloud API Registry API
       product_documentation_override: https://docs.cloud.google.com/api-registry/docs/overview
@@ -1002,14 +918,12 @@ libraries:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
       - path: google/devtools/cloudbuild/v1
-    keep:
-      - google-cloud-build/src/main/java/com/google/cloud/devtools/cloudbuild/v1/stub/Version.java
-      - google-cloud-build/src/main/java/com/google/cloud/devtools/cloudbuild/v2/stub/Version.java
     java:
       api_description_override: lets you build software quickly across all languages. Get complete control over defining custom workflows for building, testing, and deploying across multiple environments such as VMs, serverless, Kubernetes, or Firebase.
       artifact_id: google-cloud-build
       codeowner_team: '@googleapis/aap-dpes'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5226584
+      released_version: 3.94.0
       name_pretty_override: Cloud Build
       product_documentation_override: https://cloud.google.com/cloud-build/
   - name: cloudcommerceconsumerprocurement
@@ -1017,11 +931,9 @@ libraries:
     apis:
       - path: google/cloud/commerce/consumer/procurement/v1
       - path: google/cloud/commerce/consumer/procurement/v1alpha1
-    keep:
-      - google-cloud-cloudcommerceconsumerprocurement/src/main/java/com/google/cloud/commerce/consumer/procurement/v1/stub/Version.java
-      - google-cloud-cloudcommerceconsumerprocurement/src/main/java/com/google/cloud/commerce/consumer/procurement/v1alpha1/stub/Version.java
     java:
       api_description_override: Find top solutions integrated with Google Cloud to accelerate your digital transformation. Scale and simplify procurement for your organization with online discovery, flexible purchasing, and fulfillment of enterprise-grade cloud solutions.
+      released_version: 0.90.0
       name_pretty_override: Cloud Commerce Consumer Procurement
       product_documentation_override: https://cloud.google.com/marketplace/
   - name: cloudcontrolspartner
@@ -1029,11 +941,9 @@ libraries:
     apis:
       - path: google/cloud/cloudcontrolspartner/v1
       - path: google/cloud/cloudcontrolspartner/v1beta
-    keep:
-      - google-cloud-cloudcontrolspartner/src/main/java/com/google/cloud/cloudcontrolspartner/v1/stub/Version.java
-      - google-cloud-cloudcontrolspartner/src/main/java/com/google/cloud/cloudcontrolspartner/v1beta/stub/Version.java
     java:
       api_description_override: Provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.
+      released_version: 0.56.0
       name_pretty_override: Cloud Controls Partner API
       product_documentation_override: https://cloud.google.com/sovereign-controls-by-partners/docs/sovereign-partners
   - name: cloudquotas
@@ -1045,14 +955,12 @@ libraries:
       - path: google/api/cloudquotas/v1beta
         java:
           omit_common_resources: true
-    keep:
-      - google-cloud-cloudquotas/src/main/java/com/google/api/cloudquotas/v1/stub/Version.java
-      - google-cloud-cloudquotas/src/main/java/com/google/api/cloudquotas/v1beta/stub/Version.java
     java:
       api_description_override: |-
         Cloud Quotas API provides GCP service consumers with management and
             observability for resource usage, quotas, and restrictions of the services
             they consume.
+      released_version: 0.60.0
       name_pretty_override: Cloud Quotas API
       product_documentation_override: https://cloud.google.com/cloudquotas/docs/
   - name: cloudsecuritycompliance
@@ -1062,12 +970,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-cloudsecuritycompliance/src/main/java/com/google/cloud/cloudsecuritycompliance/v1/stub/Version.java
     java:
       api_id_override: cloudsecuritycompliance.googleapis.com
       api_description_override: Compliance Manager uses software-defined controls that let you assess support for multiple compliance programs and security requirements within a Google Cloud organization
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-cloudsecuritycompliance/latest/overview
+      released_version: 0.19.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Cloud Security Compliance API
       product_documentation_override: https://cloud.google.com/security-command-center/docs/compliance-manager-overview
@@ -1076,11 +983,9 @@ libraries:
     apis:
       - path: google/cloud/support/v2
       - path: google/cloud/support/v2beta
-    keep:
-      - google-cloud-cloudsupport/src/main/java/com/google/cloud/support/v2/stub/Version.java
-      - google-cloud-cloudsupport/src/main/java/com/google/cloud/support/v2beta/stub/Version.java
     java:
       api_description_override: Manages Google Cloud technical support cases for Customer Care support offerings.
+      released_version: 0.76.0
       name_pretty_override: Google Cloud Support API
       product_documentation_override: https://cloud.google.com/support/docs/reference/support-api/
   - name: common-protos
@@ -1183,6 +1088,7 @@ libraries:
         - proto-google-common-protos-bom
         - proto-google-common-protos
       group_id: com.google.api.grpc
+      released_version: 2.71.0
       library_type_override: OTHER
       name_pretty_override: Common Protos
       product_documentation_override: https://github.com/googleapis/api-common-protos
@@ -1196,7 +1102,6 @@ libraries:
         java:
           omit_common_resources: true
     keep:
-      - google-cloud-compute/src/main/java/com/google/cloud/compute/v1/stub/Version.java
       - google-cloud-compute/src/test/java/com/google/cloud/compute/v1/integration/BaseTest.java
       - google-cloud-compute/src/test/java/com/google/cloud/compute/v1/integration/ITComputeGoldenSignals.java
       - google-cloud-compute/src/test/java/com/google/cloud/compute/v1/integration/ITPaginationTest.java
@@ -1207,6 +1112,7 @@ libraries:
       excluded_dependencies: grpc-google-cloud-compute-v1
       excluded_poms:
         - grpc-google-cloud-compute-v1
+      released_version: 1.102.0
       name_pretty_override: Compute Engine
       product_documentation_override: https://cloud.google.com/compute/
   - name: confidentialcomputing
@@ -1220,11 +1126,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-confidentialcomputing/src/main/java/com/google/cloud/confidentialcomputing/v1/stub/Version.java
-      - google-cloud-confidentialcomputing/src/main/java/com/google/cloud/confidentialcomputing/v1alpha1/stub/Version.java
     java:
       api_description_override: Protect data in-use with Confidential VMs, Confidential GKE, Confidential Dataproc, and Confidential Space.
+      released_version: 0.78.0
       name_pretty_override: Confidential Computing API
       product_documentation_override: https://cloud.google.com/confidential-computing/
   - name: configdelivery
@@ -1238,13 +1142,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-configdelivery/src/main/java/com/google/cloud/configdelivery/v1/stub/Version.java
-      - google-cloud-configdelivery/src/main/java/com/google/cloud/configdelivery/v1beta/stub/Version.java
     java:
       api_id_override: configdelivery.googleapis.com
       api_description_override: ConfigDelivery service manages the deployment of kubernetes configuration to a fleet of kubernetes clusters.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-configdelivery/latest/overview
+      released_version: 0.26.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Config Delivery API
       product_documentation_override: https://cloud.google.com/kubernetes-engine/enterprise/config-sync/docs/concepts/fleet-packages
@@ -1253,12 +1155,11 @@ libraries:
     version: 0.45.0-SNAPSHOT
     apis:
       - path: google/cloud/gkeconnect/gateway/v1
-    keep:
-      - google-cloud-connectgateway/src/main/java/com/google/cloud/gkeconnect/gateway/v1/stub/Version.java
     java:
       api_id_override: connectgateway.googleapis.com
       api_description_override: The Connect Gateway service allows connectivity from external parties to     connected Kubernetes clusters.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-connectgateway/latest/overview
+      released_version: 0.44.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Connect Gateway API
       product_documentation_override: https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway
@@ -1266,11 +1167,10 @@ libraries:
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/cloud/contactcenterinsights/v1
-    keep:
-      - google-cloud-contact-center-insights/src/main/java/com/google/cloud/contactcenterinsights/v1/stub/Version.java
     java:
       api_description_override: ' helps users detect and visualize patterns in their contact center data.'
       codeowner_team: '@googleapis/api-contact-center-insights'
+      released_version: 2.92.0
       name_pretty_override: CCAI Insights
       product_documentation_override: https://cloud.google.com/dialogflow/priv/docs/insights/
   - name: container
@@ -1280,14 +1180,12 @@ libraries:
       - path: google/container/v1beta1
     keep:
       - google-cloud-container/src/main/java/com/google/cloud/container/v1/SampleApp.java
-      - google-cloud-container/src/main/java/com/google/cloud/container/v1/stub/Version.java
-      - google-cloud-container/src/main/java/com/google/cloud/container/v1beta1/stub/Version.java
-      - google-cloud-container/src/test/java/com/google/cloud/container/v1/it/ITSystemTest.java
       - google-cloud-container/src/test/java/com/google/cloud/container/v1/it/Util.java
     java:
       api_description_override: is an enterprise-grade platform for containerized applications, including stateful and stateless, AI and ML, Linux and Windows, complex and simple web apps, API, and backend services. Leverage industry-first features like four-way auto-scaling and no-stress management. Optimize GPU and TPU provisioning, use integrated developer tools, and get multi-cluster support from SREs.
       codeowner_team: '@googleapis/cloud-sdk-java-team'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559777
+      released_version: 2.95.0
       name_pretty_override: Kubernetes Engine
       product_documentation_override: https://cloud.google.com/kubernetes-engine/
       rest_documentation: https://cloud.google.com/kubernetes-engine/docs/reference/rest
@@ -1302,23 +1200,21 @@ libraries:
           samples: false
     keep:
       - google-cloud-containeranalysis/src/main/java/com/google/cloud/devtools/containeranalysis/v1/GrafeasUtils.java
-      - google-cloud-containeranalysis/src/main/java/com/google/cloud/devtools/containeranalysis/v1/stub/Version.java
-      - google-cloud-containeranalysis/src/main/java/com/google/cloud/devtools/containeranalysis/v1beta1/stub/Version.java
       - google-cloud-containeranalysis/src/test/java/com/google/cloud/devtools/containeranalysis/v1/ITGrafeasInteropTest.java
     java:
       api_description_override: is a service that provides vulnerability scanning and metadata storage for software artifacts. The service performs vulnerability scans on built software artifacts, such as the images in Container Registry, then stores the resulting metadata and makes it available for consumption through an API. The metadata may come from several sources, including vulnerability scanning, other Cloud services, and third-party providers.
       codeowner_team: '@googleapis/aap-dpes'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559777
+      released_version: 2.93.0
       name_pretty_override: Cloud Container Analysis
       product_documentation_override: https://cloud.google.com/container-registry/docs/container-analysis
   - name: contentwarehouse
     version: 0.89.0-SNAPSHOT
     apis:
       - path: google/cloud/contentwarehouse/v1
-    keep:
-      - google-cloud-contentwarehouse/src/main/java/com/google/cloud/contentwarehouse/v1/stub/Version.java
     java:
       api_description_override: Document AI Warehouse is an integrated cloud-native GCP platform to store, search, organize, govern and analyze documents and their structured metadata.
+      released_version: 0.88.0
       name_pretty_override: Document AI Warehouse
       product_documentation_override: https://cloud.google.com/document-warehouse/docs/overview
   - name: data-fusion
@@ -1326,11 +1222,9 @@ libraries:
     apis:
       - path: google/cloud/datafusion/v1
       - path: google/cloud/datafusion/v1beta1
-    keep:
-      - google-cloud-data-fusion/src/main/java/com/google/cloud/datafusion/v1/stub/Version.java
-      - google-cloud-data-fusion/src/main/java/com/google/cloud/datafusion/v1beta1/stub/Version.java
     java:
       api_description_override: is a fully managed, cloud-native, enterprise data integration service for quickly building and managing data pipelines.
+      released_version: 1.92.0
       name_pretty_override: Cloud Data Fusion
       product_documentation_override: https://cloud.google.com/data-fusion/docs
       rest_documentation: https://cloud.google.com/data-fusion/docs/reference/rest
@@ -1338,12 +1232,11 @@ libraries:
     version: 0.14.0-SNAPSHOT
     apis:
       - path: google/cloud/databasecenter/v1beta
-    keep:
-      - google-cloud-databasecenter/src/main/java/com/google/cloud/databasecenter/v1beta/stub/Version.java
     java:
       api_id_override: databasecenter.googleapis.com
       api_description_override: Database Center provides an organization-wide, cross-product fleet health platform to eliminate the overhead, complexity, and risk associated with aggregating and summarizing health signals through custom dashboards. Through Database Center's fleet health dashboard and API, database platform teams that are responsible for reliability, compliance, security, cost, and administration of database fleets will now have a single pane of glass that pinpoints issues relevant to each team.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-databasecenter/latest/overview
+      released_version: 0.13.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Database Center API
       product_documentation_override: https://cloud.google.com/database-center/docs/overview
@@ -1359,22 +1252,19 @@ libraries:
           additional_protos:
             - path: google/iam/v1/iam_policy.proto
     keep:
-      - google-cloud-datacatalog/src/main/java/com/google/cloud/datacatalog/v1/stub/Version.java
-      - google-cloud-datacatalog/src/main/java/com/google/cloud/datacatalog/v1beta1/stub/Version.java
-      - google-cloud-datacatalog/src/test/java/com/google/cloud/datacatalog/v1beta1/it/ITSystemTest.java
       - proto-google-cloud-datacatalog-v1beta1/src/main/java/com/google/cloud/datacatalog/v1beta1/FieldName.java
     java:
       api_description_override: is a fully managed and highly scalable data discovery and metadata management service.
+      released_version: 1.98.0
       name_pretty_override: Data Catalog
       product_documentation_override: https://cloud.google.com/data-catalog
   - name: dataflow
     version: 0.97.0-SNAPSHOT
     apis:
       - path: google/dataflow/v1beta3
-    keep:
-      - google-cloud-dataflow/src/main/java/com/google/dataflow/v1beta3/stub/Version.java
     java:
       api_description_override: is a managed service for executing a wide variety of data processing patterns.
+      released_version: 0.96.0
       name_pretty_override: Dataflow
       product_documentation_override: https://cloud.google.com/dataflow/docs
       rest_documentation: https://cloud.google.com/dataflow/docs/reference/rest
@@ -1392,11 +1282,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-dataform/src/main/java/com/google/cloud/dataform/v1/stub/Version.java
-      - google-cloud-dataform/src/main/java/com/google/cloud/dataform/v1beta1/stub/Version.java
     java:
       api_description_override: Help analytics teams manage data inside BigQuery using SQL.
+      released_version: 0.91.0
       name_pretty_override: Cloud Dataform
       product_documentation_override: https://cloud.google.com/dataform/docs
   - name: datalabeling
@@ -1404,10 +1292,10 @@ libraries:
     apis:
       - path: google/cloud/datalabeling/v1beta1
     keep:
-      - google-cloud-datalabeling/src/main/java/com/google/cloud/datalabeling/v1beta1/stub/Version.java
       - google-cloud-datalabeling/src/test/java/com/google/cloud/datalabeling/it/ITSystemTest.java
     java:
       api_description_override: is a service that lets you work with human labelers to generate highly accurate labels for a collection of data that you can use to train your machine learning models.
+      released_version: 0.212.0
       name_pretty_override: Data Labeling
       product_documentation_override: https://cloud.google.com/ai-platform/data-labeling/docs/
       rest_documentation: https://cloud.google.com/ai-platform/data-labeling/docs/reference/rest
@@ -1417,25 +1305,22 @@ libraries:
     apis:
       - path: google/cloud/datacatalog/lineage/v1
       - path: google/cloud/datacatalog/lineage/configmanagement/v1
-    keep:
-      - google-cloud-datalineage/src/main/java/com/google/cloud/datacatalog/lineage/configmanagement/v1/stub/Version.java
-      - google-cloud-datalineage/src/main/java/com/google/cloud/datacatalog/lineage/v1/stub/Version.java
     java:
       api_description_override: Lineage is used to track data flows between assets over time.
+      released_version: 0.84.0
       name_pretty_override: Data Lineage
       product_documentation_override: https://cloud.google.com/dataplex/docs/about-data-lineage
   - name: datamanager
     version: 0.14.0-SNAPSHOT
     apis:
       - path: google/ads/datamanager/v1
-    keep:
-      - data-manager/src/main/java/com/google/ads/datamanager/v1/stub/Version.java
     java:
       api_id_override: datamanager.googleapis.com
       api_description_override: A unified ingestion API for data partners, agencies and advertisers to connect first-party data across Google advertising products.
       artifact_id: data-manager
       client_documentation_override: https://cloud.google.com/java/docs/reference/data-manager/latest/overview
       group_id: com.google.api-ads
+      released_version: 0.13.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Data Manager API
       product_documentation_override: https://developers.google.com/data-manager
@@ -1448,10 +1333,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-dataplex/src/main/java/com/google/cloud/dataplex/v1/stub/Version.java
     java:
       api_description_override: provides intelligent data fabric that enables organizations to centrally manage, monitor, and govern their data across data lakes, data warehouses, and data marts with consistent controls, providing access to trusted data and powering analytics at scale.
+      released_version: 1.90.0
       name_pretty_override: Cloud Dataplex
       product_documentation_override: https://cloud.google.com/dataplex
       rest_documentation: https://cloud.google.com/dataplex/docs/reference/rest
@@ -1463,12 +1347,11 @@ libraries:
         java:
           additional_protos:
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-dataproc/src/main/java/com/google/cloud/dataproc/v1/stub/Version.java
     java:
       api_description_override: is a faster, easier, more cost-effective way to run Apache Spark and Apache Hadoop.
       codeowner_team: '@googleapis/api-dataproc'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559745
+      released_version: 4.89.0
       name_pretty_override: Dataproc
       product_documentation_override: https://cloud.google.com/dataproc
       rest_documentation: https://cloud.google.com/dataproc/docs/reference/rest
@@ -1491,12 +1374,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-dataproc-metastore/src/main/java/com/google/cloud/metastore/v1/stub/Version.java
-      - google-cloud-dataproc-metastore/src/main/java/com/google/cloud/metastore/v1alpha/stub/Version.java
-      - google-cloud-dataproc-metastore/src/main/java/com/google/cloud/metastore/v1beta/stub/Version.java
     java:
       api_description_override: is a fully managed, highly available, autoscaled, autohealing, OSS-native metastore service that greatly simplifies technical metadata management. Dataproc Metastore service is based on Apache Hive metastore and serves as a critical component towards enterprise data lakes.
+      released_version: 2.93.0
       name_pretty_override: Dataproc Metastore
       product_documentation_override: https://cloud.google.com/dataproc-metastore/docs
       rest_documentation: https://cloud.google.com/dataproc-metastore/docs/reference/rest
@@ -1512,9 +1392,6 @@ libraries:
           grpc_artifact_id_override: grpc-google-cloud-datastore-admin-v1
           proto_artifact_id_override: proto-google-cloud-datastore-admin-v1
           samples: false
-    keep:
-      - google-cloud-datastore/src/main/java/com/google/cloud/datastore/admin/v1/stub/Version.java
-      - google-cloud-datastore/src/main/java/com/google/cloud/datastore/v1/stub/Version.java
     java:
       api_id_override: datastore.googleapis.com
       api_description_override: is a fully managed, schemaless database for\nstoring non-relational data. Cloud Datastore automatically scales with\nyour users and supports ACID transactions, high availability of reads and\nwrites, strong consistency for reads and ancestor queries, and eventual\nconsistency for all other queries.
@@ -1524,6 +1401,7 @@ libraries:
         - grpc-google-cloud-datastore-v1
       extra_versioned_modules: datastore-v1-proto-client
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559768
+      released_version: 3.0.0
       library_type_override: GAPIC_COMBO
       name_pretty_override: Cloud Datastore
       product_documentation_override: https://cloud.google.com/datastore
@@ -1537,11 +1415,9 @@ libraries:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
       - path: google/cloud/datastream/v1alpha1
-    keep:
-      - google-cloud-datastream/src/main/java/com/google/cloud/datastream/v1/stub/Version.java
-      - google-cloud-datastream/src/main/java/com/google/cloud/datastream/v1alpha1/stub/Version.java
     java:
       api_description_override: is a serverless and easy-to-use change data capture (CDC) and replication service. It allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.
+      released_version: 1.91.0
       name_pretty_override: Datastream
       product_documentation_override: https://cloud.google.com/datastream/docs
       rest_documentation: https://cloud.google.com/datastream/docs/reference/rest
@@ -1553,11 +1429,10 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-deploy/src/main/java/com/google/cloud/deploy/v1/stub/Version.java
     java:
       api_description_override: is a service that automates delivery of your applications to a series of target environments in a defined sequence
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 1.90.0
       name_pretty_override: Google Cloud Deploy
       product_documentation_override: https://cloud.google.com/deploy/docs
   - name: developerconnect
@@ -1567,12 +1442,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-developerconnect/src/main/java/com/google/cloud/developerconnect/v1/stub/Version.java
     java:
       api_id_override: developerconnect.googleapis.com
       api_description_override: Connect third-party source code management to Google
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-developerconnect/latest/overview
+      released_version: 0.49.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Developer Connect API
       product_documentation_override: https://cloud.google.com/developer-connect/docs/overview
@@ -1585,6 +1459,7 @@ libraries:
       api_description_override: The Developer Knowledge API provides access to Google's developer knowledge
       artifact_id: google-cloud-developer-knowledge
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-developer-knowledge/latest/overview
+      released_version: 0.0.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Developer Knowledge API
       product_documentation_override: https://developers.google.com/knowledge
@@ -1592,12 +1467,11 @@ libraries:
     version: 0.33.0-SNAPSHOT
     apis:
       - path: google/cloud/devicestreaming/v1
-    keep:
-      - google-cloud-devicestreaming/src/main/java/com/google/cloud/devicestreaming/v1/stub/Version.java
     java:
       api_id_override: devicestreaming.googleapis.com
       api_description_override: The Cloud API for device streaming usage.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-devicestreaming/latest/overview
+      released_version: 0.32.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Device Streaming API
       product_documentation_override: https://cloud.google.com/device-streaming/docs
@@ -1613,10 +1487,7 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
     keep:
-      - google-cloud-dialogflow/src/main/java/com/google/cloud/dialogflow/v2/stub/Version.java
-      - google-cloud-dialogflow/src/main/java/com/google/cloud/dialogflow/v2beta1/stub/Version.java
       - google-cloud-dialogflow/src/test/java/com/google/cloud/dialogflow/v2/ContextManagementSmokeTest.java
-      - google-cloud-dialogflow/src/test/java/com/google/cloud/dialogflow/v2/it/ITSystemTest.java
       - proto-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/ConversationModelName.java
       - proto-google-cloud-dialogflow-v2/src/main/java/com/google/cloud/dialogflow/v2/ProjectAgentName.java
       - proto-google-cloud-dialogflow-v2beta1/src/main/java/com/google/cloud/dialogflow/v2beta1/ConversationModelName.java
@@ -1627,6 +1498,7 @@ libraries:
     java:
       api_description_override: is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices. You can use it to build interfaces (such as chatbots and conversational IVR) that enable natural and rich interactions between your users and your business. Dialogflow Enterprise Edition users have access to Google Cloud Support and a service level agreement (SLA) for production deployments.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5300385
+      released_version: 4.98.0
       name_pretty_override: Dialogflow API
       product_documentation_override: https://cloud.google.com/dialogflow-enterprise/
   - name: dialogflow-cx
@@ -1640,13 +1512,10 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-dialogflow-cx/src/main/java/com/google/cloud/dialogflow/cx/v3/stub/Version.java
-      - google-cloud-dialogflow-cx/src/main/java/com/google/cloud/dialogflow/cx/v3beta1/stub/Version.java
-      - google-cloud-dialogflow-cx/src/test/java/com/google/cloud/dialogflow/cx/v3beta1/it/ITSystemTest.java
     java:
       api_description_override: provides a new way of designing agents, taking a state machine approach to agent design. This gives you clear and explicit control over a conversation, a better end-user experience, and a better development workflow.
       api_shortname_override: dialogflow-cx
+      released_version: 0.103.0
       name_pretty_override: Dialogflow CX
       product_documentation_override: https://cloud.google.com/dialogflow/cx/docs
       rest_documentation: https://cloud.google.com/dialogflow/cx/docs/reference/rest
@@ -1666,12 +1535,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-discoveryengine/src/main/java/com/google/cloud/discoveryengine/v1/stub/Version.java
-      - google-cloud-discoveryengine/src/main/java/com/google/cloud/discoveryengine/v1alpha/stub/Version.java
-      - google-cloud-discoveryengine/src/main/java/com/google/cloud/discoveryengine/v1beta/stub/Version.java
     java:
       api_description_override: A Cloud API that offers search and recommendation discoverability for documents from different industry verticals (e.g. media, retail, etc.).
+      released_version: 0.88.0
       name_pretty_override: Discovery Engine API
       product_documentation_override: https://cloud.google.com/discovery-engine/media/docs
   - name: distributedcloudedge
@@ -1681,12 +1547,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-distributedcloudedge/src/main/java/com/google/cloud/edgecontainer/v1/stub/Version.java
     java:
       api_id_override: edgecontainer.googleapis.com
       api_description_override: Google Distributed Cloud Edge allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.
       api_shortname_override: distributedcloudedge
+      released_version: 0.89.0
       name_pretty_override: Google Distributed Cloud Edge
       product_documentation_override: https://cloud.google.com/distributed-cloud/edge/latest/
   - name: dlp
@@ -1694,7 +1559,6 @@ libraries:
     apis:
       - path: google/privacy/dlp/v2
     keep:
-      - google-cloud-dlp/src/main/java/com/google/cloud/dlp/v2/stub/Version.java
       - proto-google-cloud-dlp-v2/src/main/java/com/google/privacy/dlp/v2/DeidentifyTemplateNames.java
       - proto-google-cloud-dlp-v2/src/main/java/com/google/privacy/dlp/v2/InspectFindingName.java
       - proto-google-cloud-dlp-v2/src/main/java/com/google/privacy/dlp/v2/InspectTemplateNames.java
@@ -1712,6 +1576,7 @@ libraries:
     java:
       api_description_override: provides programmatic access to a powerful detection engine for personally identifiable information and other privacy-sensitive data in unstructured data streams, like text blocks and images.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5548083
+      released_version: 3.96.0
       name_pretty_override: Cloud Data Loss Prevention
       product_documentation_override: https://cloud.google.com/dlp/docs/
       rest_documentation: https://cloud.google.com/dlp/docs/reference/rest
@@ -1720,11 +1585,10 @@ libraries:
     version: 2.92.0-SNAPSHOT
     apis:
       - path: google/cloud/clouddms/v1
-    keep:
-      - google-cloud-dms/src/main/java/com/google/cloud/clouddms/v1/stub/Version.java
     java:
       api_id_override: datamigration.googleapis.com
       api_description_override: makes it easier for you to migrate your data to Google Cloud. This service helps you lift and shift your MySQL and PostgreSQL workloads into Cloud SQL.
+      released_version: 2.91.0
       name_pretty_override: Database Migration Service
       product_documentation_override: https://cloud.google.com/database-migration/docs
       rest_documentation: https://cloud.google.com/database-migration/docs/reference/rest
@@ -1739,12 +1603,10 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-document-ai/src/main/java/com/google/cloud/documentai/v1/stub/Version.java
-      - google-cloud-document-ai/src/main/java/com/google/cloud/documentai/v1beta3/stub/Version.java
     java:
       api_description_override: allows developers to unlock insights from your documents with machine learning.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559755
+      released_version: 2.96.0
       name_pretty_override: Document AI
       product_documentation_override: https://cloud.google.com/compute/docs/documentai/
   - name: domains
@@ -1753,12 +1615,9 @@ libraries:
       - path: google/cloud/domains/v1
       - path: google/cloud/domains/v1beta1
       - path: google/cloud/domains/v1alpha2
-    keep:
-      - google-cloud-domains/src/main/java/com/google/cloud/domains/v1/stub/Version.java
-      - google-cloud-domains/src/main/java/com/google/cloud/domains/v1alpha2/stub/Version.java
-      - google-cloud-domains/src/main/java/com/google/cloud/domains/v1beta1/stub/Version.java
     java:
       api_description_override: allows you to register and manage domains by using Cloud Domains.
+      released_version: 1.89.0
       name_pretty_override: Cloud Domains
       product_documentation_override: https://cloud.google.com/domains
   - name: edgenetwork
@@ -1768,20 +1627,18 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-edgenetwork/src/main/java/com/google/cloud/edgenetwork/v1/stub/Version.java
     java:
       api_description_override: Network management API for Distributed Cloud Edge.
+      released_version: 0.60.0
       name_pretty_override: Distributed Cloud Edge Network API
       product_documentation_override: https://cloud.google.com/distributed-cloud/edge/latest/docs/overview
   - name: enterpriseknowledgegraph
     version: 0.89.0-SNAPSHOT
     apis:
       - path: google/cloud/enterpriseknowledgegraph/v1
-    keep:
-      - google-cloud-enterpriseknowledgegraph/src/main/java/com/google/cloud/enterpriseknowledgegraph/v1/stub/Version.java
     java:
       api_description_override: Enterprise Knowledge Graph organizes siloed information into organizational knowledge, which involves consolidating, standardizing, and reconciling data in an efficient and useful way.
+      released_version: 0.88.0
       name_pretty_override: Enterprise Knowledge Graph
       product_documentation_override: https://cloud.google.com/enterprise-knowledge-graph/docs/overview
   - name: errorreporting
@@ -1792,12 +1649,12 @@ libraries:
           grpc_artifact_id_override: grpc-google-cloud-error-reporting-v1beta1
           proto_artifact_id_override: proto-google-cloud-error-reporting-v1beta1
     keep:
-      - google-cloud-errorreporting/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/stub/Version.java
       - google-cloud-errorreporting/src/test/java/com/google/devtools/clouderrorreporting/v1beta1/ITSystemTest.java
       - proto-google-cloud-error-reporting-v1beta1/src/main/java/com/google/devtools/clouderrorreporting/v1beta1/GroupName.java
     java:
       api_description_override: 'counts, analyzes, and aggregates the crashes in your running cloud services. A centralized error management interface displays the results with sorting and filtering capabilities. A dedicated view shows the error details: time chart, occurrences, affected user count, first- and last-seen dates and a cleaned exception stack trace. Opt in to receive email and mobile alerts on new errors.'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559780
+      released_version: 0.213.0-beta
       name_pretty_override: Error Reporting
       product_documentation_override: https://cloud.google.com/error-reporting
       billing_not_required: true
@@ -1805,10 +1662,9 @@ libraries:
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/cloud/essentialcontacts/v1
-    keep:
-      - google-cloud-essential-contacts/src/main/java/com/google/cloud/essentialcontacts/v1/stub/Version.java
     java:
       api_description_override: helps you customize who receives notifications by providing your own list of contacts in many Google Cloud services.
+      released_version: 2.92.0
       name_pretty_override: Essential Contacts API
       product_documentation_override: https://cloud.google.com/resource-manager/docs/managing-notification-contacts/
   - name: eventarc
@@ -1819,11 +1675,10 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-eventarc/src/main/java/com/google/cloud/eventarc/v1/stub/Version.java
     java:
       api_description_override: lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes. Eventarc requires no infrastructure management, you can optimize productivity and costs while building a modern, event-driven solution.
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 1.92.0
       name_pretty_override: Eventarc
       product_documentation_override: https://cloud.google.com/eventarc/docs
       rest_documentation: https://cloud.google.com/eventarc/docs/reference/rest
@@ -1832,11 +1687,10 @@ libraries:
     version: 0.93.0-SNAPSHOT
     apis:
       - path: google/cloud/eventarc/publishing/v1
-    keep:
-      - google-cloud-eventarc-publishing/src/main/java/com/google/cloud/eventarc/publishing/v1/stub/Version.java
     java:
       api_id_override: eventarc-publishing.googleapis.com
       api_description_override: lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes.
+      released_version: 0.92.0
       name_pretty_override: Eventarc Publishing
       product_documentation_override: https://cloud.google.com/eventarc/docs
       rest_documentation: https://cloud.google.com/eventarc/docs/reference/rest
@@ -1854,11 +1708,9 @@ libraries:
           additional_protos:
             - path: google/cloud/common/operation_metadata.proto
               generate_proto_classes: true
-    keep:
-      - google-cloud-filestore/src/main/java/com/google/cloud/filestore/v1/stub/Version.java
-      - google-cloud-filestore/src/main/java/com/google/cloud/filestore/v1beta1/stub/Version.java
     java:
       api_description_override: instances are fully managed NFS file servers on Google Cloud for use with applications running on Compute Engine virtual machines (VMs) instances or Google Kubernetes Engine clusters.
+      released_version: 1.93.0
       name_pretty_override: Cloud Filestore API
       product_documentation_override: https://cloud.google.com/filestore/docs
       rest_documentation: https://cloud.google.com/filestore/docs/reference/rest
@@ -1869,12 +1721,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-financialservices/src/main/java/com/google/cloud/financialservices/v1/stub/Version.java
     java:
       api_id_override: financialservices.googleapis.com
       api_description_override: Google Cloud's Anti Money Laundering AI (AML AI) product is an API that scores AML risk. Use it to identify more risk, more defensibly, with fewer false positives and reduced time per review.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-financialservices/latest/overview
+      released_version: 0.33.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Financial Services API
       product_documentation_override: https://cloud.google.com/financial-services/anti-money-laundering/docs/concepts/overview
@@ -1902,8 +1753,6 @@ libraries:
           generate_resource_names: false
           samples: false
     keep:
-      - google-cloud-firestore-admin/src/main/java/com/google/cloud/firestore/v1/stub/Version.java
-      - google-cloud-firestore/src/main/java/com/google/cloud/firestore/v1/stub/Version.java
       - google-cloud-firestore/src/main/resources/META-INF/native-image/com.google.cloud/google-cloud-firestore/reflect-config.json
       - google-cloud-firestore/src/test/resources/META-INF/native-image/reflect-config.json
       - proto-google-cloud-firestore-admin-v1/src/main/java/com/google/firestore/admin/v1/ParentName.java
@@ -1922,6 +1771,7 @@ libraries:
         - google-cloud-firestore
         - google-cloud-firestore-bom
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5337669
+      released_version: 3.42.0
       library_type_override: GAPIC_COMBO
       name_pretty_override: Cloud Firestore
       product_documentation_override: https://cloud.google.com/firestore
@@ -1951,14 +1801,10 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-functions/src/main/java/com/google/cloud/functions/v1/stub/Version.java
-      - google-cloud-functions/src/main/java/com/google/cloud/functions/v2/stub/Version.java
-      - google-cloud-functions/src/main/java/com/google/cloud/functions/v2alpha/stub/Version.java
-      - google-cloud-functions/src/main/java/com/google/cloud/functions/v2beta/stub/Version.java
     java:
       api_description_override: is a scalable pay as you go Functions-as-a-Service (FaaS) to run your code with zero server management.
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 2.94.0
       name_pretty_override: Cloud Functions
       product_documentation_override: https://cloud.google.com/functions
       rest_documentation: https://cloud.google.com/functions/docs/reference/rest
@@ -1970,12 +1816,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-gdchardwaremanagement/src/main/java/com/google/cloud/gdchardwaremanagement/v1alpha/stub/Version.java
     java:
       api_id_override: gdchardwaremanagement.googleapis.com
       api_description_override: Google Distributed Cloud connected allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-gdchardwaremanagement/latest/overview
+      released_version: 0.47.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: GDC Hardware Management API
       product_documentation_override: https://cloud.google.com/distributed-cloud/edge/latest/docs
@@ -1987,12 +1832,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-geminidataanalytics/src/main/java/com/google/cloud/geminidataanalytics/v1beta/stub/Version.java
     java:
       api_id_override: geminidataanalytics.googleapis.com
       api_description_override: Use Conversational Analytics API to build an artificial intelligence (AI)-powered chat interface, or data agent, that answers questions about structured data using natural language.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-geminidataanalytics/latest/overview
+      released_version: 0.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Data Analytics API with Gemini
       product_documentation_override: https://cloud.google.com/gemini/docs/conversational-analytics-api/overview
@@ -2005,34 +1849,31 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-gke-backup/src/main/java/com/google/cloud/gkebackup/v1/stub/Version.java
     java:
       api_id_override: gkebackup.googleapis.com
       api_description_override: is a service for backing up and restoring workloads in GKE.
       api_shortname_override: gke-backup
+      released_version: 0.91.0
       name_pretty_override: Backup for GKE
       product_documentation_override: 'https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke '
   - name: gke-connect-gateway
     version: 0.94.0-SNAPSHOT
     apis:
       - path: google/cloud/gkeconnect/gateway/v1beta1
-    keep:
-      - google-cloud-gke-connect-gateway/src/main/java/com/google/cloud/gkeconnect/gateway/v1beta1/stub/Version.java
     java:
       api_description_override: builds on the power of fleets to let Anthos users connect to and run commands against registered Anthos clusters in a simple, consistent, and secured way, whether the clusters are on Google Cloud, other public clouds, or on premises, and makes it easier to automate DevOps processes across all your clusters.
+      released_version: 0.93.0
       name_pretty_override: Connect Gateway API
       product_documentation_override: https://cloud.google.com/anthos/multicluster-management/gateway/
   - name: gke-multi-cloud
     version: 0.92.0-SNAPSHOT
     apis:
       - path: google/cloud/gkemulticloud/v1
-    keep:
-      - google-cloud-gke-multi-cloud/src/main/java/com/google/cloud/gkemulticloud/v1/stub/Version.java
     java:
       api_id_override: gkemulticloud.googleapis.com
       api_description_override: enables you to provision and manage GKE clusters running on AWS and Azure infrastructure through a centralized Google Cloud backed control plane.
       api_shortname_override: gke-multi-cloud
+      released_version: 0.91.0
       name_pretty_override: Anthos Multicloud
       product_documentation_override: https://cloud.google.com/anthos/clusters/docs/multi-cloud
   - name: gkehub
@@ -2062,31 +1903,28 @@ libraries:
       - path: google/cloud/gkehub/v1alpha
         java:
           samples: false
-    keep:
-      - google-cloud-gkehub/src/main/java/com/google/cloud/gkehub/v1/stub/Version.java
-      - google-cloud-gkehub/src/main/java/com/google/cloud/gkehub/v1alpha/stub/Version.java
-      - google-cloud-gkehub/src/main/java/com/google/cloud/gkehub/v1beta/stub/Version.java
-      - google-cloud-gkehub/src/main/java/com/google/cloud/gkehub/v1beta1/stub/Version.java
     java:
       api_description_override: provides a unified way to work with Kubernetes clusters as part of Anthos, extending GKE to work in multiple environments. You have consistent, unified, and secure infrastructure, cluster, and container management, whether you're using Anthos on Google Cloud (with traditional GKE), hybrid cloud, or multiple public clouds.
+      released_version: 1.92.0
       name_pretty_override: GKE Hub API
       product_documentation_override: https://cloud.google.com/anthos/gke/docs/
   - name: gkerecommender
     version: 0.13.0-SNAPSHOT
     apis:
       - path: google/cloud/gkerecommender/v1
-    keep:
-      - google-cloud-gkerecommender/src/main/java/com/google/cloud/gkerecommender/v1/stub/Version.java
     java:
       api_id_override: gkerecommender.googleapis.com
       api_description_override: lets you analyze the performance and cost-efficiency of your inference workloads, and make data-driven decisions about resource allocation and model deployment strategies.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-gkerecommender/latest/overview
+      released_version: 0.12.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: GKE Recommender API
       product_documentation_override: https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
   - name: google-cloud-java
     version: 1.87.0-SNAPSHOT
     skip_generate: true
+    java:
+      released_version: 1.86.2
   - name: grafeas
     version: 2.94.0-SNAPSHOT
     apis:
@@ -2102,6 +1940,7 @@ libraries:
       client_documentation_override: https://cloud.google.com/java/docs/reference/grafeas/latest/overview
       codeowner_team: '@googleapis/aap-dpes'
       group_id: io.grafeas
+      released_version: 2.93.0
       name_pretty_override: Grafeas
       product_documentation_override: https://grafeas.io
       skip_pom_updates: true
@@ -2157,10 +1996,9 @@ libraries:
           generate_grpc: false
           generate_resource_names: false
           samples: false
-    keep:
-      - google-cloud-gsuite-addons/src/main/java/com/google/cloud/gsuiteaddons/v1/stub/Version.java
     java:
       api_description_override: are customized applications that integrate with Google Workspace productivity applications.
+      released_version: 2.92.0
       name_pretty_override: Google Workspace Add-ons API
       product_documentation_override: https://developers.google.com/workspace/add-ons/overview
   - name: health
@@ -2171,6 +2009,7 @@ libraries:
       api_id_override: health.googleapis.com
       api_description_override: The Google Health API lets you view and manage health and fitness metrics and measurement data.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-health/latest/overview
+      released_version: 0.1.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Google Health API
       product_documentation_override: https://developers.google.com/health/api
@@ -2186,13 +2025,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-hypercomputecluster/src/main/java/com/google/cloud/hypercomputecluster/v1/stub/Version.java
-      - google-cloud-hypercomputecluster/src/main/java/com/google/cloud/hypercomputecluster/v1beta/stub/Version.java
     java:
       api_id_override: hypercomputecluster.googleapis.com
       api_description_override: simplifies cluster management across compute, network, and storage
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-hypercomputecluster/latest/overview
+      released_version: 0.12.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Cluster Director API
       product_documentation_override: https://cloud.google.com/blog/products/compute/managed-slurm-and-other-cluster-director-enhancements
@@ -2245,6 +2082,7 @@ libraries:
         - google-iam-policy
         - proto-google-iam-v1
       group_id: com.google.api.grpc
+      released_version: 1.66.0
       library_type_override: OTHER
       name_pretty_override: IAM
       product_documentation_override: https://cloud.google.com/iam
@@ -2253,14 +2091,12 @@ libraries:
     version: 3.88.0-SNAPSHOT
     apis:
       - path: google/iam/admin/v1
-    keep:
-      - google-iam-admin/src/main/java/com/google/cloud/iam/admin/v1/stub/Version.java
-      - google-iam-admin/src/test/java/com/google/cloud/iam/admin/v1/it/ITSystemTest.java
     java:
       api_id_override: iam.googleapis.com
       api_description_override: you to manage your Service Accounts and IAM bindings.
       api_shortname_override: iam-admin
       artifact_id: google-iam-admin
+      released_version: 3.87.0
       name_pretty_override: IAM Admin API
       product_documentation_override: https://cloud.google.com/iam/docs/apis
   - name: iam-policy
@@ -2294,11 +2130,6 @@ libraries:
           generate_grpc: false
           generate_resource_names: false
           samples: false
-    keep:
-      - google-iam-policy/src/main/java/com/google/iam/v2/stub/Version.java
-      - google-iam-policy/src/main/java/com/google/iam/v2beta/stub/Version.java
-      - google-iam-policy/src/main/java/com/google/iam/v3/stub/Version.java
-      - google-iam-policy/src/main/java/com/google/iam/v3beta/stub/Version.java
     java:
       api_id_override: iam.googleapis.com
       api_description_override: n/a
@@ -2310,17 +2141,17 @@ libraries:
         - proto-google-iam-v1-bom
         - google-iam-policy
         - proto-google-iam-v1
+      released_version: 1.89.0
       name_pretty_override: IAM
       product_documentation_override: n/a
   - name: iamcredentials
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/iam/credentials/v1
-    keep:
-      - google-cloud-iamcredentials/src/main/java/com/google/cloud/iam/credentials/v1/stub/Version.java
     java:
       api_description_override: creates short-lived, limited-privilege credentials for IAM service accounts.
       issue_tracker_override: https://issuetracker.google.com/issues/new?component=187161
+      released_version: 2.92.0
       name_pretty_override: IAM Service Account Credentials API
       product_documentation_override: https://cloud.google.com/iam/credentials/reference/rest/
       billing_not_required: true
@@ -2328,12 +2159,11 @@ libraries:
     version: 0.49.0-SNAPSHOT
     apis:
       - path: google/cloud/iap/v1
-    keep:
-      - google-cloud-iap/src/main/java/com/google/cloud/iap/v1/stub/Version.java
     java:
       api_id_override: iap.googleapis.com
       api_description_override: Controls access to cloud applications running on Google Cloud Platform.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-iap/latest/overview
+      released_version: 0.48.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Cloud Identity-Aware Proxy API
       product_documentation_override: https://cloud.google.com/iap
@@ -2341,10 +2171,9 @@ libraries:
     version: 1.92.0-SNAPSHOT
     apis:
       - path: google/cloud/ids/v1
-    keep:
-      - google-cloud-ids/src/main/java/com/google/cloud/ids/v1/stub/Version.java
     java:
       api_description_override: ' monitors your networks, and it alerts you when it detects malicious activity. Cloud IDS is powered by Palo Alto Networks.'
+      released_version: 1.91.0
       name_pretty_override: Intrusion Detection System
       product_documentation_override: https://cloud.google.com/intrusion-detection-system/docs
   - name: infra-manager
@@ -2355,22 +2184,20 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-infra-manager/src/main/java/com/google/cloud/config/v1/stub/Version.java
     java:
       api_id_override: config.googleapis.com
       api_description_override: Creates and manages Google Cloud Platform resources and infrastructure.
+      released_version: 0.69.0
       name_pretty_override: Infrastructure Manager API
       product_documentation_override: https://cloud.google.com/infrastructure-manager/docs/overview
   - name: iot
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/cloud/iot/v1
-    keep:
-      - google-cloud-iot/src/main/java/com/google/cloud/iot/v1/stub/Version.java
     java:
       api_description_override: is a complete set of tools to connect, process, store, and analyze data both at the edge and in the cloud. The platform consists of scalable, fully-managed cloud services; an integrated software stack for edge/on-premises computing with machine learning capabilities for all your IoT needs.
       issue_tracker_override: https://issuetracker.google.com/issues?q=status:open%20componentid:310170
+      released_version: 2.92.0
       name_pretty_override: Cloud Internet of Things (IoT) Core
       product_documentation_override: https://cloud.google.com/iot
   - name: java-shopping-merchant-issue-resolution
@@ -2378,15 +2205,13 @@ libraries:
     apis:
       - path: google/shopping/merchant/issueresolution/v1
       - path: google/shopping/merchant/issueresolution/v1beta
-    keep:
-      - google-shopping-merchant-issue-resolution/src/main/java/com/google/shopping/merchant/issueresolution/v1/stub/Version.java
-      - google-shopping-merchant-issue-resolution/src/main/java/com/google/shopping/merchant/issueresolution/v1beta/stub/Version.java
     java:
       api_id_override: merchantapi.googleapis.com
       api_description_override: Programatically manage your Merchant Issues
       artifact_id: google-shopping-merchant-issue-resolution
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-issue-resolution/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant Issue Resolution API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -2395,15 +2220,13 @@ libraries:
     apis:
       - path: google/shopping/merchant/ordertracking/v1
       - path: google/shopping/merchant/ordertracking/v1beta
-    keep:
-      - google-shopping-merchant-order-tracking/src/main/java/com/google/shopping/merchant/ordertracking/v1/stub/Version.java
-      - google-shopping-merchant-order-tracking/src/main/java/com/google/shopping/merchant/ordertracking/v1beta/stub/Version.java
     java:
       api_id_override: merchantapi.googleapis.com
       api_description_override: Programmatically manage your Merchant Center Accounts
       artifact_id: google-shopping-merchant-order-tracking
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-order-tracking/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant Order Tracking API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -2416,7 +2239,6 @@ libraries:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
     keep:
-      - google-cloud-kms/src/main/java/com/google/cloud/kms/v1/stub/Version.java
       - google-cloud-kms/src/test/java/com/google/cloud/kms/it/ITKmsTest.java
       - proto-google-cloud-kms-v1/src/main/java/com/google/cloud/kms/v1/CryptoKeyPathName.java
       - proto-google-cloud-kms-v1/src/main/java/com/google/cloud/kms/v1/KeyName.java
@@ -2425,16 +2247,16 @@ libraries:
     java:
       api_description_override: a cloud-hosted key management service that lets you manage cryptographic keys for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256, RSA 2048, RSA 3072, RSA 4096, EC P256, and EC P384 cryptographic keys. Cloud KMS is integrated with Cloud IAM and Cloud Audit Logging so that you can manage permissions on individual keys and monitor how these are used. Use Cloud KMS to protect secrets and other sensitive data that you need to store in Google Cloud Platform.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5264932
+      released_version: 2.95.0
       name_pretty_override: Cloud Key Management Service
       product_documentation_override: https://cloud.google.com/kms
   - name: kmsinventory
     version: 0.82.0-SNAPSHOT
     apis:
       - path: google/cloud/kms/inventory/v1
-    keep:
-      - google-cloud-kmsinventory/src/main/java/com/google/cloud/kms/inventory/v1/stub/Version.java
     java:
       api_description_override: KMS Inventory API.
+      released_version: 0.81.0
       name_pretty_override: KMS Inventory API
       product_documentation_override: https://cloud.google.com/kms/docs/
       rest_documentation: https://cloud.google.com/kms/docs/reference/rest
@@ -2445,13 +2267,10 @@ libraries:
       - path: google/cloud/language/v2
       - path: google/cloud/language/v1
       - path: google/cloud/language/v1beta2
-    keep:
-      - google-cloud-language/src/main/java/com/google/cloud/language/v1/stub/Version.java
-      - google-cloud-language/src/main/java/com/google/cloud/language/v1beta2/stub/Version.java
-      - google-cloud-language/src/main/java/com/google/cloud/language/v2/stub/Version.java
     java:
       api_description_override: provides natural language understanding technologies to developers, including sentiment analysis, entity analysis, entity sentiment analysis, content classification, and syntax analysis. This API is part of the larger Cloud Machine Learning API family.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559753
+      released_version: 2.93.0
       name_pretty_override: Natural Language
       product_documentation_override: https://cloud.google.com/natural-language/docs/
       rest_documentation: https://cloud.google.com/natural-language/docs/reference/rest
@@ -2463,12 +2282,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-licensemanager/src/main/java/com/google/cloud/licensemanager/v1/stub/Version.java
     java:
       api_id_override: licensemanager.googleapis.com
       api_description_override: License Manager is a tool to manage and track third-party licenses on Google Cloud.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-licensemanager/latest/overview
+      released_version: 0.25.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: License Manager API
       product_documentation_override: https://cloud.google.com/compute/docs/instances/windows/ms-licensing
@@ -2479,10 +2297,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-life-sciences/src/main/java/com/google/cloud/lifesciences/v2beta/stub/Version.java
     java:
       api_description_override: is a suite of services and tools for managing, processing, and transforming life sciences data.
+      released_version: 0.94.0
       name_pretty_override: Cloud Life Sciences
       product_documentation_override: https://cloud.google.com/life-sciences/docs
       rest_documentation: https://cloud.google.com/life-sciences/docs/reference/rest
@@ -2491,12 +2308,11 @@ libraries:
     version: 0.18.0-SNAPSHOT
     apis:
       - path: google/cloud/locationfinder/v1
-    keep:
-      - google-cloud-locationfinder/src/main/java/com/google/cloud/locationfinder/v1/stub/Version.java
     java:
       api_id_override: locationfinder.googleapis.com
       api_description_override: Cloud Location Finder is a public API that offers a repository of all Google Cloud and Google Distributed Cloud locations, as well as cloud locations for other cloud providers.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-locationfinder/latest/overview
+      released_version: 0.17.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Cloud Location Finder API
       product_documentation_override: https://cloud.google.com/location-finder/docs/overview
@@ -2507,14 +2323,13 @@ libraries:
       - path: google/logging/v2
         java:
           samples: false
-    keep:
-      - google-cloud-logging/src/main/java/com/google/cloud/logging/v2/stub/Version.java
     java:
       api_id_override: logging.googleapis.com
       api_description_override: allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud and Amazon Web Services. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premises systems, and hybrid cloud systems. BindPlane is included with your Google Cloud project at no additional cost.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-logging/latest/history
       codeowner_team: '@googleapis/cloud-sdk-java-team'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559764
+      released_version: 3.33.0
       library_type_override: GAPIC_COMBO
       name_pretty_override: Cloud Logging
       product_documentation_override: https://cloud.google.com/logging/docs
@@ -2527,12 +2342,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-lustre/src/main/java/com/google/cloud/lustre/v1/stub/Version.java
     java:
       api_id_override: lustre.googleapis.com
       api_description_override: Google Cloud Managed Lustre delivers a high-performance, fully managed parallel file system optimized for AI and HPC applications.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-lustre/latest/overview
+      released_version: 0.32.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Google Cloud Managed Lustre API
       product_documentation_override: https://cloud.google.com/managed-lustre/docs
@@ -2547,13 +2361,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-maintenance/src/main/java/com/google/cloud/maintenance/api/v1/stub/Version.java
-      - google-cloud-maintenance/src/main/java/com/google/cloud/maintenance/api/v1beta/stub/Version.java
     java:
       api_id_override: maintenance.googleapis.com
       api_description_override: The Maintenance API provides a centralized view of planned disruptive maintenance events across supported Google Cloud products.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-maintenance/latest/overview
+      released_version: 0.26.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Maintenance API
       product_documentation_override: https://cloud.google.com/unified-maintenance/docs/overview
@@ -2562,11 +2374,10 @@ libraries:
     version: 1.91.0-SNAPSHOT
     apis:
       - path: google/cloud/managedidentities/v1
-    keep:
-      - google-cloud-managed-identities/src/main/java/com/google/cloud/managedidentities/v1/stub/Version.java
     java:
       api_id_override: managedidentities.googleapis.com
       api_description_override: is a highly available, hardened Google Cloud service running actual Microsoft AD that enables you to manage authentication and authorization for your AD-dependent workloads, automate AD server maintenance and security configuration, and connect your on-premises AD domain to the cloud.
+      released_version: 1.90.0
       name_pretty_override: Managed Service for Microsoft Active Directory
       product_documentation_override: https://cloud.google.com/managed-microsoft-ad/
   - name: managedkafka
@@ -2576,12 +2387,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-managedkafka/src/main/java/com/google/cloud/managedkafka/v1/stub/Version.java
     java:
       api_id_override: managedkafka.googleapis.com
       api_description_override: Manage Apache Kafka clusters and resources.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-managedkafka/latest/overview
+      released_version: 0.48.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Managed Service for Apache Kafka
       product_documentation_override: https://cloud.google.com/managed-kafka
@@ -2589,22 +2399,19 @@ libraries:
     version: 0.87.0-SNAPSHOT
     apis:
       - path: google/maps/addressvalidation/v1
-    keep:
-      - google-maps-addressvalidation/src/main/java/com/google/maps/addressvalidation/v1/stub/Version.java
     java:
       api_id_override: addressvalidation.googleapis.com
       api_description_override: The Address Validation API allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.
       api_shortname_override: maps-addressvalidation
       artifact_id: google-maps-addressvalidation
       group_id: com.google.maps
+      released_version: 0.86.0
       name_pretty_override: Address Validation API
       product_documentation_override: https://developers.google.com/maps/documentation/address-validation/
   - name: maps-area-insights
     version: 0.44.0-SNAPSHOT
     apis:
       - path: google/maps/areainsights/v1
-    keep:
-      - google-maps-area-insights/src/main/java/com/google/maps/areainsights/v1/stub/Version.java
     java:
       api_id_override: maps-area-insights.googleapis.com
       api_description_override: Places Insights API.
@@ -2612,6 +2419,7 @@ libraries:
       artifact_id: google-maps-area-insights
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-maps-area-insights/latest/overview
       group_id: com.google.maps
+      released_version: 0.43.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Places Insights API
       product_documentation_override: https://developers.google.com/maps/documentation/places-insights
@@ -2619,8 +2427,6 @@ libraries:
     version: 0.40.0-SNAPSHOT
     apis:
       - path: google/maps/fleetengine/v1
-    keep:
-      - google-maps-fleetengine/src/main/java/com/google/maps/fleetengine/v1/stub/Version.java
     java:
       api_id_override: maps-fleetengine.googleapis.com
       api_description_override: Enables Fleet Engine for access to the On Demand Rides and Deliveries and Last Mile Fleet Solution APIs.  Customer's use of Google Maps Content in the Cloud Logging Services is subject to the Google Maps Platform Terms of Service located at https://cloud.google.com/maps-platform/terms.
@@ -2628,6 +2434,7 @@ libraries:
       artifact_id: google-maps-fleetengine
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-maps-fleetengine/latest/overview
       group_id: com.google.maps
+      released_version: 0.39.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Local Rides and Deliveries API
       product_documentation_override: https://developers.google.com/maps/documentation/transportation-logistics/mobility
@@ -2635,8 +2442,6 @@ libraries:
     version: 0.40.0-SNAPSHOT
     apis:
       - path: google/maps/fleetengine/delivery/v1
-    keep:
-      - google-maps-fleetengine-delivery/src/main/java/com/google/maps/fleetengine/delivery/v1/stub/Version.java
     java:
       api_id_override: maps-fleetengine-delivery.googleapis.com
       api_description_override: Enables Fleet Engine for access to the On Demand Rides and Deliveries and Last Mile Fleet Solution APIs.  Customer's use of Google Maps Content in the Cloud Logging Services is subject to the Google Maps Platform Terms of Service located at https://cloud.google.com/maps-platform/terms.
@@ -2644,6 +2449,7 @@ libraries:
       artifact_id: google-maps-fleetengine-delivery
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-maps-fleetengine-delivery/latest/overview
       group_id: com.google.maps
+      released_version: 0.39.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Last Mile Fleet Solution Delivery API
       product_documentation_override: https://developers.google.com/maps/documentation/transportation-logistics/mobility
@@ -2651,14 +2457,13 @@ libraries:
     version: 0.5.0-SNAPSHOT
     apis:
       - path: google/maps/geocode/v4
-    keep:
-      - google-maps-geocode/src/main/java/com/google/maps/geocode/v4/stub/Version.java
     java:
       api_id_override: geocode.googleapis.com
       api_description_override: The Geocoding API is a service that accepts a place as an address, latitude and longitude coordinates, or Place ID.
       artifact_id: google-maps-geocode
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-maps-geocode/latest/overview
       group_id: com.google.maps
+      released_version: 0.4.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Geocoding API
       product_documentation_override: https://developers.google.com/maps/documentation/geocoding/overview
@@ -2672,6 +2477,7 @@ libraries:
       artifact_id: google-maps-mapmanagement
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-maps-mapmanagement/latest/overview
       group_id: com.google.maps
+      released_version: 0.1.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Map Management API
       product_documentation_override: https://developers.google.com/maps/documentation/mapmanagement/overview
@@ -2679,8 +2485,6 @@ libraries:
     version: 0.82.0-SNAPSHOT
     apis:
       - path: google/maps/mapsplatformdatasets/v1
-    keep:
-      - google-maps-mapsplatformdatasets/src/main/java/com/google/maps/mapsplatformdatasets/v1/stub/Version.java
     java:
       api_id_override: mapsplatformdatasets.googleapis.com
       api_description_override: |-
@@ -2689,6 +2493,7 @@ libraries:
       api_shortname_override: maps-mapsplatformdatasets
       artifact_id: google-maps-mapsplatformdatasets
       group_id: com.google.maps
+      released_version: 0.81.0
       name_pretty_override: Maps Platform Datasets API
       product_documentation_override: https://developers.google.com/maps/documentation
   - name: maps-places
@@ -2697,28 +2502,26 @@ libraries:
       - path: google/maps/places/v1
         java:
           samples: false
-    keep:
-      - google-maps-places/src/main/java/com/google/maps/places/v1/stub/Version.java
     java:
       api_id_override: places.googleapis.com
       api_description_override: The Places API allows developers to access a variety of search and retrieval endpoints for a Place.
       api_shortname_override: maps-places
       artifact_id: google-maps-places
       group_id: com.google.maps
+      released_version: 0.63.0
       name_pretty_override: Places API (New)
       product_documentation_override: https://developers.google.com/maps/documentation/places/web-service/
   - name: maps-routeoptimization
     version: 0.51.0-SNAPSHOT
     apis:
       - path: google/maps/routeoptimization/v1
-    keep:
-      - google-maps-routeoptimization/src/main/java/com/google/maps/routeoptimization/v1/stub/Version.java
     java:
       api_id_override: routeoptimization.googleapis.com
       api_description_override: The Route Optimization API assigns tasks and routes to a vehicle fleet, optimizing against the objectives and constraints that you supply for your transportation goals.
       artifact_id: google-maps-routeoptimization
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-maps-routeoptimization/latest/overview
       group_id: com.google.maps
+      released_version: 0.50.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Route Optimization API
       product_documentation_override: https://developers.google.com/maps/documentation/route-optimization
@@ -2728,22 +2531,19 @@ libraries:
     version: 1.78.0-SNAPSHOT
     apis:
       - path: google/maps/routing/v2
-    keep:
-      - google-maps-routing/src/main/java/com/google/maps/routing/v2/stub/Version.java
     java:
       api_id_override: routes.googleapis.com
       api_description_override: Routes API is the next generation, performance optimized version of the existing Directions API and Distance Matrix API. It helps you find the ideal route from A to Z, calculates ETAs and distances for matrices of origin and destination locations, and also offers new features.
       api_shortname_override: maps-routing
       artifact_id: google-maps-routing
       group_id: com.google.maps
+      released_version: 1.77.0
       name_pretty_override: Routes API
       product_documentation_override: https://developers.google.com/maps/documentation/routes
   - name: maps-solar
     version: 0.52.0-SNAPSHOT
     apis:
       - path: google/maps/solar/v1
-    keep:
-      - google-maps-solar/src/main/java/com/google/maps/solar/v1/stub/Version.java
     java:
       api_id_override: maps-solar.googleapis.com
       api_description_override: The Solar API allows users to read details about the solar potential of over 60 million buildings. This includes measurements of the building's roof (e.g., size and tilt/azimuth), energy production for a range of sizes of solar installations, and financial costs and benefits.
@@ -2751,6 +2551,7 @@ libraries:
       artifact_id: google-maps-solar
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-maps-solar/latest/overview
       group_id: com.google.maps
+      released_version: 0.51.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Solar API
       product_documentation_override: https://developers.google.com/maps/documentation/solar/overview
@@ -2761,14 +2562,13 @@ libraries:
       - path: google/marketingplatform/admin/v1alpha
         java:
           omit_common_resources: true
-    keep:
-      - admin/src/main/java/com/google/ads/marketingplatform/admin/v1alpha/stub/Version.java
     java:
       api_id_override: marketingplatformadminapi.googleapis.com
       api_description_override: The Google Marketing Platform Admin API allows for programmatic access to the Google Marketing Platform configuration data. You can use the Google Marketing Platform Admin API to manage links between your Google Marketing Platform organization and Google Analytics accounts, and to set the service level of your GA4 properties.
       artifact_id: admin
       client_documentation_override: https://cloud.google.com/java/docs/reference/admin/latest/overview
       group_id: com.google.ads-marketingplatform
+      released_version: 0.41.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Google Marketing Platform Admin API
       product_documentation_override: https://developers.google.com/analytics/devguides/config/gmp/v1
@@ -2776,10 +2576,9 @@ libraries:
     version: 0.99.0-SNAPSHOT
     apis:
       - path: google/cloud/mediatranslation/v1beta1
-    keep:
-      - google-cloud-mediatranslation/src/main/java/com/google/cloud/mediatranslation/v1beta1/stub/Version.java
     java:
       api_description_override: provides enterprise quality translation from/to various media types.
+      released_version: 0.98.0
       name_pretty_override: Media Translation API
       product_documentation_override: https://cloud.google.com/
       billing_not_required: true
@@ -2788,11 +2587,9 @@ libraries:
     apis:
       - path: google/apps/meet/v2
       - path: google/apps/meet/v2beta
-    keep:
-      - google-cloud-meet/src/main/java/com/google/apps/meet/v2/stub/Version.java
-      - google-cloud-meet/src/main/java/com/google/apps/meet/v2beta/stub/Version.java
     java:
       api_description_override: The Google Meet REST API lets you create and manage meetings for Google Meet and offers entry points to your users directly from your app
+      released_version: 0.59.0
       name_pretty_override: Google Meet API
       product_documentation_override: https://developers.google.com/meet/api/guides/overview
   - name: memcache
@@ -2806,11 +2603,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-memcache/src/main/java/com/google/cloud/memcache/v1/stub/Version.java
-      - google-cloud-memcache/src/main/java/com/google/cloud/memcache/v1beta2/stub/Version.java
     java:
       api_description_override: is a fully-managed in-memory data store service for Memcache.
+      released_version: 2.92.0
       name_pretty_override: Cloud Memcache
       product_documentation_override: https://cloud.google.com/memorystore/
       billing_not_required: true
@@ -2821,10 +2616,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-migrationcenter/src/main/java/com/google/cloud/migrationcenter/v1/stub/Version.java
     java:
       api_description_override: Google Cloud Migration Center is a unified platform that helps you accelerate your end-to-end cloud journey from your current on-premises or cloud environments to Google Cloud
+      released_version: 0.74.0
       name_pretty_override: Migration Center API
       product_documentation_override: https://cloud.google.com/migration-center/docs/migration-center-overview
   - name: modelarmor
@@ -2838,13 +2632,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-modelarmor/src/main/java/com/google/cloud/modelarmor/v1/stub/Version.java
-      - google-cloud-modelarmor/src/main/java/com/google/cloud/modelarmor/v1beta/stub/Version.java
     java:
       api_id_override: modelarmor.googleapis.com
       api_description_override: Model Armor helps you protect against risks like prompt injection, harmful content, and data leakage in generative AI applications by letting you define policies that filter user prompts and model responses.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-modelarmor/latest/overview
+      released_version: 0.33.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Model Armor API
       product_documentation_override: https://cloud.google.com/security-command-center/docs/model-armor-overview
@@ -2853,36 +2645,34 @@ libraries:
     apis:
       - path: google/monitoring/v3
     keep:
-      - google-cloud-monitoring/src/main/java/com/google/cloud/monitoring/v3/stub/Version.java
       - google-cloud-monitoring/src/test/java/com/google/cloud/monitoring/v3/ITVPCServiceControlTest.java
     java:
       api_description_override: collects metrics, events, and metadata from Google Cloud, Amazon Web Services (AWS), hosted uptime probes, and application instrumentation. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premise systems, and hybrid cloud systems. Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. BindPlane is included with your Google Cloud project at no additional cost.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559785
+      released_version: 3.93.0
       name_pretty_override: Stackdriver Monitoring
       product_documentation_override: https://cloud.google.com/monitoring/docs
   - name: monitoring-dashboards
     version: 2.95.0-SNAPSHOT
     apis:
       - path: google/monitoring/dashboard/v1
-    keep:
-      - google-cloud-monitoring-dashboard/src/main/java/com/google/cloud/monitoring/dashboard/v1/stub/Version.java
     java:
       api_id_override: monitoring.googleapis.com
       api_description_override: are one way for you to view and analyze metric data. The Cloud Console provides predefined dashboards that require no setup or configuration. You can also define custom dashboards. With custom dashboards, you have complete control over the charts that are displayed and their configuration.
       api_shortname_override: monitoring-dashboards
       artifact_id: google-cloud-monitoring-dashboard
+      released_version: 2.94.0
       name_pretty_override: Monitoring Dashboards
       product_documentation_override: https://cloud.google.com/monitoring/charts/dashboards
   - name: monitoring-metricsscope
     version: 0.87.0-SNAPSHOT
     apis:
       - path: google/monitoring/metricsscope/v1
-    keep:
-      - google-cloud-monitoring-metricsscope/src/main/java/com/google/monitoring/metricsscope/v1/stub/Version.java
     java:
       api_id_override: monitoring.googleapis.com
       api_description_override: The metrics scope defines the set of Google Cloud projects whose metrics the current Google Cloud project can access.
       api_shortname_override: monitoring-metricsscope
+      released_version: 0.86.0
       name_pretty_override: Monitoring Metrics Scopes
       product_documentation_override: https://cloud.google.com/monitoring/api/ref_v3/rest/v1/locations.global.metricsScopes
   - name: netapp
@@ -2892,10 +2682,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-netapp/src/main/java/com/google/cloud/netapp/v1/stub/Version.java
     java:
       api_description_override: Google Cloud NetApp Volumes is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.
+      released_version: 0.71.0
       name_pretty_override: NetApp API
       product_documentation_override: https://cloud.google.com/netapp/volumes/docs/discover/overview
   - name: network-management
@@ -2911,11 +2700,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-network-management/src/main/java/com/google/cloud/networkmanagement/v1/stub/Version.java
-      - google-cloud-network-management/src/main/java/com/google/cloud/networkmanagement/v1beta1/stub/Version.java
     java:
       api_description_override: provides a collection of network performance monitoring and diagnostic capabilities.
+      released_version: 1.93.0
       name_pretty_override: Network Management API
       product_documentation_override: https://cloud.google.com/network-intelligence-center/docs/connectivity-tests/reference/networkmanagement/rest/
   - name: network-security
@@ -2931,11 +2718,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-network-security/src/main/java/com/google/cloud/networksecurity/v1/stub/Version.java
-      - google-cloud-network-security/src/main/java/com/google/cloud/networksecurity/v1beta1/stub/Version.java
     java:
       api_description_override: n/a
+      released_version: 0.95.0
       name_pretty_override: Network Security API
       product_documentation_override: https://cloud.google.com/traffic-director/docs/reference/network-security/rest
   - name: networkconnectivity
@@ -2952,12 +2737,9 @@ libraries:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
       - path: google/cloud/networkconnectivity/v1alpha1
-    keep:
-      - google-cloud-networkconnectivity/src/main/java/com/google/cloud/networkconnectivity/v1/stub/Version.java
-      - google-cloud-networkconnectivity/src/main/java/com/google/cloud/networkconnectivity/v1alpha1/stub/Version.java
-      - google-cloud-networkconnectivity/src/main/java/com/google/cloud/networkconnectivity/v1beta/stub/Version.java
     java:
       api_description_override: Google's suite of products that provide enterprise connectivity from your on-premises network or from another cloud provider to your Virtual Private Cloud (VPC) network
+      released_version: 1.91.0
       name_pretty_override: Network Connectivity Center
       product_documentation_override: https://cloud.google.com/network-connectivity/docs
   - name: networkservices
@@ -2968,12 +2750,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-networkservices/src/main/java/com/google/cloud/networkservices/v1/stub/Version.java
     java:
       api_id_override: networkservices.googleapis.com
       api_description_override: Google Cloud offers a broad portfolio of networking services built on top of planet-scale infrastructure that leverages automation, advanced AI, and programmability, enabling enterprises to connect, scale, secure, modernize and optimize their infrastructure.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-networkservices/latest/overview
+      released_version: 0.48.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Network Services API
       product_documentation_override: https://cloud.google.com/products/networking
@@ -2995,22 +2776,18 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-notebooks/src/main/java/com/google/cloud/notebooks/v1/stub/Version.java
-      - google-cloud-notebooks/src/main/java/com/google/cloud/notebooks/v1beta1/stub/Version.java
-      - google-cloud-notebooks/src/main/java/com/google/cloud/notebooks/v2/stub/Version.java
     java:
       api_description_override: is a managed service that offers an integrated and secure JupyterLab environment for data scientists and machine learning developers to experiment, develop, and deploy models into production. Users can create instances running JupyterLab that come pre-installed with the latest data science and machine learning frameworks in a single click.
+      released_version: 1.90.0
       name_pretty_override: AI Platform Notebooks
       product_documentation_override: https://cloud.google.com/ai-platform-notebooks
   - name: optimization
     version: 1.91.0-SNAPSHOT
     apis:
       - path: google/cloud/optimization/v1
-    keep:
-      - google-cloud-optimization/src/main/java/com/google/cloud/optimization/v1/stub/Version.java
     java:
       api_description_override: is a managed routing service that takes your list of orders, vehicles, constraints, and objectives and returns the most efficient plan for your entire fleet in near real-time.
+      released_version: 1.90.0
       name_pretty_override: Cloud Fleet Routing
       product_documentation_override: https://cloud.google.com/optimization/docs
       rest_documentation: https://cloud.google.com/optimization/docs/reference/rest
@@ -3022,12 +2799,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-oracledatabase/src/main/java/com/google/cloud/oracledatabase/v1/stub/Version.java
     java:
       api_id_override: oracledatabase.googleapis.com
       api_description_override: The Oracle Database@Google Cloud API provides a set of APIs to manage   Oracle database services, such as Exadata and Autonomous Databases.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-oracledatabase/latest/overview
+      released_version: 0.41.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Oracle Database@Google Cloud API
       product_documentation_override: https://cloud.google.com/oracle/database/docs
@@ -3036,13 +2812,11 @@ libraries:
     apis:
       - path: google/cloud/orchestration/airflow/service/v1
       - path: google/cloud/orchestration/airflow/service/v1beta1
-    keep:
-      - google-cloud-orchestration-airflow/src/main/java/com/google/cloud/orchestration/airflow/service/v1/stub/Version.java
-      - google-cloud-orchestration-airflow/src/main/java/com/google/cloud/orchestration/airflow/service/v1beta1/stub/Version.java
     java:
       api_id_override: composer.googleapis.com
       api_description_override: is a managed Apache Airflow service that helps you create, schedule, monitor and manage workflows. Cloud Composer automation helps you create Airflow environments quickly and use Airflow-native tools, such as the powerful Airflow web interface and command line tools, so you can focus on your workflows and not your infrastructure.
       api_shortname_override: orchestration-airflow
+      released_version: 1.92.0
       name_pretty_override: Cloud Composer
       product_documentation_override: https://cloud.google.com/composer/docs
       rest_documentation: https://cloud.google.com/composer/docs/reference/rest
@@ -3057,11 +2831,10 @@ libraries:
           generate_gapic: false
           generate_grpc: false
           generate_resource_names: false
-    keep:
-      - google-cloud-orgpolicy/src/main/java/com/google/cloud/orgpolicy/v2/stub/Version.java
     java:
       api_description_override: n/a
       client_documentation_override: https://cloud.google.com/java/docs/reference/proto-google-cloud-orgpolicy-v1/latest/overview
+      released_version: 2.92.0
       name_pretty_override: Cloud Organization Policy
       product_documentation_override: n/a
   - name: os-config
@@ -3070,13 +2843,10 @@ libraries:
       - path: google/cloud/osconfig/v1
       - path: google/cloud/osconfig/v1beta
       - path: google/cloud/osconfig/v1alpha
-    keep:
-      - google-cloud-os-config/src/main/java/com/google/cloud/osconfig/v1/stub/Version.java
-      - google-cloud-os-config/src/main/java/com/google/cloud/osconfig/v1alpha/stub/Version.java
-      - google-cloud-os-config/src/main/java/com/google/cloud/osconfig/v1beta/stub/Version.java
     java:
       api_id_override: osconfig.googleapis.com
       api_description_override: provides OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.
+      released_version: 2.94.0
       name_pretty_override: OS Config API
       product_documentation_override: https://cloud.google.com/compute/docs/os-patch-management
       billing_not_required: true
@@ -3091,8 +2861,6 @@ libraries:
               copy_to_output: true
           samples: false
     keep:
-      - google-cloud-os-login/src/main/java/com/google/cloud/oslogin/v1/stub/Version.java
-      - google-cloud-os-login/src/test/java/com/google/cloud/oslogin/v1/it/ITSystemTest.java
       - proto-google-cloud-os-login-v1/src/main/java/com/google/cloud/oslogin/common/FingerprintName.java
       - proto-google-cloud-os-login-v1/src/main/java/com/google/cloud/oslogin/common/ProjectName.java
       - proto-google-cloud-os-login-v1/src/main/java/com/google/cloud/oslogin/v1/FingerprintName.java
@@ -3102,6 +2870,7 @@ libraries:
     java:
       api_description_override: manages OS login configuration for Directory API users.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559755
+      released_version: 2.91.0
       name_pretty_override: Cloud OS Login
       product_documentation_override: https://cloud.google.com/compute/docs/oslogin/
   - name: parallelstore
@@ -3115,13 +2884,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-parallelstore/src/main/java/com/google/cloud/parallelstore/v1/stub/Version.java
-      - google-cloud-parallelstore/src/main/java/com/google/cloud/parallelstore/v1beta/stub/Version.java
     java:
       api_id_override: parallelstore.googleapis.com
       api_description_override: 'Parallelstore is based on Intel DAOS and delivers up to 6.3x greater read throughput performance compared to competitive Lustre scratch offerings. '
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-parallelstore/latest/overview
+      released_version: 0.55.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Parallelstore API
       product_documentation_override: https://cloud/parallelstore?hl=en
@@ -3132,12 +2899,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-parametermanager/src/main/java/com/google/cloud/parametermanager/v1/stub/Version.java
     java:
       api_id_override: parametermanager.googleapis.com
       api_description_override: (Public Preview) Parameter Manager is a single source of truth to store,     access and manage the lifecycle of your workload parameters. Parameter     Manager aims to make management of sensitive application parameters     effortless for customers without diminishing focus on security.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-parametermanager/latest/overview
+      released_version: 0.36.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Parameter Manager API
       product_documentation_override: https://cloud.google.com/secret-manager/parameter-manager/docs/overview
@@ -3145,10 +2911,9 @@ libraries:
     version: 0.124.0-SNAPSHOT
     apis:
       - path: google/cloud/phishingprotection/v1beta1
-    keep:
-      - google-cloud-phishingprotection/src/main/java/com/google/cloud/phishingprotection/v1beta1/stub/Version.java
     java:
       api_description_override: helps prevent users from accessing phishing sites by identifying various signals associated with malicious content, including the use of your brand assets, classifying malicious content that uses your brand and reporting the unsafe URLs to Google Safe Browsing. Once a site is propagated to Safe Browsing, users will see warnings across more than 4 billion devices.
+      released_version: 0.123.0
       name_pretty_override: Phishing Protection
       product_documentation_override: https://cloud.google.com/phishing-protection/docs/
       billing_not_required: true
@@ -3157,33 +2922,29 @@ libraries:
     apis:
       - path: google/cloud/policytroubleshooter/v1
       - path: google/cloud/policytroubleshooter/iam/v3
-    keep:
-      - google-cloud-policy-troubleshooter/src/main/java/com/google/cloud/policytroubleshooter/iam/v3/stub/Version.java
-      - google-cloud-policy-troubleshooter/src/main/java/com/google/cloud/policytroubleshooter/v1/stub/Version.java
     java:
       api_id_override: policytroubleshooter.googleapis.com
       api_description_override: makes it easier to understand why a user has access to a resource or doesn't have permission to call an API. Given an email, resource, and permission, Policy Troubleshooter examines all Identity and Access Management (IAM) policies that apply to the resource. It then reveals whether the member's roles include the permission on that resource and, if so, which policies bind the member to those roles.
+      released_version: 1.91.0
       name_pretty_override: IAM Policy Troubleshooter API
       product_documentation_override: https://cloud.google.com/iam/docs/troubleshooting-access
   - name: policysimulator
     version: 0.72.0-SNAPSHOT
     apis:
       - path: google/cloud/policysimulator/v1
-    keep:
-      - google-cloud-policysimulator/src/main/java/com/google/cloud/policysimulator/v1/stub/Version.java
     java:
       api_description_override: Policy Simulator is a collection of endpoints for creating, running, and viewing a Replay.
+      released_version: 0.71.0
       name_pretty_override: Policy Simulator API
       product_documentation_override: https://cloud.google.com/policysimulator/docs/overview
   - name: private-catalog
     version: 0.95.0-SNAPSHOT
     apis:
       - path: google/cloud/privatecatalog/v1beta1
-    keep:
-      - google-cloud-private-catalog/src/main/java/com/google/cloud/privatecatalog/v1beta1/stub/Version.java
     java:
       api_id_override: privatecatalog.googleapis.com
       api_description_override: allows developers and cloud admins to make their solutions discoverable to their internal enterprise users. Cloud admins can manage their solutions and ensure their users are always launching the latest versions.
+      released_version: 0.94.0
       name_pretty_override: Private Catalog
       product_documentation_override: https://cloud.google.com/private-catalog/docs
   - name: privilegedaccessmanager
@@ -3193,12 +2954,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-privilegedaccessmanager/src/main/java/com/google/cloud/privilegedaccessmanager/v1/stub/Version.java
     java:
       api_id_override: privilegedaccessmanager.googleapis.com
       api_description_override: Privileged Access Manager (PAM) helps you on your journey towards least privilege and helps mitigate risks tied to privileged access misuse orabuse. PAM allows you to shift from always-on standing privileges towards on-demand access with just-in-time, time-bound, and approval-based access elevations. PAM allows IAM administrators to create entitlements that can grant just-in-time, temporary access to any resource scope. Requesters can explore eligible entitlements and request the access needed for their task. Approvers are notified when approvals await their decision. Streamlined workflows facilitated by using PAM can support various use cases, including emergency access for incident responders, time-boxed access for developers for critical deployment or maintenance, temporary access for operators for data ingestion and audits, JIT access to service accounts for automated tasks, and more.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-privilegedaccessmanager/latest/overview
+      released_version: 0.46.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Privileged Access Manager API
       product_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-privilegedaccessmanager/latest/overview
@@ -3207,11 +2967,10 @@ libraries:
     version: 2.93.0-SNAPSHOT
     apis:
       - path: google/devtools/cloudprofiler/v2
-    keep:
-      - google-cloud-profiler/src/main/java/com/google/devtools/cloudprofiler/v2/stub/Version.java
     java:
       api_id_override: cloudprofiler.googleapis.com
       api_description_override: is a statistical, low-overhead profiler that continuously gathers CPU usage and memory-allocation information from your production applications. It attributes that information to the application's source code, helping you identify the parts of the application consuming the most resources, and otherwise illuminating the performance characteristics of the code.
+      released_version: 2.92.0
       name_pretty_override: Cloud Profiler
       product_documentation_override: https://cloud.google.com/profiler/docs
   - name: publicca
@@ -3219,11 +2978,9 @@ libraries:
     apis:
       - path: google/cloud/security/publicca/v1
       - path: google/cloud/security/publicca/v1beta1
-    keep:
-      - google-cloud-publicca/src/main/java/com/google/cloud/security/publicca/v1/stub/Version.java
-      - google-cloud-publicca/src/main/java/com/google/cloud/security/publicca/v1beta1/stub/Version.java
     java:
       api_description_override: The Public Certificate Authority API may be used to create and manage ACME external account binding keys associated with Google Trust Services' publicly trusted certificate authority.
+      released_version: 0.89.0
       name_pretty_override: Public Certificate Authority API
       product_documentation_override: https://cloud.google.com/certificate-manager/docs/public-ca
       rpc_documentation: https://cloud.google.com/certificate-manager/docs/reference/public-ca/rpc
@@ -3260,7 +3017,6 @@ libraries:
       - google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SubscriberShutdownSettings.java
       - google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/SubscriberStats.java
       - google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Waiter.java
-      - google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/stub/Version.java
       - google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/it/ITPubSubTest.java
       - google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/CustomArgumentMatchers.java
       - google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/FakeClock.java
@@ -3293,6 +3049,7 @@ libraries:
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/history
       codeowner_team: '@googleapis/pubsub-team'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559741
+      released_version: 1.150.2
       library_type_override: GAPIC_COMBO
       name_pretty_override: Cloud Pub/Sub
       product_documentation_override: https://cloud.google.com/pubsub/docs/
@@ -3304,10 +3061,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-rapidmigrationassessment/src/main/java/com/google/cloud/rapidmigrationassessment/v1/stub/Version.java
     java:
       api_description_override: Rapid Migration Assessment API
+      released_version: 0.75.0
       name_pretty_override: Rapid Migration Assessment API
       product_documentation_override: https://cloud.google.com/migration-center/docs
   - name: recaptchaenterprise
@@ -3315,11 +3071,9 @@ libraries:
     apis:
       - path: google/cloud/recaptchaenterprise/v1
       - path: google/cloud/recaptchaenterprise/v1beta1
-    keep:
-      - google-cloud-recaptchaenterprise/src/main/java/com/google/cloud/recaptchaenterprise/v1/stub/Version.java
-      - google-cloud-recaptchaenterprise/src/main/java/com/google/cloud/recaptchaenterprise/v1beta1/stub/Version.java
     java:
       api_description_override: is a service that protects your site from spam and abuse.
+      released_version: 3.89.0
       name_pretty_override: reCAPTCHA Enterprise
       product_documentation_override: https://cloud.google.com/recaptcha-enterprise/docs/
       billing_not_required: true
@@ -3329,10 +3083,9 @@ libraries:
     version: 0.100.0-SNAPSHOT
     apis:
       - path: google/cloud/recommendationengine/v1beta1
-    keep:
-      - google-cloud-recommendations-ai/src/main/java/com/google/cloud/recommendationengine/v1beta1/stub/Version.java
     java:
       api_description_override: delivers highly personalized product recommendations at scale.
+      released_version: 0.99.0
       name_pretty_override: Recommendations AI
       product_documentation_override: https://cloud.google.com/recommendations-ai/
   - name: recommender
@@ -3340,12 +3093,9 @@ libraries:
     apis:
       - path: google/cloud/recommender/v1
       - path: google/cloud/recommender/v1beta1
-    keep:
-      - google-cloud-recommender/src/main/java/com/google/cloud/recommender/v1/stub/Version.java
-      - google-cloud-recommender/src/main/java/com/google/cloud/recommender/v1beta1/stub/Version.java
-      - google-cloud-recommender/src/test/java/com/google/cloud/recommender/v1beta1/it/ITSystemTest.java
     java:
       api_description_override: delivers highly personalized product recommendations at scale.
+      released_version: 2.94.0
       name_pretty_override: Recommender
       product_documentation_override: https://cloud.google.com/recommendations/
   - name: redis
@@ -3356,14 +3106,10 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
       - path: google/cloud/redis/v1beta1
-    keep:
-      - google-cloud-redis/src/main/java/com/google/cloud/redis/v1/stub/Version.java
-      - google-cloud-redis/src/main/java/com/google/cloud/redis/v1beta1/stub/Version.java
-      - google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
-      - google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
     java:
       api_description_override: is a fully managed Redis service for the Google Cloud. Applications running on Google Cloud can achieve extreme performance by leveraging the highly scalable, available, secure Redis service without the burden of managing complex Redis deployments.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5169231
+      released_version: 2.95.0
       name_pretty_override: Cloud Redis
       product_documentation_override: https://cloud.google.com/memorystore/docs/redis/
   - name: redis-cluster
@@ -3377,12 +3123,10 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-redis-cluster/src/main/java/com/google/cloud/redis/cluster/v1/stub/Version.java
-      - google-cloud-redis-cluster/src/main/java/com/google/cloud/redis/cluster/v1beta1/stub/Version.java
     java:
       api_description_override: Creates and manages Redis instances on the Google Cloud Platform.
       api_shortname_override: redis-cluster
+      released_version: 0.64.0
       name_pretty_override: Google Cloud Memorystore for Redis API
       product_documentation_override: https://cloud.google.com/memorystore/docs/cluster
   - name: resourcemanager
@@ -3391,11 +3135,10 @@ libraries:
       - path: google/cloud/resourcemanager/v3
         java:
           omit_common_resources: true
-    keep:
-      - google-cloud-resourcemanager/src/main/java/com/google/cloud/resourcemanager/v3/stub/Version.java
     java:
       api_description_override: enables you to programmatically manage resources by project, folder, and organization.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559757
+      released_version: 1.94.0
       name_pretty_override: Resource Manager API
       product_documentation_override: https://cloud.google.com/resource-manager
       billing_not_required: true
@@ -3414,12 +3157,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-retail/src/main/java/com/google/cloud/retail/v2/stub/Version.java
-      - google-cloud-retail/src/main/java/com/google/cloud/retail/v2alpha/stub/Version.java
-      - google-cloud-retail/src/main/java/com/google/cloud/retail/v2beta/stub/Version.java
     java:
       api_description_override: Retail solutions API.
+      released_version: 2.94.0
       name_pretty_override: Cloud Retail
       product_documentation_override: https://cloud.google.com/solutions/retail
   - name: run
@@ -3429,10 +3169,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-run/src/main/java/com/google/cloud/run/v2/stub/Version.java
     java:
       api_description_override: is a managed compute platform that enables you to run containers that are invocable via requests or events.
+      released_version: 0.92.0
       name_pretty_override: Cloud Run
       product_documentation_override: https://cloud.google.com/run/docs
       rest_documentation: https://cloud.google.com/run/docs/reference/rest
@@ -3444,12 +3183,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-saasservicemgmt/src/main/java/com/google/cloud/saasplatform/saasservicemgmt/v1beta1/stub/Version.java
     java:
       api_id_override: saasservicemgmt.googleapis.com
       api_description_override: "Model, deploy, and operate your SaaS at scale.\t"
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-saasservicemgmt/latest/overview
+      released_version: 0.22.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: App Lifecycle Manager
       product_documentation_override: https://cloud.google.com/saas-runtime/docs/overview
@@ -3466,15 +3204,12 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
     keep:
-      - google-cloud-scheduler/src/main/java/com/google/cloud/scheduler/v1/stub/Version.java
-      - google-cloud-scheduler/src/main/java/com/google/cloud/scheduler/v1beta1/stub/Version.java
-      - google-cloud-scheduler/src/test/java/com/google/cloud/scheduler/v1/it/ITSystemTest.java
-      - google-cloud-scheduler/src/test/java/com/google/cloud/scheduler/v1beta1/it/ITSystemTest.java
       - proto-google-cloud-scheduler-v1/src/main/java/com/google/cloud/scheduler/v1/ProjectName.java
       - proto-google-cloud-scheduler-v1beta1/src/main/java/com/google/cloud/scheduler/v1beta1/ProjectName.java
     java:
       api_description_override: lets you set up scheduled units of work to be executed at defined times or regular intervals. These work units are commonly known as cron jobs. Typical use cases might include sending out a report email on a daily basis, updating some cached data every 10 minutes, or updating some summary information once an hour.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5411429
+      released_version: 2.92.0
       name_pretty_override: Google Cloud Scheduler
       product_documentation_override: https://cloud.google.com/scheduler/docs
       billing_not_required: true
@@ -3492,12 +3227,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-secretmanager/src/main/java/com/google/cloud/secretmanager/v1/stub/Version.java
-      - google-cloud-secretmanager/src/main/java/com/google/cloud/secretmanager/v1beta1/stub/Version.java
-      - google-cloud-secretmanager/src/main/java/com/google/cloud/secretmanager/v1beta2/stub/Version.java
     java:
       api_description_override: allows you to encrypt, store, manage, and audit infrastructure and application-level secrets.
+      released_version: 2.92.0
       name_pretty_override: Secret Management
       product_documentation_override: https://cloud.google.com/solutions/secrets-management/
       billing_not_required: true
@@ -3509,12 +3241,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-securesourcemanager/src/main/java/com/google/cloud/securesourcemanager/v1/stub/Version.java
     java:
       api_description_override: |-
         Regionally deployed, single-tenant managed source code repository hosted on
             Google Cloud.
+      released_version: 0.62.0
       name_pretty_override: Secure Source Manager API
       product_documentation_override: https://cloud.google.com/secure-source-manager/docs/overview
   - name: security-private-ca
@@ -3526,12 +3257,10 @@ libraries:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
       - path: google/cloud/security/privateca/v1beta1
-    keep:
-      - google-cloud-security-private-ca/src/main/java/com/google/cloud/security/privateca/v1/stub/Version.java
-      - google-cloud-security-private-ca/src/main/java/com/google/cloud/security/privateca/v1beta1/stub/Version.java
     java:
       api_id_override: privateca.googleapis.com
       api_description_override: simplifies the deployment and management of private CAs without managing infrastructure.
+      released_version: 2.94.0
       name_pretty_override: Certificate Authority Service
       product_documentation_override: https://cloud.google.com/certificate-authority-service/docs
       rest_documentation: https://cloud.google.com/certificate-authority-service/docs/reference/rest
@@ -3544,10 +3273,6 @@ libraries:
       - path: google/cloud/securitycenter/v1p1beta1
       - path: google/cloud/securitycenter/v1beta1
     keep:
-      - google-cloud-securitycenter/src/main/java/com/google/cloud/securitycenter/v1/stub/Version.java
-      - google-cloud-securitycenter/src/main/java/com/google/cloud/securitycenter/v1beta1/stub/Version.java
-      - google-cloud-securitycenter/src/main/java/com/google/cloud/securitycenter/v1p1beta1/stub/Version.java
-      - google-cloud-securitycenter/src/main/java/com/google/cloud/securitycenter/v2/stub/Version.java
       - proto-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/AssetSecurityMarksName.java
       - proto-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/FindingSecurityMarksName.java
       - proto-google-cloud-securitycenter-v1beta1/src/main/java/com/google/cloud/securitycenter/v1beta1/SecuritymarksName.java
@@ -3556,6 +3281,7 @@ libraries:
     java:
       api_description_override: makes it easier for you to prevent, detect, and respond to threats. Identify security misconfigurations in virtual machines, networks, applications, and storage buckets from a centralized dashboard. Take action on them before they can potentially result in business damage or loss. Built-in capabilities can quickly surface suspicious activity in your Stackdriver security logs or indicate compromised virtual machines. Respond to threats by following actionable recommendations or exporting logs to your SIEM for further investigation.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559748
+      released_version: 2.100.0
       name_pretty_override: Security Command Center
       product_documentation_override: https://cloud.google.com/security-command-center
       billing_not_required: true
@@ -3564,11 +3290,10 @@ libraries:
     version: 0.96.0-SNAPSHOT
     apis:
       - path: google/cloud/securitycenter/settings/v1beta1
-    keep:
-      - google-cloud-securitycenter-settings/src/main/java/com/google/cloud/securitycenter/settings/v1beta1/stub/Version.java
     java:
       api_id_override: securitycenter-settings.googleapis.com
       api_description_override: is the canonical security and data risk database for Google Cloud. Security Command Center enables you to understand your security and data attack surface by providing asset inventory, discovery, search, and management.
+      released_version: 0.95.0
       name_pretty_override: Security Command Center Settings API
       product_documentation_override: https://cloud.google.com/security-command-center/
       billing_not_required: true
@@ -3580,10 +3305,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-securitycentermanagement/src/main/java/com/google/cloud/securitycentermanagement/v1/stub/Version.java
     java:
       api_description_override: Security Center Management API
+      released_version: 0.60.0
       name_pretty_override: Security Center Management API
       product_documentation_override: https://cloud.google.com/securitycentermanagement/docs/overview
   - name: securityposture
@@ -3593,10 +3317,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-securityposture/src/main/java/com/google/cloud/securityposture/v1/stub/Version.java
     java:
       api_description_override: Security Posture is a comprehensive framework of policy sets that empowers organizations to define, assess early, deploy, and monitor their security measures in a unified way and helps simplify governance and reduces administrative toil.
+      released_version: 0.57.0
       name_pretty_override: Security Posture API
       product_documentation_override: https://cloud.google.com/security-command-center/docs/security-posture-overview
   - name: service-control
@@ -3604,11 +3327,9 @@ libraries:
     apis:
       - path: google/api/servicecontrol/v2
       - path: google/api/servicecontrol/v1
-    keep:
-      - google-cloud-service-control/src/main/java/com/google/api/servicecontrol/v1/stub/Version.java
-      - google-cloud-service-control/src/main/java/com/google/api/servicecontrol/v2/stub/Version.java
     java:
       api_description_override: ' is a foundational platform for creating, managing, securing, and consuming APIs and services across organizations. It is used by Google APIs, Cloud APIs, Cloud Endpoints, and API Gateway.'
+      released_version: 1.92.0
       name_pretty_override: Service Control API
       product_documentation_override: https://cloud.google.com/service-infrastructure/docs/overview/
   - name: service-management
@@ -3619,11 +3340,11 @@ libraries:
           additional_protos:
             - path: google/iam/v1/iam_policy.proto
     keep:
-      - google-cloud-service-management/src/main/java/com/google/cloud/api/servicemanagement/v1/stub/Version.java
       - google-cloud-service-management/src/test/java/com/google/cloud/api/servicemanagement/v1/ServiceManagerClientHttpJsonTest.java
     java:
       api_id_override: servicemanagement.googleapis.com
       api_description_override: is a foundational platform for creating, managing, securing, and consuming APIs and services across organizations. It is used by Google APIs, Cloud APIs, Cloud Endpoints, and API Gateway. Service Infrastructure provides a wide range of features to service consumers and service producers, including authentication, authorization, auditing, rate limiting, analytics, billing, logging, and monitoring.
+      released_version: 3.90.0
       name_pretty_override: Service Management API
       product_documentation_override: https://cloud.google.com/service-infrastructure/docs/overview/
   - name: service-usage
@@ -3631,11 +3352,9 @@ libraries:
     apis:
       - path: google/api/serviceusage/v1
       - path: google/api/serviceusage/v1beta1
-    keep:
-      - google-cloud-service-usage/src/main/java/com/google/api/serviceusage/v1/stub/Version.java
-      - google-cloud-service-usage/src/main/java/com/google/api/serviceusage/v1beta1/stub/Version.java
     java:
       api_description_override: is an infrastructure service of Google Cloud that lets you list and manage other APIs and services in your Cloud projects.
+      released_version: 2.92.0
       name_pretty_override: Service Usage
       product_documentation_override: https://cloud.google.com/service-usage/docs/overview
   - name: servicedirectory
@@ -3649,11 +3368,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-servicedirectory/src/main/java/com/google/cloud/servicedirectory/v1/stub/Version.java
-      - google-cloud-servicedirectory/src/main/java/com/google/cloud/servicedirectory/v1beta1/stub/Version.java
     java:
       api_description_override: allows the registration and lookup of service endpoints.
+      released_version: 2.93.0
       name_pretty_override: Service Directory
       product_documentation_override: https://cloud.google.com/service-directory/
       billing_not_required: true
@@ -3666,10 +3383,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-servicehealth/src/main/java/com/google/cloud/servicehealth/v1/stub/Version.java
     java:
       api_description_override: Personalized Service Health helps you gain visibility into disruptive events impacting Google Cloud products.
+      released_version: 0.59.0
       name_pretty_override: Service Health API
       product_documentation_override: https://cloud.google.com/service-health/docs/overview
       rpc_documentation: https://cloud.google.com/service-health/docs/reference/rpc
@@ -3677,11 +3393,10 @@ libraries:
     version: 2.92.0-SNAPSHOT
     apis:
       - path: google/cloud/shell/v1
-    keep:
-      - google-cloud-shell/src/main/java/com/google/cloud/shell/v1/stub/Version.java
     java:
       api_description_override: is an interactive shell environment for Google Cloud that makes it easy for you to learn and experiment with Google Cloud and manage your projects and resources from your web browser.
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 2.91.0
       name_pretty_override: Cloud Shell
       product_documentation_override: https://cloud.google.com/shell/docs
       rest_documentation: https://cloud.google.com/shell/docs/reference/rest
@@ -3690,12 +3405,11 @@ libraries:
     version: 0.61.0-SNAPSHOT
     apis:
       - path: google/shopping/css/v1
-    keep:
-      - google-shopping-css/src/main/java/com/google/shopping/css/v1/stub/Version.java
     java:
       api_description_override: The CSS API is used to manage your CSS and control your CSS Products portfolio
       artifact_id: google-shopping-css
       group_id: com.google.shopping
+      released_version: 0.60.0
       name_pretty_override: CSS API
       product_documentation_override: https://developers.google.com/comparison-shopping-services/api
   - name: shopping-merchant-accounts
@@ -3703,15 +3417,13 @@ libraries:
     apis:
       - path: google/shopping/merchant/accounts/v1
       - path: google/shopping/merchant/accounts/v1beta
-    keep:
-      - google-shopping-merchant-accounts/src/main/java/com/google/shopping/merchant/accounts/v1/stub/Version.java
-      - google-shopping-merchant-accounts/src/main/java/com/google/shopping/merchant/accounts/v1beta/stub/Version.java
     java:
       api_id_override: merchantapi.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
       artifact_id: google-shopping-merchant-accounts
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-accounts/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3720,9 +3432,6 @@ libraries:
     apis:
       - path: google/shopping/merchant/conversions/v1
       - path: google/shopping/merchant/conversions/v1beta
-    keep:
-      - google-shopping-merchant-conversions/src/main/java/com/google/shopping/merchant/conversions/v1/stub/Version.java
-      - google-shopping-merchant-conversions/src/main/java/com/google/shopping/merchant/conversions/v1beta/stub/Version.java
     java:
       api_id_override: shopping-merchant-conversions.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
@@ -3730,6 +3439,7 @@ libraries:
       artifact_id: google-shopping-merchant-conversions
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-conversions/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant Conversions API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3738,15 +3448,13 @@ libraries:
     apis:
       - path: google/shopping/merchant/datasources/v1
       - path: google/shopping/merchant/datasources/v1beta
-    keep:
-      - google-shopping-merchant-datasources/src/main/java/com/google/shopping/merchant/datasources/v1/stub/Version.java
-      - google-shopping-merchant-datasources/src/main/java/com/google/shopping/merchant/datasources/v1beta/stub/Version.java
     java:
       api_id_override: merchantapi.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
       artifact_id: google-shopping-merchant-datasources
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-datasources/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3755,13 +3463,11 @@ libraries:
     apis:
       - path: google/shopping/merchant/inventories/v1
       - path: google/shopping/merchant/inventories/v1beta
-    keep:
-      - google-shopping-merchant-inventories/src/main/java/com/google/shopping/merchant/inventories/v1/stub/Version.java
-      - google-shopping-merchant-inventories/src/main/java/com/google/shopping/merchant/inventories/v1beta/stub/Version.java
     java:
       api_description_override: Programmatically manage your Merchant Center accounts.
       artifact_id: google-shopping-merchant-inventories
       group_id: com.google.shopping
+      released_version: 1.20.0
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
   - name: shopping-merchant-lfp
@@ -3769,9 +3475,6 @@ libraries:
     apis:
       - path: google/shopping/merchant/lfp/v1
       - path: google/shopping/merchant/lfp/v1beta
-    keep:
-      - google-shopping-merchant-lfp/src/main/java/com/google/shopping/merchant/lfp/v1/stub/Version.java
-      - google-shopping-merchant-lfp/src/main/java/com/google/shopping/merchant/lfp/v1beta/stub/Version.java
     java:
       api_id_override: shopping-merchant-lfp.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
@@ -3779,6 +3482,7 @@ libraries:
       artifact_id: google-shopping-merchant-lfp
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-lfp/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant LFP API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3787,9 +3491,6 @@ libraries:
     apis:
       - path: google/shopping/merchant/notifications/v1
       - path: google/shopping/merchant/notifications/v1beta
-    keep:
-      - google-shopping-merchant-notifications/src/main/java/com/google/shopping/merchant/notifications/v1/stub/Version.java
-      - google-shopping-merchant-notifications/src/main/java/com/google/shopping/merchant/notifications/v1beta/stub/Version.java
     java:
       api_id_override: shopping-merchant-notifications.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
@@ -3797,6 +3498,7 @@ libraries:
       artifact_id: google-shopping-merchant-notifications
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-notifications/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant Notifications API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3804,14 +3506,13 @@ libraries:
     version: 0.33.0-SNAPSHOT
     apis:
       - path: google/shopping/merchant/productstudio/v1alpha
-    keep:
-      - google-shopping-merchant-productstudio/src/main/java/com/google/shopping/merchant/productstudio/v1alpha/stub/Version.java
     java:
       api_id_override: merchantapi.googleapis.com
       api_description_override: Programmatically manage your products.
       artifact_id: google-shopping-merchant-productstudio
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-productstudio/latest/overview
       group_id: com.google.shopping
+      released_version: 0.32.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3820,15 +3521,13 @@ libraries:
     apis:
       - path: google/shopping/merchant/products/v1
       - path: google/shopping/merchant/products/v1beta
-    keep:
-      - google-shopping-merchant-products/src/main/java/com/google/shopping/merchant/products/v1/stub/Version.java
-      - google-shopping-merchant-products/src/main/java/com/google/shopping/merchant/products/v1beta/stub/Version.java
     java:
       api_id_override: merchantapi.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
       artifact_id: google-shopping-merchant-products
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-products/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3837,15 +3536,13 @@ libraries:
     apis:
       - path: google/shopping/merchant/promotions/v1
       - path: google/shopping/merchant/promotions/v1beta
-    keep:
-      - google-shopping-merchant-promotions/src/main/java/com/google/shopping/merchant/promotions/v1/stub/Version.java
-      - google-shopping-merchant-promotions/src/main/java/com/google/shopping/merchant/promotions/v1beta/stub/Version.java
     java:
       api_id_override: merchantapi.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
       artifact_id: google-shopping-merchant-promotions
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-promotions/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3854,9 +3551,6 @@ libraries:
     apis:
       - path: google/shopping/merchant/quota/v1
       - path: google/shopping/merchant/quota/v1beta
-    keep:
-      - google-shopping-merchant-quota/src/main/java/com/google/shopping/merchant/quota/v1/stub/Version.java
-      - google-shopping-merchant-quota/src/main/java/com/google/shopping/merchant/quota/v1beta/stub/Version.java
     java:
       api_id_override: shopping-merchant-quota.googleapis.com
       api_description_override: Programmatically manage your Merchant Center accounts.
@@ -3864,6 +3558,7 @@ libraries:
       artifact_id: google-shopping-merchant-quota
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-quota/latest/overview
       group_id: com.google.shopping
+      released_version: 1.20.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant Quota API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3873,27 +3568,23 @@ libraries:
       - path: google/shopping/merchant/reports/v1
       - path: google/shopping/merchant/reports/v1beta
       - path: google/shopping/merchant/reports/v1alpha
-    keep:
-      - google-shopping-merchant-reports/src/main/java/com/google/shopping/merchant/reports/v1/stub/Version.java
-      - google-shopping-merchant-reports/src/main/java/com/google/shopping/merchant/reports/v1alpha/stub/Version.java
-      - google-shopping-merchant-reports/src/main/java/com/google/shopping/merchant/reports/v1beta/stub/Version.java
     java:
       api_description_override: Programmatically manage your Merchant Center accounts.
       artifact_id: google-shopping-merchant-reports
       group_id: com.google.shopping
+      released_version: 1.20.0
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
   - name: shopping-merchant-reviews
     version: 0.39.0-SNAPSHOT
     apis:
       - path: google/shopping/merchant/reviews/v1beta
-    keep:
-      - google-shopping-merchant-reviews/src/main/java/com/google/shopping/merchant/reviews/v1beta/stub/Version.java
     java:
       api_description_override: Programmatically manage your Merchant Center Accounts.
       artifact_id: google-shopping-merchant-reviews
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-shopping-merchant-reviews/latest/overview
       group_id: com.google.shopping
+      released_version: 0.38.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Merchant API
       product_documentation_override: https://developers.google.com/merchant/api
@@ -3909,8 +3600,8 @@ libraries:
           grpc_artifact_id_override: grpc-gapic-showcase-v1beta1
           proto_artifact_id_override: proto-gapic-showcase-v1beta1
     keep:
-      - gapic-showcase/src/test
       - gapic-showcase/src/main/java/com/google/showcase/v1beta1/Version.java
+      - gapic-showcase/src/test
     roots:
       - showcase
       - googleapis
@@ -3919,6 +3610,7 @@ libraries:
       artifact_id: gapic-showcase
       excluded_poms:
         - gapic-showcase-bom
+      released_version: 0.0.0
       library_type_override: OTHER
       name_pretty_override: Showcase
       product_documentation_override: https://cloud.google.com/dummy
@@ -3946,10 +3638,6 @@ libraries:
           proto_artifact_id_override: proto-google-cloud-spanner-admin-instance-v1
           samples: false
     keep:
-      - google-cloud-spanner-executor/src/main/java/com/google/cloud/spanner/executor/v1/stub/Version.java
-      - google-cloud-spanner/src/main/java/com/google/cloud/spanner/admin/database/v1/stub/Version.java
-      - google-cloud-spanner/src/main/java/com/google/cloud/spanner/admin/instance/v1/stub/Version.java
-      - google-cloud-spanner/src/main/java/com/google/cloud/spanner/v1/stub/Version.java
       - google-cloud-spanner/src/main/resources/META-INF/native-image/com.google.cloud.spanner/reflect-config.json
       - proto-google-cloud-spanner-admin-database-v1/src/main/java/com/google/spanner/admin/database/v1/CryptoKeyName.java
       - proto-google-cloud-spanner-admin-database-v1/src/main/java/com/google/spanner/admin/database/v1/CryptoKeyVersionName.java
@@ -3962,6 +3650,7 @@ libraries:
         - google-cloud-spanner-bom
         - google-cloud-spanner
       issue_tracker_override: https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open
+      released_version: 6.117.0
       library_type_override: GAPIC_COMBO
       min_java_version: 8
       name_pretty_override: Cloud Spanner
@@ -3972,13 +3661,12 @@ libraries:
     version: 0.29.0-SNAPSHOT
     apis:
       - path: google/spanner/adapter/v1
-    keep:
-      - google-cloud-spanneradapter/src/main/java/com/google/spanner/adapter/v1/stub/Version.java
     java:
       api_id_override: spanneradapter.googleapis.com
       api_description_override: The Cloud Spanner Adapter service allows native drivers of supported     database dialects to interact directly with Cloud Spanner by wrapping the underlying     wire protocol used by the driver in a gRPC stream.
       api_shortname_override: spanneradapter
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-spanneradapter/latest/overview
+      released_version: 0.28.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Cloud Spanner Adapter API
       product_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-spanneradapter/latest/overview
@@ -3992,17 +3680,14 @@ libraries:
       - path: google/cloud/speech/v1
       - path: google/cloud/speech/v1p1beta1
     keep:
-      - google-cloud-speech/src/main/java/com/google/cloud/speech/v1/stub/Version.java
-      - google-cloud-speech/src/main/java/com/google/cloud/speech/v1p1beta1/stub/Version.java
-      - google-cloud-speech/src/main/java/com/google/cloud/speech/v2/stub/Version.java
       - google-cloud-speech/src/test/java/com/google/cloud/speech/v1/SpeechSmokeTest.java
-      - google-cloud-speech/src/test/java/com/google/cloud/speech/v1/it/ITSpeechTest.java
       - google-cloud-speech/src/test/java/com/google/cloud/speech/v1p1beta1/SpeechSmokeTest.java
       - google-cloud-speech/src/test/resources/META-INF/native-image/com.google.cloud/google-cloud-speech/resource-config.json
       - google-cloud-speech/src/test/resources/hello.flac
     java:
       api_description_override: enables easy integration of Google speech recognition technologies into developer applications. Send audio and receive a text transcription from the Speech-to-Text API service.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559758
+      released_version: 4.87.0
       name_pretty_override: Cloud Speech
       product_documentation_override: https://cloud.google.com/speech-to-text/docs/
       billing_not_required: true
@@ -4029,9 +3714,6 @@ libraries:
             - source: src/main/java/com/google/storage/control/v2/gapic_metadata.json
               destination: src/main/resources/com/google/storage/control/v2/gapic_metadata.json
           samples: false
-    keep:
-      - gapic-google-cloud-storage-v2/src/main/java/com/google/storage/v2/stub/Version.java
-      - google-cloud-storage-control/src/main/java/com/google/storage/control/v2/stub/Version.java
     java:
       api_id_override: storage.googleapis.com
       api_description_override: 'is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.'
@@ -4042,6 +3724,7 @@ libraries:
         - google-cloud-storage
       extra_versioned_modules: gapic-google-cloud-storage-v2
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559782
+      released_version: 2.68.0
       library_type_override: GAPIC_COMBO
       name_pretty_override: Cloud Storage
       product_documentation_override: https://cloud.google.com/storage
@@ -4051,10 +3734,9 @@ libraries:
     version: 1.93.0-SNAPSHOT
     apis:
       - path: google/storagetransfer/v1
-    keep:
-      - google-cloud-storage-transfer/src/main/java/com/google/storagetransfer/v1/proto/stub/Version.java
     java:
       api_description_override: Secure, low-cost services for transferring data from cloud or on-premises sources.
+      released_version: 1.92.0
       name_pretty_override: Storage Transfer Service
       product_documentation_override: https://cloud.google.com/storage-transfer-service
   - name: storagebatchoperations
@@ -4064,12 +3746,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-storagebatchoperations/src/main/java/com/google/cloud/storagebatchoperations/v1/stub/Version.java
     java:
       api_id_override: storagebatchoperations.googleapis.com
       api_description_override: Storage batch operations is a Cloud Storage management feature that performs operations on billions of Cloud Storage objects in a serverless manner.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-storagebatchoperations/latest/overview
+      released_version: 0.32.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Storage Batch Operations API
       product_documentation_override: https://cloud.google.com/storage/docs/batch-operations/overview
@@ -4080,10 +3761,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-storageinsights/src/main/java/com/google/cloud/storageinsights/v1/stub/Version.java
     java:
       api_description_override: Provides insights capability on Google Cloud Storage
+      released_version: 0.77.0
       name_pretty_override: Storage Insights API
       product_documentation_override: https://cloud.google.com/storage/docs/insights/storage-insights/
   - name: talent
@@ -4091,13 +3771,10 @@ libraries:
     apis:
       - path: google/cloud/talent/v4
       - path: google/cloud/talent/v4beta1
-    keep:
-      - google-cloud-talent/src/main/java/com/google/cloud/talent/v4/stub/Version.java
-      - google-cloud-talent/src/main/java/com/google/cloud/talent/v4beta1/stub/Version.java
-      - google-cloud-talent/src/test/java/com/google/cloud/talent/v4/it/ITSystemTest.java
     java:
       api_description_override: allows you to transform your job search and candidate matching capabilities with Cloud Talent Solution, designed to support enterprise talent acquisition technology and evolve with your growing needs. This AI solution includes features such as Job Search and Profile Search (Beta) to provide candidates and employers with an enhanced talent acquisition experience. Learn more about Cloud Talent Solution from the product overview page.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559664
+      released_version: 2.93.0
       name_pretty_override: Talent Solution
       product_documentation_override: https://cloud.google.com/solutions/talent-solution/
   - name: tasks
@@ -4116,10 +3793,6 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
     keep:
-      - google-cloud-tasks/src/main/java/com/google/cloud/tasks/v2/stub/Version.java
-      - google-cloud-tasks/src/main/java/com/google/cloud/tasks/v2beta2/stub/Version.java
-      - google-cloud-tasks/src/main/java/com/google/cloud/tasks/v2beta3/stub/Version.java
-      - google-cloud-tasks/src/test/java/com/google/cloud/tasks/v2/it/ITSystemTest.java
       - google-cloud-tasks/src/test/java/com/google/cloud/tasks/v2beta3/CloudTasksSmokeTest.java
       - proto-google-cloud-tasks-v2/src/main/java/com/google/cloud/tasks/v2/ProjectName.java
       - proto-google-cloud-tasks-v2beta2/src/main/java/com/google/cloud/tasks/v2beta2/ProjectName.java
@@ -4128,6 +3801,7 @@ libraries:
       api_description_override: a fully managed service that allows you to manage the execution, dispatch and delivery of a large number of distributed tasks. You can asynchronously perform work outside of a user request. Your tasks can be executed on App Engine or any arbitrary HTTP endpoint.
       codeowner_team: '@googleapis/aap-dpes'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5433985
+      released_version: 2.92.0
       name_pretty_override: Cloud Tasks
       product_documentation_override: https://cloud.google.com/tasks/docs/
       rest_documentation: https://cloud.google.com/tasks/docs/reference/rest
@@ -4143,11 +3817,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-telcoautomation/src/main/java/com/google/cloud/telcoautomation/v1/stub/Version.java
-      - google-cloud-telcoautomation/src/main/java/com/google/cloud/telcoautomation/v1alpha1/stub/Version.java
     java:
       api_description_override: APIs to automate 5G deployment and management of cloud infrastructure and network functions.
+      released_version: 0.62.0
       name_pretty_override: Telco Automation API
       product_documentation_override: https://cloud.google.com/telecom-network-automation
   - name: texttospeech
@@ -4156,15 +3828,12 @@ libraries:
       - path: google/cloud/texttospeech/v1
       - path: google/cloud/texttospeech/v1beta1
     keep:
-      - google-cloud-texttospeech/src/main/java/com/google/cloud/texttospeech/v1/stub/Version.java
-      - google-cloud-texttospeech/src/main/java/com/google/cloud/texttospeech/v1beta1/stub/Version.java
       - google-cloud-texttospeech/src/test/java/com/google/cloud/texttospeech/v1/TextToSpeechSmokeTest.java
-      - google-cloud-texttospeech/src/test/java/com/google/cloud/texttospeech/v1/it/ITSystemTest.java
       - google-cloud-texttospeech/src/test/java/com/google/cloud/texttospeech/v1beta1/TextToSpeechSmokeTest.java
-      - google-cloud-texttospeech/src/test/java/com/google/cloud/texttospeech/v1beta1/it/ITSystemTest.java
     java:
       api_description_override: enables easy integration of Google text recognition technologies into developer applications. Send text and receive synthesized audio output from the Cloud Text-to-Speech API service.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5235428
+      released_version: 2.93.0
       name_pretty_override: Cloud Text-to-Speech
       product_documentation_override: https://cloud.google.com/text-to-speech
       billing_not_required: true
@@ -4185,12 +3854,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-tpu/src/main/java/com/google/cloud/tpu/v1/stub/Version.java
-      - google-cloud-tpu/src/main/java/com/google/cloud/tpu/v2/stub/Version.java
-      - google-cloud-tpu/src/main/java/com/google/cloud/tpu/v2alpha1/stub/Version.java
     java:
       api_description_override: are Google's custom-developed application-specific integrated circuits (ASICs) used to accelerate machine learning workloads.
+      released_version: 2.93.0
       name_pretty_override: Cloud TPU
       product_documentation_override: https://cloud.google.com/tpu/docs
       rest_documentation: https://cloud.google.com/tpu/docs/reference/rest
@@ -4200,14 +3866,11 @@ libraries:
       - path: google/devtools/cloudtrace/v2
       - path: google/devtools/cloudtrace/v1
     keep:
-      - google-cloud-trace/src/main/java/com/google/cloud/trace/v1/stub/Version.java
-      - google-cloud-trace/src/main/java/com/google/cloud/trace/v2/stub/Version.java
       - google-cloud-trace/src/test/java/com/google/cloud/trace/v1/VPCServiceControlTest.java
-      - google-cloud-trace/src/test/java/com/google/cloud/trace/v1/it/ITSystemTest.java
       - google-cloud-trace/src/test/java/com/google/cloud/trace/v2/VPCServiceControlTest.java
-      - google-cloud-trace/src/test/java/com/google/cloud/trace/v2/it/ITSystemTest.java
     java:
       api_description_override: is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.
+      released_version: 2.92.0
       name_pretty_override: Stackdriver Trace
       product_documentation_override: https://cloud.google.com/trace/docs/
       billing_not_required: true
@@ -4216,13 +3879,11 @@ libraries:
     apis:
       - path: google/cloud/translate/v3
       - path: google/cloud/translate/v3beta1
-    keep:
-      - google-cloud-translate/src/main/java/com/google/cloud/translate/v3/stub/Version.java
-      - google-cloud-translate/src/main/java/com/google/cloud/translate/v3beta1/stub/Version.java
     java:
       api_id_override: translate.googleapis.com
       api_description_override: can dynamically translate text between thousands of language pairs. Translation lets websites and programs programmatically integrate with the translation service.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559749
+      released_version: 2.92.0
       name_pretty_override: Cloud Translation
       product_documentation_override: https://cloud.google.com/translate/docs/
       rest_documentation: https://cloud.google.com/translate/docs/reference/rest
@@ -4238,13 +3899,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-valkey/src/main/java/com/google/cloud/memorystore/v1/stub/Version.java
-      - google-cloud-valkey/src/main/java/com/google/cloud/memorystore/v1beta/stub/Version.java
     java:
       api_id_override: memorystore.googleapis.com
       api_description_override: Memorystore for Valkey is a fully managed Valkey Cluster service for Google Cloud.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-memorystore/latest/overview
+      released_version: 0.38.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Memorystore API
       product_documentation_override: https://cloud.google.com/memorystore/docs/valkey
@@ -4260,13 +3919,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-vectorsearch/src/main/java/com/google/cloud/vectorsearch/v1/stub/Version.java
-      - google-cloud-vectorsearch/src/main/java/com/google/cloud/vectorsearch/v1beta/stub/Version.java
     java:
       api_id_override: vectorsearch.googleapis.com
       api_description_override: The Vector Search API provides a fully-managed, highly performant, and scalable vector database designed to power next-generation search, recommendation, and generative AI applications. It allows you to store, index, and query your data and its corresponding vector embeddings through a simple, intuitive interface. With Vector Search, you can define custom schemas for your data, insert objects with associated metadata, automatically generate embeddings from your data, and perform fast approximate nearest neighbor (ANN) searches to find semantically similar items at scale.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-vectorsearch/latest/overview
+      released_version: 0.14.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Vector Search API
       product_documentation_override: https://docs.cloud.google.com/vertex-ai/docs/vector-search/overview
@@ -4278,20 +3935,10 @@ libraries:
       - path: google/cloud/videointelligence/v1p2beta1
       - path: google/cloud/videointelligence/v1p1beta1
       - path: google/cloud/videointelligence/v1beta2
-    keep:
-      - google-cloud-video-intelligence/src/main/java/com/google/cloud/videointelligence/v1/stub/Version.java
-      - google-cloud-video-intelligence/src/main/java/com/google/cloud/videointelligence/v1beta2/stub/Version.java
-      - google-cloud-video-intelligence/src/main/java/com/google/cloud/videointelligence/v1p1beta1/stub/Version.java
-      - google-cloud-video-intelligence/src/main/java/com/google/cloud/videointelligence/v1p2beta1/stub/Version.java
-      - google-cloud-video-intelligence/src/main/java/com/google/cloud/videointelligence/v1p3beta1/stub/Version.java
-      - google-cloud-video-intelligence/src/test/java/com/google/cloud/videointelligence/v1/it/ITSystemTest.java
-      - google-cloud-video-intelligence/src/test/java/com/google/cloud/videointelligence/v1beta2/it/ITSystemTest.java
-      - google-cloud-video-intelligence/src/test/java/com/google/cloud/videointelligence/v1p1beta1/it/ITSystemTest.java
-      - google-cloud-video-intelligence/src/test/java/com/google/cloud/videointelligence/v1p2beta1/it/ITSystemTest.java
-      - google-cloud-video-intelligence/src/test/java/com/google/cloud/videointelligence/v1p3beta1/it/ITSystemTest.java
     java:
       api_description_override: allows developers to use Google video analysis technology as part of their applications.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5084810
+      released_version: 2.91.0
       name_pretty_override: Cloud Video Intelligence
       product_documentation_override: https://cloud.google.com/video-intelligence/docs/
       rest_documentation: https://cloud.google.com/video-intelligence/docs/reference/rest
@@ -4303,32 +3950,29 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-live-stream/src/main/java/com/google/cloud/video/livestream/v1/stub/Version.java
     java:
       api_description_override: transcodes mezzanine live signals into direct-to-consumer streaming formats, including Dynamic Adaptive Streaming over HTTP (DASH/MPEG-DASH), and HTTP Live Streaming (HLS), for multiple device platforms.
       artifact_id: google-cloud-live-stream
+      released_version: 0.94.0
       name_pretty_override: Live Stream API
       product_documentation_override: https://cloud.google.com/livestream/
   - name: video-stitcher
     version: 0.93.0-SNAPSHOT
     apis:
       - path: google/cloud/video/stitcher/v1
-    keep:
-      - google-cloud-video-stitcher/src/main/java/com/google/cloud/video/stitcher/v1/stub/Version.java
     java:
       api_description_override: allows you to manipulate video content to dynamically insert ads prior to delivery to client devices.
+      released_version: 0.92.0
       name_pretty_override: Video Stitcher API
       product_documentation_override: https://cloud.google.com/video-stitcher/
   - name: video-transcoder
     version: 1.92.0-SNAPSHOT
     apis:
       - path: google/cloud/video/transcoder/v1
-    keep:
-      - google-cloud-video-transcoder/src/main/java/com/google/cloud/video/transcoder/v1/stub/Version.java
     java:
       api_id_override: transcoder.googleapis.com
       api_description_override: allows you to transcode videos into a variety of formats. The Transcoder API benefits broadcasters, production companies, businesses, and individuals looking to transform their video content for use across a variety of user devices.
+      released_version: 1.91.0
       name_pretty_override: Video Transcoder
       product_documentation_override: https://cloud.google.com/transcoder/docs
       rest_documentation: https://cloud.google.com/transcoder/docs/reference/rest
@@ -4342,11 +3986,6 @@ libraries:
       - path: google/cloud/vision/v1p2beta1
       - path: google/cloud/vision/v1p1beta1
     keep:
-      - google-cloud-vision/src/main/java/com/google/cloud/vision/v1/stub/Version.java
-      - google-cloud-vision/src/main/java/com/google/cloud/vision/v1p1beta1/stub/Version.java
-      - google-cloud-vision/src/main/java/com/google/cloud/vision/v1p2beta1/stub/Version.java
-      - google-cloud-vision/src/main/java/com/google/cloud/vision/v1p3beta1/stub/Version.java
-      - google-cloud-vision/src/main/java/com/google/cloud/vision/v1p4beta1/stub/Version.java
       - google-cloud-vision/src/test/java/com/google/cloud/vision/it/ITSystemTest.java
       - google-cloud-vision/src/test/resources/city.jpg
       - google-cloud-vision/src/test/resources/face_no_surprise.jpg
@@ -4359,6 +3998,7 @@ libraries:
     java:
       api_description_override: allows developers to easily integrate vision detection features within applications, including image labeling, face and landmark detection, optical character recognition (OCR), and tagging of explicit content.
       issue_tracker_override: https://issuetracker.google.com/issues?q=status:open%20componentid:187174
+      released_version: 3.90.0
       name_pretty_override: Cloud Vision
       product_documentation_override: https://cloud.google.com/vision/docs/
       rest_documentation: https://cloud.google.com/vision/docs/reference/rest
@@ -4371,12 +4011,11 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-visionai/src/main/java/com/google/cloud/visionai/v1/stub/Version.java
     java:
       api_id_override: visionai.googleapis.com
       api_description_override: Vertex AI Vision is an AI-powered platform to ingest, analyze and store video data.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-visionai/latest/overview
+      released_version: 0.49.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Vision AI API
       product_documentation_override: https://cloud.google.com/vision-ai/docs
@@ -4389,10 +4028,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-vmmigration/src/main/java/com/google/cloud/vmmigration/v1/stub/Version.java
     java:
       api_description_override: helps customers migrating VMs to GCP at no additional cost, as well as an extensive ecosystem of partners to help with discovery and assessment, planning, migration, special use cases, and more.
+      released_version: 1.92.0
       name_pretty_override: VM Migration
       product_documentation_override: n/a
   - name: vmwareengine
@@ -4403,10 +4041,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-vmwareengine/src/main/java/com/google/cloud/vmwareengine/v1/stub/Version.java
     java:
       api_description_override: Easily lift and shift your VMware-based applications to Google Cloud without changes to your apps, tools, or processes.
+      released_version: 0.86.0
       name_pretty_override: Google Cloud VMware Engine
       product_documentation_override: https://cloud.google.com/vmware-engine/
       rest_documentation: https://cloud.google.com/vmware-engine/docs/reference/rest
@@ -4417,10 +4054,9 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-vpcaccess/src/main/java/com/google/cloud/vpcaccess/v1/stub/Version.java
     java:
       api_description_override: enables you to connect from a serverless environment on Google Cloud directly to your VPC network. This connection makes it possible for your serverless environment to access resources in your VPC network via internal IP addresses.
+      released_version: 2.93.0
       name_pretty_override: Serverless VPC Access
       product_documentation_override: https://cloud.google.com/vpc/docs/serverless-vpc-access
   - name: webrisk
@@ -4428,11 +4064,9 @@ libraries:
     apis:
       - path: google/cloud/webrisk/v1
       - path: google/cloud/webrisk/v1beta1
-    keep:
-      - google-cloud-webrisk/src/main/java/com/google/cloud/webrisk/v1/stub/Version.java
-      - google-cloud-webrisk/src/main/java/com/google/cloud/webrisk/v1beta1/stub/Version.java
     java:
       api_description_override: is a Google Cloud service that lets client applications check URLs against Google's constantly updated lists of unsafe web resources. Unsafe web resources include social engineering sites - such as phishing and deceptive sites - and sites that host malware or unwanted software. With the Web Risk API, you can quickly identify known bad sites, warn users before they click infected links, and prevent users from posting links to known infected pages from your site. The Web Risk API includes data on more than a million unsafe URLs and stays up to date by examining billions of URLs each day.
+      released_version: 2.91.0
       name_pretty_override: Web Risk
       product_documentation_override: https://cloud.google.com/web-risk/docs/
       billing_not_required: true
@@ -4445,14 +4079,12 @@ libraries:
       - path: google/cloud/websecurityscanner/v1beta
       - path: google/cloud/websecurityscanner/v1alpha
     keep:
-      - google-cloud-websecurityscanner/src/main/java/com/google/cloud/websecurityscanner/v1/stub/Version.java
-      - google-cloud-websecurityscanner/src/main/java/com/google/cloud/websecurityscanner/v1alpha/stub/Version.java
-      - google-cloud-websecurityscanner/src/main/java/com/google/cloud/websecurityscanner/v1beta/stub/Version.java
       - google-cloud-websecurityscanner/src/test/java/com/google/cloud/websecurityscanner/it/v1beta/VPCServiceControlNegativeTest.java
       - google-cloud-websecurityscanner/src/test/java/com/google/cloud/websecurityscanner/it/v1beta/VPCServiceControlPositiveTest.java
     java:
       api_description_override: identifies security vulnerabilities in your App Engine, Compute Engine, and Google Kubernetes Engine web applications. It crawls your application, following all links within the scope of your starting URLs, and attempts to exercise as many user inputs and event handlers as possible.
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559748
+      released_version: 2.92.0
       name_pretty_override: Cloud Security Scanner
       product_documentation_override: https://cloud.google.com/security-scanner/docs/
       billing_not_required: true
@@ -4461,12 +4093,10 @@ libraries:
     apis:
       - path: google/cloud/workflows/executions/v1
       - path: google/cloud/workflows/executions/v1beta
-    keep:
-      - google-cloud-workflow-executions/src/main/java/com/google/cloud/workflows/executions/v1/stub/Version.java
-      - google-cloud-workflow-executions/src/main/java/com/google/cloud/workflows/executions/v1beta/stub/Version.java
     java:
       api_description_override: allows you to ochestrate and automate Google Cloud and HTTP-based API services with serverless workflows.
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 2.92.0
       name_pretty_override: Cloud Workflow Executions
       product_documentation_override: https://cloud.google.com/workflows
       rest_documentation: https://cloud.google.com/workflows/docs/reference/rest
@@ -4481,12 +4111,10 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-workflows/src/main/java/com/google/cloud/workflows/v1/stub/Version.java
-      - google-cloud-workflows/src/main/java/com/google/cloud/workflows/v1beta/stub/Version.java
     java:
       api_description_override: allows you to ochestrate and automate Google Cloud and HTTP-based API services with serverless workflows.
       codeowner_team: '@googleapis/aap-dpes'
+      released_version: 2.92.0
       name_pretty_override: Cloud Workflows
       product_documentation_override: https://cloud.google.com/workflows
       rest_documentation: https://cloud.google.com/workflows/docs/reference/rest
@@ -4497,12 +4125,11 @@ libraries:
         java:
           additional_protos:
             - path: google/cloud/location/locations.proto
-    keep:
-      - google-cloud-workloadmanager/src/main/java/com/google/cloud/workloadmanager/v1/stub/Version.java
     java:
       api_id_override: workloadmanager.googleapis.com
       api_description_override: Workload Manager is a service that provides tooling for enterprise workloads to automate the deployment and validation of your workloads against best practices and recommendations.
       client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-workloadmanager/latest/overview
+      released_version: 0.8.0
       library_type_override: GAPIC_AUTO
       name_pretty_override: Workload Manager API
       product_documentation_override: https://docs.cloud.google.com/workload-manager/docs
@@ -4512,11 +4139,9 @@ libraries:
     apis:
       - path: google/apps/events/subscriptions/v1
       - path: google/apps/events/subscriptions/v1beta
-    keep:
-      - google-cloud-workspaceevents/src/main/java/com/google/apps/events/subscriptions/v1/stub/Version.java
-      - google-cloud-workspaceevents/src/main/java/com/google/apps/events/subscriptions/v1beta/stub/Version.java
     java:
       api_description_override: The Google Workspace Events API lets you subscribe to events and manage change notifications across Google Workspace applications.
+      released_version: 0.56.0
       name_pretty_override: Google Workspace Events API
       product_documentation_override: https://developers.google.com/workspace/events
       rest_documentation: https://developers.google.com/workspace/events/reference/rest
@@ -4533,11 +4158,9 @@ libraries:
           additional_protos:
             - path: google/cloud/location/locations.proto
             - path: google/iam/v1/iam_policy.proto
-    keep:
-      - google-cloud-workstations/src/main/java/com/google/cloud/workstations/v1/stub/Version.java
-      - google-cloud-workstations/src/main/java/com/google/cloud/workstations/v1beta/stub/Version.java
     java:
       api_description_override: Fully managed development environments built to meet the needs of security-sensitive enterprises. It enhances the security of development environments while accelerating developer onboarding and productivity.
+      released_version: 0.80.0
       name_pretty_override: Cloud Workstations
       product_documentation_override: https://cloud.google.com/workstations
       rest_documentation: https://cloud.google.com/workstations/docs/reference/rest

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.15.0
 repo: googleapis/google-cloud-java
 sources:
   googleapis:
-    commit: 3aa565f453bae9dcef06685a6f84b6e48ccdf335
-    sha256: 1e65551719e3fb01f52f4da4373e222e4ee46df985b34ae40e6d06f79b0080cc
+    commit: dae2a496666e372c1ebf56ceb54fe7f467a2c10e
+    sha256: 867490e3ce7818a2011475a888ce5d77c68cb7a13764f47d9aec8cf3038320e0
   showcase:
     commit: 328bec7ce4c1fb77c37fdf1868d0506bc02a70fc
     sha256: 8df187486e37edf5a78c1646c859c311bc452871b9ba4641d93149d3c53450a2
@@ -49,7 +48,7 @@ tools:
       local_path: sdk-platform-java/hermetic_build/library_generation
 default:
   java:
-    libraries_bom_version: 26.82.0
+    libraries_bom_version: 26.83.0
 libraries:
   - name: accessapproval
     version: 2.94.0-SNAPSHOT
@@ -1576,6 +1575,18 @@ libraries:
       library_type_override: GAPIC_AUTO
       name_pretty_override: Developer Connect API
       product_documentation_override: https://cloud.google.com/developer-connect/docs/overview
+  - name: developerknowledge
+    version: 0.0.1-SNAPSHOT
+    apis:
+      - path: google/developers/knowledge/v1
+    java:
+      api_id_override: developerknowledge.googleapis.com
+      api_description_override: The Developer Knowledge API provides access to Google's developer knowledge
+      artifact_id: google-cloud-developer-knowledge
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-developer-knowledge/latest/overview
+      library_type_override: GAPIC_AUTO
+      name_pretty_override: Developer Knowledge API
+      product_documentation_override: https://developers.google.com/knowledge
   - name: devicestreaming
     version: 0.33.0-SNAPSHOT
     apis:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.15.1-0.20260601155236-20ff0d932dcc
+version: v0.16.1-0.20260602193207-5917f20190fa
 repo: googleapis/google-cloud-java
 sources:
   googleapis:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1828,6 +1828,10 @@ libraries:
   - name: geminidataanalytics
     version: 0.21.0-SNAPSHOT
     apis:
+      - path: google/cloud/geminidataanalytics/v1
+        java:
+          additional_protos:
+            - path: google/cloud/location/locations.proto
       - path: google/cloud/geminidataanalytics/v1beta
         java:
           additional_protos:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
+version: v0.15.0
 repo: googleapis/google-cloud-java
 sources:
   googleapis:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.15.0
+version: v0.15.1-0.20260601155236-20ff0d932dcc
 repo: googleapis/google-cloud-java
 sources:
   googleapis:


### PR DESCRIPTION
Sync librarian.yaml with generation_config.yaml for latest changes, including googleapis commit change, new library addition and libraries bom version.
Update librarian version, which brings in changes from https://github.com/googleapis/librarian/pull/6252 and https://github.com/googleapis/librarian/pull/6125.

This change is made be following steps:

- `migrate .` syn generation_config.yaml changes
- set librarian pseudo version
```
PSEUDO=$(GOPROXY=direct go list -m -f '{{.Version}}' [github.com/googleapis/librarian@main](http://github.com/googleapis/librarian@main))
```


For https://github.com/googleapis/librarian/issues/6173