### PR TITLE
fix(storage): add junit-vintage-engine to native profile to fix version mismatch

### DIFF
--- a/java-storage/gapic-google-cloud-storage-v2/pom.xml
+++ b/java-storage/gapic-google-cloud-storage-v2/pom.xml
@@ -95,5 +95,15 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <id>native</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/java-storage/google-cloud-storage-control/pom.xml
+++ b/java-storage/google-cloud-storage-control/pom.xml
@@ -111,6 +111,16 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>native</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
     <properties>
         <maven.compiler.source>8</maven.compiler.source>


### PR DESCRIPTION
[Kokoro - Test: Storage GraalVM Native Image](https://source.cloud.google.com/results/invocations/6a61cb07-ae2d-461c-a2ea-b8e9d15f85d9) is passing below with this PR.

b/519557208