### PR TITLE
feat: enable self-signed JWTs by default in ServiceOptions

### DIFF
--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
@@ -77,7 +77,9 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
     private Tracer openTelemetryTracer;
     private ResultRetryAlgorithm<?> resultRetryAlgorithm;
 
-    private Builder() {}
+    private Builder() {
+      setUseJwtAccessWithScope(false);
+    }
 
     private Builder(BigQueryOptions options) {
       super(options);
@@ -211,11 +213,6 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
 
   public static HttpTransportOptions getDefaultHttpTransportOptions() {
     return HttpTransportOptions.newBuilder().setReadTimeout(DEFAULT_READ_API_TIME_OUT).build();
-  }
-
-  @Override
-  protected boolean useSelfSignedJwt() {
-    return false;
   }
 
   @Override

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryOptions.java
@@ -214,6 +214,11 @@ public class BigQueryOptions extends ServiceOptions<BigQuery, BigQueryOptions> {
   }
 
   @Override
+  protected boolean useSelfSignedJwt() {
+    return false;
+  }
+
+  @Override
   protected Set<String> getScopes() {
     return SCOPES;
   }

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryOptionsTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryOptionsTest.java
@@ -92,4 +92,11 @@ public class BigQueryOptionsTest {
 
     assertTrue(options.getDataFormatOptions().useInt64Timestamp());
   }
+
+  @Test
+  void testUseJwtAccessWithScope_defaultsToFalse() {
+    BigQueryOptions options = BigQueryOptions.newBuilder().setProjectId("project-id").build();
+
+    assertFalse(options.getUseJwtAccessWithScope());
+  }
 }

--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/StorageOptions.java
@@ -112,7 +112,9 @@ public abstract class StorageOptions extends ServiceOptions<Storage, StorageOpti
   public abstract static class Builder
       extends ServiceOptions.Builder<Storage, StorageOptions, Builder> {
 
-    Builder() {}
+    Builder() {
+      setUseJwtAccessWithScope(false);
+    }
 
     Builder(StorageOptions options) {
       super(options);

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageOptionsBuilderTest.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/StorageOptionsBuilderTest.java
@@ -69,6 +69,15 @@ public final class StorageOptionsBuilderTest {
         () -> assertThat(rebuilt.hashCode()).isEqualTo(base.hashCode()));
   }
 
+  @Test
+  public void useJwtAccessWithScope_defaultsToFalse() {
+    HttpStorageOptions httpOptions = HttpStorageOptions.http().build();
+    GrpcStorageOptions grpcOptions = GrpcStorageOptions.grpc().build();
+
+    assertThat(httpOptions.getUseJwtAccessWithScope()).isFalse();
+    assertThat(grpcOptions.getUseJwtAccessWithScope()).isFalse();
+  }
+
   private static class MyStorageRetryStrategy implements StorageRetryStrategy {
 
     @Override

--- a/sdk-platform-java/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
+++ b/sdk-platform-java/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
@@ -650,7 +650,15 @@ public abstract class ServiceOptions<
         && ((GoogleCredentials) credentials).createScopedRequired()) {
       credentialsToReturn = ((GoogleCredentials) credentials).createScoped(getScopes());
     }
+    if (useSelfSignedJwt() && credentialsToReturn instanceof ServiceAccountCredentials) {
+      credentialsToReturn =
+          ((ServiceAccountCredentials) credentialsToReturn).createWithUseJwtAccessWithScope(true);
+    }
     return credentialsToReturn;
+  }
+
+  protected boolean useSelfSignedJwt() {
+    return true;
   }
 
   /** Returns configuration parameters for request retries. */

--- a/sdk-platform-java/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
+++ b/sdk-platform-java/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
@@ -106,6 +106,7 @@ public abstract class ServiceOptions<
   private final TransportOptions transportOptions;
   private final HeaderProvider headerProvider;
   private final String quotaProjectId;
+  private final boolean useJwtAccessWithScope;
 
   private transient ServiceRpcFactory<OptionsT> serviceRpcFactory;
   private transient ServiceFactory<ServiceT, OptionsT> serviceFactory;
@@ -140,6 +141,7 @@ public abstract class ServiceOptions<
     private HeaderProvider headerProvider;
     private String clientLibToken = ServiceOptions.getGoogApiClientLibName();
     private String quotaProjectId;
+    private boolean useJwtAccessWithScope = true;
 
     private ApiTracerFactory apiTracerFactory;
 
@@ -159,6 +161,7 @@ public abstract class ServiceOptions<
       transportOptions = options.transportOptions;
       clientLibToken = options.clientLibToken;
       quotaProjectId = options.quotaProjectId;
+      useJwtAccessWithScope = options.useJwtAccessWithScope;
       apiTracerFactory = options.apiTracerFactory;
     }
 
@@ -314,6 +317,18 @@ public abstract class ServiceOptions<
     }
 
     /**
+     * Sets the configuration determining whether self-signed JWT with scopes are used for service
+     * account credentials.
+     *
+     * @param useJwtAccessWithScope whether to use self-signed JWT with scopes
+     * @return the builder
+     */
+    public B setUseJwtAccessWithScope(final boolean useJwtAccessWithScope) {
+      this.useJwtAccessWithScope = useJwtAccessWithScope;
+      return self();
+    }
+
+    /**
      * Sets the {@link ApiTracerFactory}. It will be used to create an {@link ApiTracer} that is
      * annotated throughout the lifecycle of an RPC operation.
      */
@@ -365,6 +380,7 @@ public abstract class ServiceOptions<
         builder.quotaProjectId != null
             ? builder.quotaProjectId
             : getValueFromCredentialsFile(getCredentialsPath(), "quota_project_id");
+    useJwtAccessWithScope = builder.useJwtAccessWithScope;
     apiTracerFactory = builder.apiTracerFactory;
   }
 
@@ -650,15 +666,11 @@ public abstract class ServiceOptions<
         && ((GoogleCredentials) credentials).createScopedRequired()) {
       credentialsToReturn = ((GoogleCredentials) credentials).createScoped(getScopes());
     }
-    if (useSelfSignedJwt() && credentialsToReturn instanceof ServiceAccountCredentials) {
+    if (getUseJwtAccessWithScope() && credentialsToReturn instanceof ServiceAccountCredentials) {
       credentialsToReturn =
           ((ServiceAccountCredentials) credentialsToReturn).createWithUseJwtAccessWithScope(true);
     }
     return credentialsToReturn;
-  }
-
-  protected boolean useSelfSignedJwt() {
-    return true;
   }
 
   /** Returns configuration parameters for request retries. */
@@ -829,6 +841,15 @@ public abstract class ServiceOptions<
   /** Returns the quotaProjectId that specifies the project used for quota and billing purposes. */
   public String getQuotaProjectId() {
     return quotaProjectId;
+  }
+
+  /**
+   * Returns true when self-signed JWT with scopes are used for service account credentials.
+   *
+   * @return true when self-signed JWT with scopes are used
+   */
+  public boolean getUseJwtAccessWithScope() {
+    return useJwtAccessWithScope;
   }
 
   /**

--- a/sdk-platform-java/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
+++ b/sdk-platform-java/java-core/google-cloud-core/src/main/java/com/google/cloud/ServiceOptions.java
@@ -666,9 +666,10 @@ public abstract class ServiceOptions<
         && ((GoogleCredentials) credentials).createScopedRequired()) {
       credentialsToReturn = ((GoogleCredentials) credentials).createScoped(getScopes());
     }
-    if (getUseJwtAccessWithScope() && credentialsToReturn instanceof ServiceAccountCredentials) {
+    if (credentialsToReturn instanceof ServiceAccountCredentials) {
       credentialsToReturn =
-          ((ServiceAccountCredentials) credentialsToReturn).createWithUseJwtAccessWithScope(true);
+          ((ServiceAccountCredentials) credentialsToReturn)
+              .createWithUseJwtAccessWithScope(getUseJwtAccessWithScope());
     }
     return credentialsToReturn;
   }

--- a/sdk-platform-java/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
+++ b/sdk-platform-java/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
@@ -285,7 +285,7 @@ class ServiceOptionsTest {
       }
     }
 
-    private TestServiceOptions(Builder builder) {
+    protected TestServiceOptions(Builder builder) {
       super(
           TestServiceFactory.class,
           TestServiceRpcFactory.class,
@@ -336,6 +336,25 @@ class ServiceOptionsTest {
       return baseHashCode();
     }
   }
+
+  private static class NonSsjwtServiceOptions extends TestServiceOptions {
+    private static class Builder extends TestServiceOptions.Builder {
+      @Override
+      protected NonSsjwtServiceOptions build() {
+        return new NonSsjwtServiceOptions(this);
+      }
+    }
+
+    private NonSsjwtServiceOptions(Builder builder) {
+      super(builder);
+    }
+
+    @Override
+    protected boolean useSelfSignedJwt() {
+      return false;
+    }
+  }
+
 
   @Test
   public void testBuilder() {
@@ -627,7 +646,29 @@ class ServiceOptionsTest {
             .setUniverseDomain("random.com")
             .setCredentials(credentialsNotInGDU)
             .build();
-    assertThat(options.hasValidUniverseDomain()).isTrue();
+  }
+
+  @Test
+  void testGetScopedCredentials_enablesSelfSignedJwtForServiceAccount() {
+    TestServiceOptions options =
+        TestServiceOptions.newBuilder()
+            .setProjectId("project-id")
+            .setCredentials(credentials)
+            .build();
+    com.google.auth.Credentials scoped = options.getScopedCredentials();
+    assertThat(scoped).isInstanceOf(ServiceAccountCredentials.class);
+  }
+
+  @Test
+  void testGetScopedCredentials_optsOutSelfSignedJwt() {
+    TestServiceOptions options =
+        new NonSsjwtServiceOptions.Builder()
+            .setProjectId("project-id")
+            .setCredentials(credentials)
+            .build();
+    com.google.auth.Credentials scoped = options.getScopedCredentials();
+    assertThat(scoped).isInstanceOf(ServiceAccountCredentials.class);
+    assertThat(((ServiceAccountCredentials) scoped).getUseJwtAccessWithScope()).isFalse();
   }
 
   private HttpResponse createHttpResponseWithHeader(final Multimap<String, String> headers)

--- a/sdk-platform-java/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
+++ b/sdk-platform-java/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
@@ -285,7 +285,7 @@ class ServiceOptionsTest {
       }
     }
 
-    protected TestServiceOptions(Builder builder) {
+    private TestServiceOptions(Builder builder) {
       super(
           TestServiceFactory.class,
           TestServiceRpcFactory.class,
@@ -336,25 +336,6 @@ class ServiceOptionsTest {
       return baseHashCode();
     }
   }
-
-  private static class NonSsjwtServiceOptions extends TestServiceOptions {
-    private static class Builder extends TestServiceOptions.Builder {
-      @Override
-      protected NonSsjwtServiceOptions build() {
-        return new NonSsjwtServiceOptions(this);
-      }
-    }
-
-    private NonSsjwtServiceOptions(Builder builder) {
-      super(builder);
-    }
-
-    @Override
-    protected boolean useSelfSignedJwt() {
-      return false;
-    }
-  }
-
 
   @Test
   public void testBuilder() {
@@ -646,6 +627,7 @@ class ServiceOptionsTest {
             .setUniverseDomain("random.com")
             .setCredentials(credentialsNotInGDU)
             .build();
+    assertThat(options.hasValidUniverseDomain()).isTrue();
   }
 
   @Test
@@ -657,14 +639,16 @@ class ServiceOptionsTest {
             .build();
     com.google.auth.Credentials scoped = options.getScopedCredentials();
     assertThat(scoped).isInstanceOf(ServiceAccountCredentials.class);
+    assertThat(((ServiceAccountCredentials) scoped).getUseJwtAccessWithScope()).isTrue();
   }
 
   @Test
   void testGetScopedCredentials_optsOutSelfSignedJwt() {
     TestServiceOptions options =
-        new NonSsjwtServiceOptions.Builder()
+        new TestServiceOptions.Builder()
             .setProjectId("project-id")
             .setCredentials(credentials)
+            .setUseJwtAccessWithScope(false)
             .build();
     com.google.auth.Credentials scoped = options.getScopedCredentials();
     assertThat(scoped).isInstanceOf(ServiceAccountCredentials.class);

--- a/sdk-platform-java/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
+++ b/sdk-platform-java/java-core/google-cloud-core/src/test/java/com/google/cloud/ServiceOptionsTest.java
@@ -631,7 +631,7 @@ class ServiceOptionsTest {
   }
 
   @Test
-  void testGetScopedCredentials_enablesSelfSignedJwtForServiceAccount() {
+  void testGetScopedCredentials_useJwtAccessWithScope_enablesByDefault() {
     TestServiceOptions options =
         TestServiceOptions.newBuilder()
             .setProjectId("project-id")
@@ -643,11 +643,26 @@ class ServiceOptionsTest {
   }
 
   @Test
-  void testGetScopedCredentials_optsOutSelfSignedJwt() {
+  void testGetScopedCredentials_useJwtAccessWithScope_canBeDisabled() {
     TestServiceOptions options =
         new TestServiceOptions.Builder()
             .setProjectId("project-id")
             .setCredentials(credentials)
+            .setUseJwtAccessWithScope(false)
+            .build();
+    com.google.auth.Credentials scoped = options.getScopedCredentials();
+    assertThat(scoped).isInstanceOf(ServiceAccountCredentials.class);
+    assertThat(((ServiceAccountCredentials) scoped).getUseJwtAccessWithScope()).isFalse();
+  }
+
+  @Test
+  void testGetScopedCredentials_useJwtAccessWithScope_overridesCredentials() {
+    ServiceAccountCredentials trueCredentials =
+        ((ServiceAccountCredentials) credentials).createWithUseJwtAccessWithScope(true);
+    TestServiceOptions options =
+        new TestServiceOptions.Builder()
+            .setProjectId("project-id")
+            .setCredentials(trueCredentials)
             .setUseJwtAccessWithScope(false)
             .build();
     com.google.auth.Credentials scoped = options.getScopedCredentials();


### PR DESCRIPTION
This should improve efficiency/reliability by avoiding OAuth token exchange - see https://google.aip.dev/auth/4111.

BigQueryOptions (b/523372553) and StorageOptions (b/523372960) are disabled by default for now.