### PR TITLE
fix(gapic-generator): allow non-versioned proto paths and correct help text

### DIFF
--- a/generation/new_client_hermetic_build/add-new-client-config.py
+++ b/generation/new_client_hermetic_build/add-new-client-config.py
@@ -61,10 +61,10 @@ def main(ctx):
     required=True,
     type=str,
     default=None,
-    help="Path to proto file from the root of the googleapis repository to the"
-    "directory that contains the proto files (without the version)."
+    help="Path to proto file from the root of the googleapis repository to the "
+    "directory that contains the proto files (including the version). "
     "For example, to generate the library for 'google/maps/routing/v2', "
-    "then you specify this value as 'google/maps/routing'",
+    "then you specify this value as 'google/maps/routing/v2'",
 )
 @click.option(
     "--product-docs",
@@ -221,9 +221,10 @@ def add_new_library(
     version_re = re.compile(r"v\d[\w\d]*")
     is_library_version = lambda p: version_re.match(p.split("/")[-1]) is not None
     if not is_library_version(proto_path):
-        raise ValueError(
-            "Only versioned proto_paths are supported. "
-            "For example `google/datastore/v1` instead of `google/datastore`."
+        print(
+            f"WARNING: proto_path '{proto_path}' does not end with a version (e.g., v1). "
+            "Please ensure this is intentional and that this represents a non-versioned "
+            "or custom proto path."
         )
 
     new_library = {


### PR DESCRIPTION
New library generation [failed](https://github.com/googleapis/google-cloud-java/actions/runs/26787296071/job/78965954089) with the error below
```
ValueError: Only versioned proto_paths are supported. For example `google/datastore/v1` instead of `google/datastore`.

```

Relax version validation in add-new-client-config.py from a hard ValueError to a warning. This allows onboarding APIs with non-versioned proto paths like chronicle backstory. Also corrected the misleading CLI help text for --proto-path.