### PR TITLE
fix(bigquery-jdbc): implement JDBC wrapper interface methods

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -674,4 +674,17 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
   public Timestamp getTimestamp(String columnLabel, Calendar cal) throws SQLException {
     return getTimestamp(getColumnIndex(columnLabel), cal);
   }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    if (iface.isInstance(this)) {
+      return iface.cast(this);
+    }
+    throw new SQLException("Cannot unwrap to " + iface.getName());
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return iface != null && iface.isInstance(this);
+  }
 }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSet.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.exception.BigQueryConversionException;
 import com.google.cloud.bigquery.exception.BigQueryJdbcCoercionException;
 import com.google.cloud.bigquery.exception.BigQueryJdbcCoercionNotFoundException;
+import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
@@ -680,7 +681,7 @@ public abstract class BigQueryBaseResultSet extends BigQueryNoOpsResultSet
     if (iface.isInstance(this)) {
       return iface.cast(this);
     }
-    throw new SQLException("Cannot unwrap to " + iface.getName());
+    throw new BigQueryJdbcException("Cannot unwrap to " + iface.getName());
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1220,4 +1220,17 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     }
     return false;
   }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    if (iface.isInstance(this)) {
+      return iface.cast(this);
+    }
+    throw new SQLException("Cannot unwrap to " + iface.getName());
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return iface != null && iface.isInstance(this);
+  }
 }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1226,7 +1226,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
     if (iface.isInstance(this)) {
       return iface.cast(this);
     }
-    throw new SQLException("Cannot unwrap to " + iface.getName());
+    throw new BigQueryJdbcException("Cannot unwrap to " + iface.getName());
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -4756,7 +4756,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     if (iface.isInstance(this)) {
       return iface.cast(this);
     }
-    throw new SQLException("Cannot unwrap to " + iface.getName());
+    throw new BigQueryJdbcException("Cannot unwrap to " + iface.getName());
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsConnection.java
@@ -48,16 +48,6 @@ abstract class BigQueryNoOpsConnection implements Connection {
   }
 
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
-    throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
-  }
-
-  @Override
-  public boolean isWrapperFor(Class<?> iface) {
-    return false;
-  }
-
-  @Override
   public boolean isReadOnly() {
     return false;
   }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsConnection.java
@@ -58,8 +58,6 @@ abstract class BigQueryNoOpsConnection implements Connection {
   @Override
   public void setCatalog(String catalog) {}
 
-  // TODO: post MVP feature
-
   @Override
   public Map<String, Class<?>> getTypeMap() throws SQLException {
     throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsResultSet.java
@@ -656,16 +656,6 @@ abstract class BigQueryNoOpsResultSet implements ResultSet {
   }
 
   @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
-    throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
-  }
-
-  @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
-    throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
-  }
-
-  @Override
   public SQLWarning getWarnings() throws SQLException {
     throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
   }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsStatement.java
@@ -27,17 +27,6 @@ abstract class BigQueryNoOpsStatement implements Statement {
 
   @Override
   public void setCursorName(String name) throws SQLException {
-    // TODO: ResultSet Concurrency is read only(Not updatable)
-    throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
-  }
-
-  @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
-    throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
-  }
-
-  @Override
-  public boolean isWrapperFor(Class<?> iface) throws SQLException {
     throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
   }
 

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryNoOpsStatement.java
@@ -32,8 +32,6 @@ abstract class BigQueryNoOpsStatement implements Statement {
 
   @Override
   public ResultSet getGeneratedKeys() throws SQLException {
-    // TODO: Returns an empty resultset.
-    // return empty ResultSet
     throw new BigQueryJdbcSqlFeatureNotSupportedException(METHOD_NOT_IMPLEMENTED);
   }
 

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Field.Mode;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -209,7 +210,7 @@ class BigQueryResultSetMetadata implements ResultSetMetaData {
     if (iface.isInstance(this)) {
       return iface.cast(this);
     }
-    throw new SQLException("Cannot unwrap to " + iface.getName());
+    throw new BigQueryJdbcException("Cannot unwrap to " + iface.getName());
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -1608,7 +1608,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     if (iface.isInstance(this)) {
       return iface.cast(this);
     }
-    throw new SQLException("Cannot unwrap to " + iface.getName());
+    throw new BigQueryJdbcException("Cannot unwrap to " + iface.getName());
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -1574,20 +1574,6 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) {
-    return iface.isInstance(this);
-  }
-
-  @Override
-  public <T> T unwrap(Class<T> iface) throws SQLException {
-    if (!isWrapperFor(iface)) {
-      throw new BigQueryJdbcException(
-          String.format("Unable to cast Statement to %s class.", iface.getName()));
-    }
-    return (T) this;
-  }
-
-  @Override
   public int getResultSetHoldability() {
     return ResultSet.CLOSE_CURSORS_AT_COMMIT;
   }
@@ -1615,6 +1601,19 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   @Override
   public boolean isCloseOnCompletion() {
     return this.closeOnCompletion;
+  }
+
+  @Override
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    if (iface.isInstance(this)) {
+      return iface.cast(this);
+    }
+    throw new SQLException("Cannot unwrap to " + iface.getName());
+  }
+
+  @Override
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return iface != null && iface.isInstance(this);
   }
 
   protected void logQueryExecutionStart(String sql) {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
@@ -1372,7 +1372,7 @@ public class DataSource implements javax.sql.DataSource {
     if (iface.isInstance(this)) {
       return iface.cast(this);
     }
-    throw new SQLException("Cannot unwrap to " + iface.getName());
+    throw new BigQueryJdbcException("Cannot unwrap to " + iface.getName());
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
@@ -1368,13 +1368,16 @@ public class DataSource implements javax.sql.DataSource {
   }
 
   @Override
-  public <T> T unwrap(Class<T> iface) {
-    return null;
+  public <T> T unwrap(Class<T> iface) throws SQLException {
+    if (iface.isInstance(this)) {
+      return iface.cast(this);
+    }
+    throw new SQLException("Cannot unwrap to " + iface.getName());
   }
 
   @Override
-  public boolean isWrapperFor(Class<?> iface) {
-    return false;
+  public boolean isWrapperFor(Class<?> iface) throws SQLException {
+    return iface != null && iface.isInstance(this);
   }
 
   private static void validateNonNegative(long val, String propertyName) {

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSetTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSetTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics;
+import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import java.lang.reflect.Field;
 import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeEach;
@@ -119,8 +120,8 @@ public class BigQueryBaseResultSetTest {
     Object unwrappedImpl = resultSet.unwrap(BigQueryBaseResultSet.class);
     assertSame(unwrappedImpl, resultSet);
 
-    SQLException e =
-        assertThrows(SQLException.class, () -> resultSet.unwrap(java.sql.Statement.class));
+    BigQueryJdbcException e =
+        assertThrows(BigQueryJdbcException.class, () -> resultSet.unwrap(java.sql.Statement.class));
     assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Statement"));
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSetTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryBaseResultSetTest.java
@@ -18,6 +18,9 @@ package com.google.cloud.bigquery.jdbc;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
@@ -28,6 +31,7 @@ import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics;
 import java.lang.reflect.Field;
+import java.sql.SQLException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -100,5 +104,23 @@ public class BigQueryBaseResultSetTest {
   public void testGetQueryStatistics_no_job() {
     doReturn(job).when(bigQuery).getJob(any(JobId.class));
     assertThat(resultSet.getQueryStatistics()).isNull();
+  }
+
+  @Test
+  public void testWrapperMethods() throws SQLException {
+    assertTrue(resultSet.isWrapperFor(java.sql.ResultSet.class));
+    assertTrue(resultSet.isWrapperFor(BigQueryBaseResultSet.class));
+    assertFalse(resultSet.isWrapperFor(java.sql.Statement.class));
+    assertFalse(resultSet.isWrapperFor(null));
+
+    Object unwrappedRs = resultSet.unwrap(java.sql.ResultSet.class);
+    assertSame(unwrappedRs, resultSet);
+
+    Object unwrappedImpl = resultSet.unwrap(BigQueryBaseResultSet.class);
+    assertSame(unwrappedImpl, resultSet);
+
+    SQLException e =
+        assertThrows(SQLException.class, () -> resultSet.unwrap(java.sql.Statement.class));
+    assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Statement"));
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
@@ -494,6 +496,26 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
       assertFalse(logMessage.contains("secretAccessToken"));
     } finally {
       rootLogger.setLevel(originalLevel);
+    }
+  }
+
+  @Test
+  public void testWrapperMethods() throws Exception {
+    try (BigQueryConnection connection = new BigQueryConnection(BASE_URL)) {
+      assertTrue(connection.isWrapperFor(java.sql.Connection.class));
+      assertTrue(connection.isWrapperFor(BigQueryConnection.class));
+      assertFalse(connection.isWrapperFor(java.sql.Statement.class));
+      assertFalse(connection.isWrapperFor(null));
+
+      Object unwrappedConn = connection.unwrap(java.sql.Connection.class);
+      assertSame(unwrappedConn, connection);
+
+      Object unwrappedImpl = connection.unwrap(BigQueryConnection.class);
+      assertSame(unwrappedImpl, connection);
+
+      SQLException e =
+          assertThrows(SQLException.class, () -> connection.unwrap(java.sql.Statement.class));
+      assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Statement"));
     }
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -513,8 +513,9 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
       Object unwrappedImpl = connection.unwrap(BigQueryConnection.class);
       assertSame(unwrappedImpl, connection);
 
-      SQLException e =
-          assertThrows(SQLException.class, () -> connection.unwrap(java.sql.Statement.class));
+      BigQueryJdbcException e =
+          assertThrows(
+              BigQueryJdbcException.class, () -> connection.unwrap(java.sql.Statement.class));
       assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Statement"));
     }
   }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.*;
 import com.google.api.gax.paging.Page;
 import com.google.cloud.bigquery.*;
 import com.google.cloud.bigquery.BigQuery.RoutineListOption;
+import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.DatabaseMetaData;
@@ -3259,8 +3260,9 @@ public class BigQueryDatabaseMetaDataTest {
     assertSame(dbMetadata, dbMetadata.unwrap(DatabaseMetaData.class));
     assertSame(dbMetadata, dbMetadata.unwrap(BigQueryDatabaseMetaData.class));
 
-    SQLException e =
-        assertThrows(SQLException.class, () -> dbMetadata.unwrap(java.sql.Connection.class));
+    BigQueryJdbcException e =
+        assertThrows(
+            BigQueryJdbcException.class, () -> dbMetadata.unwrap(java.sql.Connection.class));
     assertThat((Throwable) e).hasMessageThat().contains("Cannot unwrap to java.sql.Connection");
   }
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadataTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import com.google.common.collect.ImmutableList;
 import java.sql.Array;
 import java.sql.ResultSetMetaData;
@@ -293,8 +294,9 @@ public class BigQueryResultSetMetadataTest {
     assertThat(unwrappedImpl).isNotSameInstanceAs(resultSetMetaData);
     assertThat(unwrappedImpl).isInstanceOf(BigQueryResultSetMetadata.class);
 
-    SQLException e =
-        assertThrows(SQLException.class, () -> resultSetMetaData.unwrap(java.sql.Connection.class));
+    BigQueryJdbcException e =
+        assertThrows(
+            BigQueryJdbcException.class, () -> resultSetMetaData.unwrap(java.sql.Connection.class));
     assertThat((Throwable) e).hasMessageThat().contains("Cannot unwrap to java.sql.Connection");
   }
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -684,9 +684,9 @@ public class BigQueryStatementTest {
     Object unwrappedImpl = bigQueryStatement.unwrap(BigQueryStatement.class);
     org.junit.jupiter.api.Assertions.assertSame(unwrappedImpl, bigQueryStatement);
 
-    SQLException e =
+    BigQueryJdbcException e =
         org.junit.jupiter.api.Assertions.assertThrows(
-            SQLException.class, () -> bigQueryStatement.unwrap(java.sql.Connection.class));
+            BigQueryJdbcException.class, () -> bigQueryStatement.unwrap(java.sql.Connection.class));
     assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Connection"));
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigquery.jdbc;
 import static com.google.cloud.bigquery.jdbc.utils.ArrowUtilities.serializeSchema;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -668,5 +669,24 @@ public class BigQueryStatementTest {
     // This should not throw ArithmeticException (/ by zero) and should evaluate safely
     boolean useReadApi = statement.useReadAPI(tableResult);
     assertThat(useReadApi).isTrue(); // ratio = 500 / 1 = 500 > 2 -> true
+  }
+
+  @Test
+  public void testWrapperMethods() throws SQLException {
+    assertTrue(bigQueryStatement.isWrapperFor(java.sql.Statement.class));
+    assertTrue(bigQueryStatement.isWrapperFor(BigQueryStatement.class));
+    assertFalse(bigQueryStatement.isWrapperFor(java.sql.Connection.class));
+    assertFalse(bigQueryStatement.isWrapperFor(null));
+
+    Object unwrappedStmt = bigQueryStatement.unwrap(java.sql.Statement.class);
+    org.junit.jupiter.api.Assertions.assertSame(unwrappedStmt, bigQueryStatement);
+
+    Object unwrappedImpl = bigQueryStatement.unwrap(BigQueryStatement.class);
+    org.junit.jupiter.api.Assertions.assertSame(unwrappedImpl, bigQueryStatement);
+
+    SQLException e =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            SQLException.class, () -> bigQueryStatement.unwrap(java.sql.Connection.class));
+    assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Connection"));
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/DataSourceTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/DataSourceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery.jdbc;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import org.junit.jupiter.api.Test;
+
+public class DataSourceTest {
+
+  @Test
+  public void testWrapperMethods() throws SQLException {
+    DataSource dataSource = new DataSource();
+    assertTrue(dataSource.isWrapperFor(javax.sql.DataSource.class));
+    assertTrue(dataSource.isWrapperFor(DataSource.class));
+    assertFalse(dataSource.isWrapperFor(java.sql.Connection.class));
+    assertFalse(dataSource.isWrapperFor(null));
+
+    Object unwrappedDs = dataSource.unwrap(javax.sql.DataSource.class);
+    assertSame(unwrappedDs, dataSource);
+
+    Object unwrappedImpl = dataSource.unwrap(DataSource.class);
+    assertSame(unwrappedImpl, dataSource);
+
+    SQLException e =
+        assertThrows(SQLException.class, () -> dataSource.unwrap(java.sql.Connection.class));
+    assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Connection"));
+  }
+}

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/DataSourceTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/DataSourceTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import java.sql.SQLException;
 import org.junit.jupiter.api.Test;
 
@@ -40,8 +41,9 @@ public class DataSourceTest {
     Object unwrappedImpl = dataSource.unwrap(DataSource.class);
     assertSame(unwrappedImpl, dataSource);
 
-    SQLException e =
-        assertThrows(SQLException.class, () -> dataSource.unwrap(java.sql.Connection.class));
+    BigQueryJdbcException e =
+        assertThrows(
+            BigQueryJdbcException.class, () -> dataSource.unwrap(java.sql.Connection.class));
     assertTrue(e.getMessage().contains("Cannot unwrap to java.sql.Connection"));
   }
 }


### PR DESCRIPTION
b/473601569

# Description
Standardize and relocate JDBC `Wrapper` interface methods (`unwrap` and `isWrapperFor`) in the BigQuery JDBC driver.

### Key Changes
- **Removed placeholder stubs from NoOps classes:**
  - Removed `unwrap` and `isWrapperFor` from `BigQueryNoOpsConnection`, `BigQueryNoOpsStatement`, and `BigQueryNoOpsResultSet`.
- **Implemented spec-compliant wrapper logic:**
  - Added `unwrap` and `isWrapperFor` to `BigQueryConnection`, `BigQueryStatement`, and `BigQueryBaseResultSet` (enabling support across all concrete statements/result sets via inheritance).
  - Ensured `DataSource` also supports compliant `unwrap` and `isWrapperFor` checks.
- **Unit Testing:**
  - Added wrapper unit tests in `BigQueryConnectionTest`, `BigQueryStatementTest`, `BigQueryBaseResultSetTest`, and created a new `DataSourceTest`.
