### PR TITLE
feat(library_generation): generic grouping folder for unversioned libraries staging paths

### DIFF
--- a/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
+++ b/sdk-platform-java/hermetic_build/library_generation/templates/owlbot.yaml.monorepo.j2
@@ -33,14 +33,19 @@ deep-copy-regex:
 - source: "/{{ proto_path }}/(v.*)/.*-java/samples/snippets/generated"
   dest: "/owl-bot-staging/{{ module_name }}/$1/samples/snippets/generated"
 {%- else %}
+{%- if proto_only %}
 - source: "/{{ proto_path }}/.*-java/proto-google-.*/src"
-  dest: "/owl-bot-staging/{{ module_name }}/proto-{{ artifact_id }}/src"
+  dest: "/owl-bot-staging/{{ module_name }}/{{ unversioned_dir }}/{{ artifact_id }}/src"
+{%- else %}
+- source: "/{{ proto_path }}/.*-java/proto-google-.*/src"
+  dest: "/owl-bot-staging/{{ module_name }}/{{ unversioned_dir }}/proto-{{ artifact_id }}/src"
 - source: "/{{ proto_path }}/.*-java/grpc-google-.*/src"
-  dest: "/owl-bot-staging/{{ module_name }}/grpc-{{ artifact_id }}/src"
+  dest: "/owl-bot-staging/{{ module_name }}/{{ unversioned_dir }}/grpc-{{ artifact_id }}/src"
 - source: "/{{ proto_path }}/.*-java/gapic-google-.*/src"
-  dest: "/owl-bot-staging/{{ module_name }}/{{ artifact_id }}/src"
+  dest: "/owl-bot-staging/{{ module_name }}/{{ unversioned_dir }}/{{ artifact_id }}/src"
 - source: "/{{ proto_path }}/.*-java/samples/snippets/generated"
-  dest: "/owl-bot-staging/{{ module_name }}/samples/snippets/generated"
+  dest: "/owl-bot-staging/{{ module_name }}/{{ unversioned_dir }}/samples/snippets/generated"
+{%- endif %}
 {%- endif %}
 {%- endif %}
 

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-unversioned-gapic-golden.yaml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-unversioned-gapic-golden.yaml
@@ -1,0 +1,35 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+deep-remove-regex:
+- "/java-bare-metal-solution/grpc-google-.*/src"
+- "/java-bare-metal-solution/proto-google-.*/src"
+- "/java-bare-metal-solution/google-.*/src"
+- "/java-bare-metal-solution/samples/snippets/generated"
+
+deep-preserve-regex:
+- "/java-bare-metal-solution/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
+
+deep-copy-regex:
+- source: "/google/cloud/baremetalsolution/.*-java/proto-google-.*/src"
+  dest: "/owl-bot-staging/java-bare-metal-solution/baremetalsolution/proto-google-cloud-bare-metal-solution/src"
+- source: "/google/cloud/baremetalsolution/.*-java/grpc-google-.*/src"
+  dest: "/owl-bot-staging/java-bare-metal-solution/baremetalsolution/grpc-google-cloud-bare-metal-solution/src"
+- source: "/google/cloud/baremetalsolution/.*-java/gapic-google-.*/src"
+  dest: "/owl-bot-staging/java-bare-metal-solution/baremetalsolution/google-cloud-bare-metal-solution/src"
+- source: "/google/cloud/baremetalsolution/.*-java/samples/snippets/generated"
+  dest: "/owl-bot-staging/java-bare-metal-solution/baremetalsolution/samples/snippets/generated"
+
+api-name: baremetalsolution

--- a/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-unversioned-proto-only-golden.yaml
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/resources/goldens/.OwlBot-hermetic-unversioned-proto-only-golden.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+deep-remove-regex:
+- "/java-bare-metal-solution/grpc-google-.*/src"
+- "/java-bare-metal-solution/proto-google-.*/src"
+- "/java-bare-metal-solution/google-.*/src"
+- "/java-bare-metal-solution/samples/snippets/generated"
+
+deep-preserve-regex:
+- "/java-bare-metal-solution/google-.*/src/test/java/com/google/cloud/.*/v.*/it/IT.*Test.java"
+
+deep-copy-regex:
+- source: "/google/cloud/baremetalsolution/.*-java/proto-google-.*/src"
+  dest: "/owl-bot-staging/java-bare-metal-solution/baremetalsolution/google-cloud-bare-metal-solution/src"
+
+api-name: baremetalsolution

--- a/sdk-platform-java/hermetic_build/library_generation/tests/utilities_unit_tests.py
+++ b/sdk-platform-java/hermetic_build/library_generation/tests/utilities_unit_tests.py
@@ -253,6 +253,38 @@ class UtilitiesTest(unittest.TestCase):
         )
         self.__remove_postprocessing_prerequisite_files(path=library_path)
 
+    def test_generate_postprocessing_prerequisite_files_unversioned_proto_only_success(self):
+        self.maxDiff = None
+        library_path = self.__setup_postprocessing_prerequisite_files(
+            combination=3,
+            library_type="OTHER",
+            proto_path="google/cloud/baremetalsolution",
+            has_version=False,
+            proto_only=True,
+        )
+
+        file_comparator.compare_files(
+            f"{library_path}/.OwlBot-hermetic.yaml",
+            f"{library_path}/.OwlBot-hermetic-unversioned-proto-only-golden.yaml",
+        )
+        self.__remove_postprocessing_prerequisite_files(path=library_path)
+
+    def test_generate_postprocessing_prerequisite_files_unversioned_gapic_success(self):
+        self.maxDiff = None
+        library_path = self.__setup_postprocessing_prerequisite_files(
+            combination=2,
+            library_type="GAPIC_AUTO",
+            proto_path="google/cloud/baremetalsolution",
+            has_version=False,
+            proto_only=False,
+        )
+
+        file_comparator.compare_files(
+            f"{library_path}/.OwlBot-hermetic.yaml",
+            f"{library_path}/.OwlBot-hermetic-unversioned-gapic-golden.yaml",
+        )
+        self.__remove_postprocessing_prerequisite_files(path=library_path)
+
     def test_generate_postprocessing_prerequisite_files__custom_transport_set_in_config__success(
         self,
     ):
@@ -326,6 +358,9 @@ class UtilitiesTest(unittest.TestCase):
         combination: int,
         library_type: str = "GAPIC_AUTO",
         library: LibraryConfig = library_1,
+        proto_path: str = "google/cloud/baremetalsolution/v2",
+        has_version: bool = True,
+        proto_only: bool = False,
     ) -> str:
         library_path = f"{resources_dir}/goldens"
         files = [
@@ -336,7 +371,6 @@ class UtilitiesTest(unittest.TestCase):
         cleanup(files)
         library.library_type = library_type
         config = self.__get_a_gen_config(combination, library_type=library_type)
-        proto_path = "google/cloud/baremetalsolution/v2"
         gapic_inputs = GapicInputs()  # defaults to transport=grpc
         transport = library.get_transport(gapic_inputs)
         util.generate_postprocessing_prerequisite_files(
@@ -345,6 +379,8 @@ class UtilitiesTest(unittest.TestCase):
             proto_path=proto_path,
             transport=transport,
             library_path=library_path,
+            has_version=has_version,
+            proto_only=proto_only,
         )
         return library_path
 

--- a/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
+++ b/sdk-platform-java/hermetic_build/library_generation/utils/utilities.py
@@ -206,6 +206,7 @@ def generate_postprocessing_prerequisite_files(
     library_path: str,
     language: str = "java",
     has_version: bool = True,
+    proto_only: bool = False,
 ) -> None:
     """
     Generates the postprocessing prerequisite files for a library.
@@ -301,6 +302,7 @@ def generate_postprocessing_prerequisite_files(
         else f"{library_path}/.github/{owlbot_yaml_file}"
     )
     if not os.path.exists(path_to_owlbot_yaml_file):
+        unversioned_dir = remove_version_from(proto_path).split("/")[-1]
         render(
             template_name="owlbot.yaml.monorepo.j2",
             output_name=path_to_owlbot_yaml_file,
@@ -309,6 +311,8 @@ def generate_postprocessing_prerequisite_files(
             module_name=repo_metadata["repo_short"],
             api_shortname=library.api_shortname,
             has_version=has_version,
+            proto_only=proto_only,
+            unversioned_dir=unversioned_dir,
         )
 
     # generate owlbot.py


### PR DESCRIPTION
Use dynamically resolved grouping folder names (instead of the static 'unversioned' directory placeholder) in OwlBot staging paths for unversioned libraries.