### PR TITLE
chore(.github/workflows): let librarian update workflow also sync new commit to generation_config.yaml

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -76,14 +76,14 @@ jobs:
         sed -i -e "s/^googleapis_commitish.*$/googleapis_commitish: ${{ steps.commit.outputs.new_commit }}/" generation_config.yaml
         echo "After update:"
         grep "^googleapis_commitish" generation_config.yaml
-    - name: Detect Changes To Configs
-      id: detect_config
+    - name: Detect Changes To Librarian.yaml
+      id: detect_librarian
       run: |
-        git add librarian.yaml generation_config.yaml
+        git add librarian.yaml
         changed_files=$(git diff --cached --name-only)
         if [[ "${changed_files}" == "" ]]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
-          echo "No changes in librarian.yaml or generation_config.yaml"
+          echo "No changes in librarian.yaml"
         else
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
@@ -118,7 +118,7 @@ jobs:
       env:
         PYTHONPATH: ${{ github.workspace }}/sdk-platform-java/hermetic_build/library_generation/owlbot
     - name: Generate Libraries
-      if: steps.detect_config.outputs.has_changes == 'true'
+      if: steps.detect_librarian.outputs.has_changes == 'true'
       id: generate
       run: |
         go run github.com/googleapis/librarian/cmd/librarian@latest generate --all
@@ -131,7 +131,7 @@ jobs:
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
     - name: Commit and Create PR
-      if: steps.detect_config.outputs.has_changes == 'true' || steps.generate.outputs.has_changes == 'true'
+      if: steps.detect_librarian.outputs.has_changes == 'true' || steps.generate.outputs.has_changes == 'true'
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
         PR_TITLE: "chore: update googleapis commitish to ${{ steps.commit.outputs.short_commit }}"

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -68,6 +68,7 @@ jobs:
         new_commit=$(go run "github.com/googleapis/librarian/cmd/librarian@${version}" config get sources.googleapis.commit)
         echo "new_commit=${new_commit}" >> $GITHUB_OUTPUT
         echo "short_commit=${new_commit:0:7}" >> $GITHUB_OUTPUT
+    # TODO(https://github.com/googleapis/librarian/issues/6220): Remove this step.
     - name: Update generation_config.yaml
       run: |
         echo "Before update:"

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -68,14 +68,21 @@ jobs:
         new_commit=$(go run "github.com/googleapis/librarian/cmd/librarian@${version}" config get sources.googleapis.commit)
         echo "new_commit=${new_commit}" >> $GITHUB_OUTPUT
         echo "short_commit=${new_commit:0:7}" >> $GITHUB_OUTPUT
-    - name: Detect Changes To Librarian.yaml
-      id: detect_librarian
+    - name: Update generation_config.yaml
       run: |
-        git add librarian.yaml
+        echo "Before update:"
+        grep "^googleapis_commitish" generation_config.yaml
+        sed -i -e "s/^googleapis_commitish.*$/googleapis_commitish: ${{ steps.commit.outputs.new_commit }}/" generation_config.yaml
+        echo "After update:"
+        grep "^googleapis_commitish" generation_config.yaml
+    - name: Detect Changes To Configs
+      id: detect_config
+      run: |
+        git add librarian.yaml generation_config.yaml
         changed_files=$(git diff --cached --name-only)
         if [[ "${changed_files}" == "" ]]; then
           echo "has_changes=false" >> $GITHUB_OUTPUT
-          echo "No changes in librarian.yaml"
+          echo "No changes in librarian.yaml or generation_config.yaml"
         else
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
@@ -110,7 +117,7 @@ jobs:
       env:
         PYTHONPATH: ${{ github.workspace }}/sdk-platform-java/hermetic_build/library_generation/owlbot
     - name: Generate Libraries
-      if: steps.detect_librarian.outputs.has_changes == 'true'
+      if: steps.detect_config.outputs.has_changes == 'true'
       id: generate
       run: |
         go run github.com/googleapis/librarian/cmd/librarian@latest generate --all
@@ -123,11 +130,11 @@ jobs:
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
     - name: Commit and Create PR
-      if: steps.detect_librarian.outputs.has_changes == 'true' || steps.generate.outputs.has_changes == 'true'
+      if: steps.detect_config.outputs.has_changes == 'true' || steps.generate.outputs.has_changes == 'true'
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
         PR_TITLE: "chore: update googleapis commitish to ${{ steps.commit.outputs.short_commit }}"
-        PR_BODY: "Updated googleapis commitish in librarian.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}"
+        PR_BODY: "Updated googleapis commitish in librarian.yaml and generation_config.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}"
       run: |
         set -x
         

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -71,11 +71,8 @@ jobs:
     # TODO(https://github.com/googleapis/librarian/issues/6220): Remove this step.
     - name: Update generation_config.yaml
       run: |
-        echo "Before update:"
-        grep "^googleapis_commitish" generation_config.yaml
         sed -i -e "s/^googleapis_commitish.*$/googleapis_commitish: ${{ steps.commit.outputs.new_commit }}/" generation_config.yaml
-        echo "After update:"
-        grep "^googleapis_commitish" generation_config.yaml
+        git diff generation_config.yaml
     - name: Detect Changes To Librarian.yaml
       id: detect_librarian
       run: |


### PR DESCRIPTION
Add this step temporarily so that this workflow also triggers hermetic build generation workflow, and we can verify changes in the same PR.
This change is intended to be set till 06/10/2026 to verify librarian generate against hermetic build. 

Here is the sequence:
- nightly, this scheduled workflow updates librarian.yaml with new googleapis commit.
- [additional step] update generation_config.yaml with same commit.
- run `librarian generate -all` and add code change to commit
- raise PR.
- hermetic build [generation workflow](https://github.com/googleapis/google-cloud-java/blob/main/.github/workflows/hermetic_library_generation.yaml) triggered because generation_config.yaml `googleapis_commitish` is updated.

On the next day, we verify the results on this PR, expect hermetic build [generation workflow] runs succesfully with no code change added. If any, we should investigate the diff.

Note: hermetic build workflow will not trigger on this PR, because I pushed from fork. This is to avoid it adding code changes to this PR.