### PR TITLE
chore: Comment out backstory in generation_config.yaml

### DIFF
--- a/generation_config.yaml
+++ b/generation_config.yaml
@@ -284,21 +284,21 @@ libraries:
   GAPICs:
   - proto_path: google/cloud/automl/v1
   - proto_path: google/cloud/automl/v1beta1
-- api_shortname: backstory
-  name_pretty: Malachite Common Protos
-  product_documentation: https://cloud.google.com/chronicle/docs/secops/secops-overview
-  api_description: Common Universal Data Model (UDM) and Entity protos used by Chronicle.
-  client_documentation: 
-    https://cloud.google.com/java/docs/reference/google-cloud-backstory/latest/overview
-  release_level: preview
-  distribution_name: com.google.cloud:google-cloud-backstory
-  api_id: backstory.googleapis.com
-  library_type: GAPIC_AUTO
-  group_id: com.google.cloud
-  cloud_api: true
-  GAPICs:
-  - proto_path: backstory
-  requires_billing: true
+# - api_shortname: backstory
+#   name_pretty: Malachite Common Protos
+#   product_documentation: https://cloud.google.com/chronicle/docs/secops/secops-overview
+#   api_description: Common Universal Data Model (UDM) and Entity protos used by Chronicle.
+#   client_documentation: 
+#     https://cloud.google.com/java/docs/reference/google-cloud-backstory/latest/overview
+#   release_level: preview
+#   distribution_name: com.google.cloud:google-cloud-backstory
+#   api_id: backstory.googleapis.com
+#   library_type: GAPIC_AUTO
+#   group_id: com.google.cloud
+#   cloud_api: true
+#   GAPICs:
+#   - proto_path: backstory
+#   requires_billing: true
 - api_shortname: backupdr
   name_pretty: Backup and DR Service API
   product_documentation: https://cloud.google.com/backup-disaster-recovery/docs/concepts/backup-dr


### PR DESCRIPTION
backstory is a top level, non-versioned proto only module. This caused the [library generation](https://github.com/googleapis/google-cloud-java/actions/runs/26861145003) to fail. 
Considering that Librarian is taking over, we are not going to fix the hermetic build scripts. Commenting out the section so the daily generation can still continue and we can compare the daily hermetic build generation with the Librarian generation.