### PR TITLE
fix(hermetic_build): restore Version.java after postprocessing entrypoint

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/postprocess_library.sh
+++ b/sdk-platform-java/hermetic_build/library_generation/postprocess_library.sh
@@ -96,9 +96,6 @@ owl-bot copy-code \
   --source-repo="${owlbot_cli_source_folder}" \
   --config-file="${owlbot_yaml_relative_path}"
 
-restore_version_java "${PWD}" "${backup_dir}"
-rm -rf "${backup_dir}"
-
 
 # clean the custom owlbot yaml
 if [[ "${is_monorepo}" == "true" ]]; then
@@ -115,4 +112,8 @@ bash "${scripts_root}/owlbot/bin/entrypoint.sh" \
   "${libraries_bom_version}" \
   "${library_version}"
 
+restore_version_java "${PWD}" "${backup_dir}"
+rm -rf "${backup_dir}"
+
 popd # postprocessing_target
+


### PR DESCRIPTION
PR containing the postprocessing fix that restores Version.java after the owlbot entrypoint execution, resolving the missing Version.java issue in newly generated library versions.

Demo: https://github.com/googleapis/google-cloud-java/pull/13330