### PR TITLE
fix(build): support generating unversioned libraries in OwlBot config

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/generate_composed_library.py
+++ b/sdk-platform-java/hermetic_build/library_generation/generate_composed_library.py
@@ -32,6 +32,7 @@ import os
 from pathlib import Path
 from typing import List
 import library_generation.utils.utilities as util
+from library_generation.utils.proto_path_utils import remove_version_from
 from common.model.generation_config import GenerationConfig
 from common.model.gapic_config import GapicConfig
 from common.model.gapic_inputs import GapicInputs
@@ -72,12 +73,14 @@ def generate_composed_library(
         # overridden by the config object if specified. Note that this override
         # does not affect library generation but instead used only for
         # generating postprocessing files such as README.
+        has_version = remove_version_from(gapic.proto_path) != gapic.proto_path
         util.generate_postprocessing_prerequisite_files(
             config=config,
             library=library,
             proto_path=util.remove_version_from(gapic.proto_path),
             library_path=library_path,
             transport=library.get_transport(gapic_inputs),
+            has_version=has_version,
         )
         temp_destination_path = f"java-{gapic.proto_path.replace('/','-')}"
         effective_arguments = _construct_effective_arg(

--- a/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
+++ b/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
@@ -23,6 +23,7 @@ deep-preserve-regex:
 - "/{{ module_name }}/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
 
 deep-copy-regex:
+{%- if has_version %}
 - source: "/{{ proto_path }}/(v.*)/.*-java/proto-google-.*/src"
   dest: "/owl-bot-staging/{{ module_name }}/$1/proto-{{ artifact_id }}-$1/src"
 - source: "/{{ proto_path }}/(v.*)/.*-java/grpc-google-.*/src"
@@ -31,6 +32,16 @@ deep-copy-regex:
   dest: "/owl-bot-staging/{{ module_name }}/$1/{{ artifact_id }}/src"
 - source: "/{{ proto_path }}/(v.*)/.*-java/samples/snippets/generated"
   dest: "/owl-bot-staging/{{ module_name }}/$1/samples/snippets/generated"
+{%- else %}
+- source: "/{{ proto_path }}/.*-java/proto-google-.*/src"
+  dest: "/owl-bot-staging/{{ module_name }}/proto-{{ artifact_id }}/src"
+- source: "/{{ proto_path }}/.*-java/grpc-google-.*/src"
+  dest: "/owl-bot-staging/{{ module_name }}/grpc-{{ artifact_id }}/src"
+- source: "/{{ proto_path }}/.*-java/gapic-google-.*/src"
+  dest: "/owl-bot-staging/{{ module_name }}/{{ artifact_id }}/src"
+- source: "/{{ proto_path }}/.*-java/samples/snippets/generated"
+  dest: "/owl-bot-staging/{{ module_name }}/samples/snippets/generated"
+{%- endif %}
 {%- endif %}
 
 api-name: {{ api_shortname }}

--- a/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
@@ -205,6 +205,7 @@ def generate_postprocessing_prerequisite_files(
     transport: str,
     library_path: str,
     language: str = "java",
+    has_version: bool = True,
 ) -> None:
     """
     Generates the postprocessing prerequisite files for a library.
@@ -307,6 +308,7 @@ def generate_postprocessing_prerequisite_files(
             proto_path=remove_version_from(proto_path),
             module_name=repo_metadata["repo_short"],
             api_shortname=library.api_shortname,
+            has_version=has_version,
         )
 
     # generate owlbot.py


### PR DESCRIPTION
This PR adds support for generating unversioned libraries (such as backstory) in the hermetic build OwlBot configuration. Historically, only versioned libraries (with v1, v1beta, etc. directories) were supported in deep-copy regex. For example, new library generation for [backstory](https://github.com/googleapis/google-cloud-java/pull/13334) didn't trigger any code changes.

This PR checks if a version component is present and conditionally outputs versioned or unversioned copy patterns.