### PR TITLE
chore: always run units jobs with step-level skips

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,6 @@ jobs:
   units:
     runs-on: ubuntu-latest
     needs: bulk-filter
-    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -64,54 +63,64 @@ jobs:
     steps:
     - name: Get current week within the year
       id: date
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@v4
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     - uses: actions/setup-java@v4
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       with:
         distribution: temurin
         java-version: ${{matrix.java}}
     - run: java -version
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     - uses: actions/cache@v4
       id: mvn-cache
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.week_of_year }}
     - run: .kokoro/build.sh
-      if: ${{ needs.bulk-filter.outputs.src == 'true' || needs.bulk-filter.outputs.ci == 'true' }}
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' && (needs.bulk-filter.outputs.src == 'true' || needs.bulk-filter.outputs.ci == 'true') }}
       env:
         JOB_TYPE: test
         JOB_NAME: units-${{matrix.java}}
   units-8-runtime:
     runs-on: ubuntu-latest
     needs: bulk-filter
-    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     name: "units (8)"
     steps:
     - name: Get current week within the year
       id: date
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@v4
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     - uses: actions/setup-java@v4
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       with:
         java-version: 8
         distribution: temurin
     - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
       # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
       # https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#jvm
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       run: echo "SUREFIRE_JVM_OPT=-Djvm=${JAVA_HOME}/bin/java" >> $GITHUB_ENV
       shell: bash    
     - uses: actions/setup-java@v4
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       with:
         java-version: 11
         distribution: temurin
         cache: maven
     - uses: actions/cache@v4
       id: mvn-cache
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.week_of_year }}
     - run: .kokoro/build.sh
-      if: ${{ needs.bulk-filter.outputs.src == 'true' || needs.bulk-filter.outputs.ci == 'true' }}
+      if: ${{ needs.bulk-filter.outputs.runnable == 'true' && (needs.bulk-filter.outputs.src == 'true' || needs.bulk-filter.outputs.ci == 'true') }}
       shell: bash      
       env:
         JOB_TYPE: test


### PR DESCRIPTION
### Description

This PR solves the issue where required checks `units (11)`, `units (17)`, `units (21)`, `units (25)`, and `units (8)` get stuck in a pending "stuck forever" state on GitHub.

For example, https://screenshot.googleplex.com/9bpNwWP7jParbuM

### Root Cause
The `units` and `units-8-runtime` jobs in `.github/workflows/ci.yaml` are conditionally skipped using job-level `if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}`.
Because the entire job is skipped at the job-level, the matrix versions are not expanded, and status checks like `units (11)` are never reported to GitHub. When these checks are configured directly as required status checks in branch protection rules, PRs that skip the jobs (e.g., workflow-only PRs) are stuck forever.

### Solution
We removed the job-level `if: runnable == true` conditional from both `units` and `units-8-runtime` jobs so they always start. Instead, we applied the `if: runnable == true` check to every individual step inside these jobs.
When a PR doesn't need to run these checks:
1. The jobs will still start and run.
2. All steps will skip instantly.
3. The jobs will finish successfully in 1–2 seconds, reporting success and satisfying GitHub's required status checks.
