### PR TITLE
fix(auth): Skip RAB lookup in case of non-email response from MDS.

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -805,6 +805,11 @@ public class ComputeEngineCredentials extends GoogleCredentials
     // Since RAB lookup requires a valid email-based service account, we skip RAB lookup
     // in non-email scenarios by returning null.
     if (account == null || !account.contains("@")) {
+      LoggingUtils.log(
+          LOGGER_PROVIDER,
+          Level.INFO,
+          Collections.emptyMap(),
+          "Regional Access Boundary lookup is skipped for this instance because it is a non-email instance.");
       return null;
     }
     return String.format(

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -800,8 +800,15 @@ public class ComputeEngineCredentials extends GoogleCredentials
   @InternalApi
   @Override
   public String getRegionalAccessBoundaryUrl() throws IOException {
+    String account = getAccount();
+    // In GKE environments, the default service account might return a non-email placeholder.
+    // Since RAB lookup requires a valid email-based service account, we skip RAB lookup
+    // in non-email scenarios by returning null.
+    if (account == null || !account.contains("@")) {
+      return null;
+    }
     return String.format(
-        OAuth2Utils.IAM_CREDENTIALS_ALLOWED_LOCATIONS_URL_FORMAT_SERVICE_ACCOUNT, getAccount());
+        OAuth2Utils.IAM_CREDENTIALS_ALLOWED_LOCATIONS_URL_FORMAT_SERVICE_ACCOUNT, account);
   }
 
   /**

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -72,6 +72,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 
 /**
  * OAuth2 credentials representing the built-in service account for a Google Compute Engine VM.
@@ -117,6 +118,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
 
   private static final String PARSE_ERROR_PREFIX = "Error parsing token refresh response. ";
   private static final String PARSE_ERROR_ACCOUNT = "Error parsing service account response. ";
+  private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^@]+@[^@]+\\.[^@]+$");
   private static final long serialVersionUID = -4113476462526554235L;
 
   private final String transportFactoryClassName;
@@ -804,7 +806,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
     // In GKE environments, the default service account might return a non-email placeholder.
     // Since RAB lookup requires a valid email-based service account, we skip RAB lookup
     // in non-email scenarios by returning null.
-    if (account == null || !account.contains("@")) {
+    if (account == null || !EMAIL_PATTERN.matcher(account).matches()) {
       LoggingUtils.log(
           LOGGER_PROVIDER,
           Level.INFO,

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -803,15 +803,14 @@ public class ComputeEngineCredentials extends GoogleCredentials
   @Override
   public String getRegionalAccessBoundaryUrl() throws IOException {
     String account = getAccount();
-    // In GKE environments, the default service account might return a non-email placeholder.
-    // Since RAB lookup requires a valid email-based service account, we skip RAB lookup
-    // in non-email scenarios by returning null.
+    // The MDS may return a non-email value for the account and we should skip RAB refresh in that
+    // scenario.
     if (account == null || !EMAIL_PATTERN.matcher(account).matches()) {
       LoggingUtils.log(
           LOGGER_PROVIDER,
           Level.INFO,
           Collections.emptyMap(),
-          "Regional Access Boundary lookup is skipped for this instance because it is a non-email instance.");
+          "Unable to retrieve this instance's email and will skip the regional request routing. Proceeding with request");
       return null;
     }
     return String.format(

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -37,7 +37,6 @@ import com.google.api.client.util.Clock;
 import com.google.api.core.InternalApi;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.util.concurrent.SettableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -76,12 +75,10 @@ final class RegionalAccessBoundaryManager {
   private final AtomicReference<RegionalAccessBoundary> cachedRAB = new AtomicReference<>();
 
   /**
-   * refreshFuture acts as an atomic gate for request de-duplication. If a future is present, it
-   * indicates a background refresh is already in progress. It also provides a handle for
-   * observability and unit testing to track the background task's lifecycle.
+   * isRefreshing acts as an atomic gate for request de-duplication. If true, it indicates a
+   * background refresh is already in progress.
    */
-  private final AtomicReference<SettableFuture<RegionalAccessBoundary>> refreshFuture =
-      new AtomicReference<>();
+  private final AtomicBoolean isRefreshing = new AtomicBoolean(false);
 
   private final AtomicReference<CooldownState> cooldownState =
       new AtomicReference<>(new CooldownState(0, INITIAL_COOLDOWN_MILLIS));
@@ -190,18 +187,16 @@ final class RegionalAccessBoundaryManager {
       return;
     }
 
-    SettableFuture<RegionalAccessBoundary> future = SettableFuture.create();
     // Atomically check if a refresh is already running. If compareAndSet returns true,
     // this thread "won the race" and is responsible for starting the background task.
     // All other concurrent threads will return false and exit immediately.
-    if (refreshFuture.compareAndSet(null, future)) {
+    if (isRefreshing.compareAndSet(false, true)) {
       Runnable refreshTask =
           () -> {
             try {
               String url = provider.getRegionalAccessBoundaryUrl();
               if (url == null) {
                 skipRAB.set(true);
-                future.set(null);
                 return;
               }
               RegionalAccessBoundary newRAB =
@@ -209,14 +204,11 @@ final class RegionalAccessBoundaryManager {
                       transportFactory, url, accessToken, clock, maxRetryElapsedTimeMillis);
               cachedRAB.set(newRAB);
               resetCooldown();
-              // Complete the future so monitors (like unit tests) know we are done.
-              future.set(newRAB);
             } catch (Exception e) {
               handleRefreshFailure(e);
-              future.setException(e);
             } finally {
               // Open the gate again for future refresh requests.
-              refreshFuture.set(null);
+              isRefreshing.set(false);
             }
           };
 
@@ -232,8 +224,7 @@ final class RegionalAccessBoundaryManager {
             "Could not submit background refresh task for Regional Access Boundary. "
                 + "This is non-blocking and the library will attempt to refresh on the next access. Error: "
                 + e.getMessage());
-        future.setException(e);
-        refreshFuture.set(null);
+        isRefreshing.set(false);
       }
     }
   }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
@@ -84,6 +85,8 @@ final class RegionalAccessBoundaryManager {
 
   private final AtomicReference<CooldownState> cooldownState =
       new AtomicReference<>(new CooldownState(0, INITIAL_COOLDOWN_MILLIS));
+
+  private final AtomicBoolean skipRAB = new AtomicBoolean(false);
 
   // Unbounded thread creation is discouraged in library code to avoid resource
   // exhaustion. A shared, bounded executor service ensures a hard limit (5)
@@ -178,7 +181,7 @@ final class RegionalAccessBoundaryManager {
       final HttpTransportFactory transportFactory,
       final RegionalAccessBoundaryProvider provider,
       final AccessToken accessToken) {
-    if (isCooldownActive()) {
+    if (skipRAB.get() || isCooldownActive()) {
       return;
     }
 
@@ -197,6 +200,7 @@ final class RegionalAccessBoundaryManager {
             try {
               String url = provider.getRegionalAccessBoundaryUrl();
               if (url == null) {
+                skipRAB.set(true);
                 future.set(null);
                 return;
               }
@@ -281,6 +285,11 @@ final class RegionalAccessBoundaryManager {
   @VisibleForTesting
   long getCurrentCooldownMillis() {
     return cooldownState.get().durationMillis;
+  }
+
+  @VisibleForTesting
+  boolean isSkipRAB() {
+    return skipRAB.get();
   }
 
   private static class CooldownState {

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/RegionalAccessBoundaryManager.java
@@ -196,6 +196,10 @@ final class RegionalAccessBoundaryManager {
           () -> {
             try {
               String url = provider.getRegionalAccessBoundaryUrl();
+              if (url == null) {
+                future.set(null);
+                return;
+              }
               RegionalAccessBoundary newRAB =
                   RegionalAccessBoundary.refresh(
                       transportFactory, url, accessToken, clock, maxRetryElapsedTimeMillis);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -1243,8 +1243,8 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @org.junit.jupiter.api.Test
-  void refresh_regionalAccessBoundaryNonEmail() throws IOException, InterruptedException {
-
+  void refresh_regionalAccessBoundaryNonEmail_skipsRABLookup()
+      throws IOException, InterruptedException {
     String nonEmailAccount = "non-email-account-value";
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     RegionalAccessBoundary regionalAccessBoundary =
@@ -1258,17 +1258,28 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
-    // First call: should NOT initiate async refresh (or should skip it gracefully).
+    // Before any call, skipRAB flag should be false
+    assertFalse(credentials.regionalAccessBoundaryManager.isSkipRAB());
+
+    // First call: triggers lookup which determines non-email, returns null, and sets skipRAB to
+    // true
     Map<String, List<String>> headers = credentials.getRequestMetadata();
     assertNull(headers.get(X_ALLOWED_LOCATIONS_HEADER_KEY));
 
-    // Wait a brief time to make sure no background tasks execute and set it.
-    Thread.sleep(500);
+    // Since the task is scheduled asynchronously on the shared executor, wait for it to complete
+    long deadline = System.currentTimeMillis() + 5000;
+    while (!credentials.regionalAccessBoundaryManager.isSkipRAB()
+        && System.currentTimeMillis() < deadline) {
+      Thread.sleep(50);
+    }
 
-    // It should still be null.
+    // Verify skipRAB flag has been set to true
+    assertTrue(credentials.regionalAccessBoundaryManager.isSkipRAB());
+
+    // Verify RAB is still null
     assertNull(credentials.getRegionalAccessBoundary());
 
-    // And header should still be missing on second call.
+    // Second call: should bypass triggerAsyncRefresh completely and remain null
     headers = credentials.getRequestMetadata();
     assertNull(headers.get(X_ALLOWED_LOCATIONS_HEADER_KEY));
   }

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -1213,7 +1213,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     assertEquals(0, transportFactory.transport.getRequestCount());
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void refresh_regionalAccessBoundarySuccess() throws IOException, InterruptedException {
 
     String defaultAccountEmail = "default@email.com";
@@ -1242,7 +1242,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
         Arrays.asList(TestUtils.REGIONAL_ACCESS_BOUNDARY_ENCODED_LOCATION));
   }
 
-  @org.junit.jupiter.api.Test
+  @Test
   void refresh_regionalAccessBoundaryNonEmail_skipsRABLookup()
       throws IOException, InterruptedException {
     String nonEmailAccount = "non-email-account-value";
@@ -1282,6 +1282,34 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     // Second call: should bypass triggerAsyncRefresh completely and remain null
     headers = credentials.getRequestMetadata();
     assertNull(headers.get(X_ALLOWED_LOCATIONS_HEADER_KEY));
+  }
+
+  @Test
+  void getRegionalAccessBoundaryUrl_validEmail_returnsUrl() throws IOException {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    String defaultAccountEmail = "mail@mail.com";
+
+    transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String expectedUrl =
+        String.format(
+            OAuth2Utils.IAM_CREDENTIALS_ALLOWED_LOCATIONS_URL_FORMAT_SERVICE_ACCOUNT,
+            defaultAccountEmail);
+    assertEquals(expectedUrl, credentials.getRegionalAccessBoundaryUrl());
+  }
+
+  @Test
+  void getRegionalAccessBoundaryUrl_invalidEmail_returnsNull() throws IOException {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    String defaultAccountEmail = "default"; // non-email account format
+
+    transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    assertNull(credentials.getRegionalAccessBoundaryUrl());
   }
 
   private void waitForRegionalAccessBoundary(GoogleCredentials credentials)

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -1242,6 +1242,37 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
         Arrays.asList(TestUtils.REGIONAL_ACCESS_BOUNDARY_ENCODED_LOCATION));
   }
 
+  @org.junit.jupiter.api.Test
+  void refresh_regionalAccessBoundaryNonEmail() throws IOException, InterruptedException {
+
+    String nonEmailAccount = "non-email-account-value";
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    RegionalAccessBoundary regionalAccessBoundary =
+        new RegionalAccessBoundary(
+            TestUtils.REGIONAL_ACCESS_BOUNDARY_ENCODED_LOCATION,
+            TestUtils.REGIONAL_ACCESS_BOUNDARY_LOCATIONS,
+            null);
+    transportFactory.transport.setRegionalAccessBoundary(regionalAccessBoundary);
+    transportFactory.transport.setServiceAccountEmail(nonEmailAccount);
+
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    // First call: should NOT initiate async refresh (or should skip it gracefully).
+    Map<String, List<String>> headers = credentials.getRequestMetadata();
+    assertNull(headers.get(X_ALLOWED_LOCATIONS_HEADER_KEY));
+
+    // Wait a brief time to make sure no background tasks execute and set it.
+    Thread.sleep(500);
+
+    // It should still be null.
+    assertNull(credentials.getRegionalAccessBoundary());
+
+    // And header should still be missing on second call.
+    headers = credentials.getRequestMetadata();
+    assertNull(headers.get(X_ALLOWED_LOCATIONS_HEADER_KEY));
+  }
+
   private void waitForRegionalAccessBoundary(GoogleCredentials credentials)
       throws InterruptedException {
     long deadline = System.currentTimeMillis() + 5000;


### PR DESCRIPTION
In ComputeEngineCredentials when running on GKE platform, the getAccount() call may return a value which isn't an email.

In this case the right behaviour is to skip RAB lookup which is what this PR does.

Added tests.