### PR TITLE
chore: Revert googleapis_commitish in generation_config.yaml

### DIFF
--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -1,4 +1,4 @@
-googleapis_commitish: 5481332007e57ad3d9cb81e83ff6bf9c449476b6
+googleapis_commitish: 0ff3c706a5e0964c6430529c406208f2ff57cf65
 libraries_bom_version: 26.83.0
 is_monorepo: true
 libraries:


### PR DESCRIPTION
The latest [generation PR](https://github.com/googleapis/google-cloud-java/pull/13315/commits) failed to generate code but the googleapis_comitish has already been updated. Revert it to keep the commitish consistent with the gen code.