### PR TITLE
feat(bigquery-jdbc): implement connection scoped thread pools

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
@@ -80,7 +81,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   private VectorSchemaRoot vectorSchemaRoot;
   private VectorLoader vectorLoader;
   // producer thread's reference
-  private final Thread ownedThread;
+  private final Future<?> ownedFuture;
 
   private BigQueryArrowResultSet(
       Schema schema,
@@ -92,7 +93,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
       boolean isNested,
       int fromIndex,
       int toIndexExclusive,
-      Thread ownedThread,
+      Future<?> ownedFuture,
       BigQuery bigQuery)
       throws SQLException {
     super(bigQuery, statement, schema, isNested);
@@ -103,7 +104,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     this.fromIndex = fromIndex;
     this.toIndexExclusive = toIndexExclusive;
     this.nestedRowIndex = fromIndex - 1;
-    this.ownedThread = ownedThread;
+    this.ownedFuture = ownedFuture;
     if (!isNested && arrowSchema != null) {
       try {
         this.arrowDeserializer = new ArrowDeserializer(arrowSchema);
@@ -125,7 +126,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
       long totalRows,
       BigQueryStatement statement,
       BlockingQueue<BigQueryArrowBatchWrapper> buffer,
-      Thread ownedThread,
+      Future<?> ownedFuture,
       BigQuery bigQuery)
       throws SQLException {
     return new BigQueryArrowResultSet(
@@ -138,7 +139,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         false,
         -1,
         -1,
-        ownedThread,
+        ownedFuture,
         bigQuery);
   }
 
@@ -149,7 +150,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     this.currentNestedBatch = null;
     this.fromIndex = 0;
     this.toIndexExclusive = 0;
-    this.ownedThread = null;
+    this.ownedFuture = null;
     this.arrowDeserializer = null;
     this.vectorSchemaRoot = null;
     this.vectorLoader = null;
@@ -457,9 +458,8 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   public void close() {
     LOG.fineTrace("close", () -> String.format("Closing BigqueryArrowResultSet %s.", this));
     this.isClosed = true;
-    if (ownedThread != null && !ownedThread.isInterrupted()) {
-      // interrupt the producer thread when result set is closed
-      ownedThread.interrupt();
+    if (ownedFuture != null) {
+      ownedFuture.cancel(true);
     }
     super.close();
   }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -62,6 +62,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -209,6 +210,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   Boolean reqGoogleDriveScope;
   private final Properties clientInfo = new Properties();
   private boolean isReadOnlyTokenUsed = false;
+  private final ExecutorService executorService;
 
   BigQueryConnection(String url) throws IOException {
     this(url, DataSource.fromUrl(url));
@@ -344,6 +346,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
       this.headerProvider = createHeaderProvider();
       this.bigQuery = getBigQueryConnection();
+      this.executorService = BigQueryJdbcMdc.newFixedThreadPool(this.metadataFetchThreadCount);
     }
   }
 
@@ -954,6 +957,12 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
         statement.close();
       }
       this.openStatements.clear();
+
+      if (this.executorService != null) {
+        this.executorService.shutdown();
+        this.executorService.awaitTermination(10, TimeUnit.SECONDS);
+        this.executorService.shutdownNow();
+      }
     } catch (ConcurrentModificationException ex) {
       throw new BigQueryJdbcException("Concurrent modification during close", ex);
     } catch (InterruptedException e) {
@@ -963,6 +972,10 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
       BigQueryJdbcRootLogger.closeConnectionHandler(this.connectionId);
     }
     this.isClosed = true;
+  }
+
+  ExecutorService getExecutorService() {
+    return this.executorService;
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -68,10 +68,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -829,8 +830,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            apiExecutor = connection.getExecutorService();
-            routineProcessorExecutor = connection.getExecutorService();
+            apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
+            routineProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
 
             LOG.fine("Submitting parallel findMatchingRoutines tasks...");
             for (Dataset dataset : datasetsToScan) {
@@ -861,6 +862,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               apiFutures.add(apiFuture);
             }
             LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingRoutines tasks.");
+            apiExecutor.shutdown();
 
             LOG.fine("Processing results from findMatchingRoutines tasks...");
             for (Future<List<Routine>> apiFuture : apiFutures) {
@@ -935,14 +937,16 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
+            shutdownExecutor(apiExecutor);
+            shutdownExecutor(routineProcessorExecutor);
             LOG.info("Procedure fetcher thread finished.");
           }
         };
 
-    FutureTask<?> fetcherFuture = new FutureTask<>(procedureFetcher, null);
-    Thread fetcherThread = new Thread(fetcherFuture, "getProcedures-fetcher-" + catalog);
+    Thread fetcherThread = new Thread(procedureFetcher, "getProcedures-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
+        BigQueryJsonResultSet.of(
+            resultSchema, -1, queue, null, new Future<?>[] {new ThreadFuture(fetcherThread)});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedures");
@@ -1105,7 +1109,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            listRoutinesExecutor = connection.getExecutorService();
+            listRoutinesExecutor =
+                Executors.newFixedThreadPool(
+                    API_EXECUTOR_POOL_SIZE,
+                    runnable -> new Thread(runnable, "pcol-list-rout" + fetcherThreadNameSuffix));
             List<RoutineId> procedureIdsToGet =
                 listMatchingProcedureIdsFromDatasets(
                     datasetsToScan,
@@ -1114,15 +1121,22 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                     listRoutinesExecutor,
                     catalogParam,
                     LOG);
+            shutdownExecutor(listRoutinesExecutor);
+            listRoutinesExecutor = null;
 
             if (procedureIdsToGet.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info("Fetcher: No procedure IDs found or interrupted. Catalog: " + catalogParam);
               return;
             }
 
-            getRoutineDetailsExecutor = connection.getExecutorService();
+            getRoutineDetailsExecutor =
+                Executors.newFixedThreadPool(
+                    100,
+                    runnable -> new Thread(runnable, "pcol-get-details" + fetcherThreadNameSuffix));
             List<Routine> fullRoutines =
                 fetchFullRoutineDetailsForIds(procedureIdsToGet, getRoutineDetailsExecutor, LOG);
+            shutdownExecutor(getRoutineDetailsExecutor);
+            getRoutineDetailsExecutor = null;
 
             if (fullRoutines.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info(
@@ -1130,7 +1144,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            processArgsExecutor = connection.getExecutorService();
+            processArgsExecutor =
+                Executors.newFixedThreadPool(
+                    this.metadataFetchThreadCount,
+                    runnable -> new Thread(runnable, "pcol-proc-args" + fetcherThreadNameSuffix));
             submitProcedureArgumentProcessingJobs(
                 fullRoutines,
                 columnNameRegex,
@@ -1181,14 +1198,18 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, resultSchema.getFields());
+            if (listRoutinesExecutor != null) shutdownExecutor(listRoutinesExecutor);
+            if (getRoutineDetailsExecutor != null) shutdownExecutor(getRoutineDetailsExecutor);
+            if (processArgsExecutor != null) shutdownExecutor(processArgsExecutor);
             LOG.info("Procedure column fetcher thread finished for catalog: " + catalogParam);
           }
         };
 
-    FutureTask<?> fetcherFuture = new FutureTask<>(procedureColumnFetcher, null);
-    Thread fetcherThread = new Thread(fetcherFuture, "getProcedureColumns-fetcher-" + catalog);
+    Thread fetcherThread =
+        new Thread(procedureColumnFetcher, "getProcedureColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
+        BigQueryJsonResultSet.of(
+            resultSchema, -1, queue, null, new Future<?>[] {new ThreadFuture(fetcherThread)});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedureColumns for catalog: " + catalog);
@@ -1749,8 +1770,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            apiExecutor = connection.getExecutorService();
-            tableProcessorExecutor = connection.getExecutorService();
+            apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
+            tableProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
 
             LOG.fine("Submitting parallel findMatchingTables tasks...");
             for (Dataset dataset : datasetsToScan) {
@@ -1781,6 +1802,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               apiFutures.add(apiFuture);
             }
             LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
+            apiExecutor.shutdown();
 
             LOG.fine("Processing results from findMatchingTables tasks...");
             for (Future<List<Table>> apiFuture : apiFutures) {
@@ -1850,14 +1872,16 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
+            shutdownExecutor(apiExecutor);
+            shutdownExecutor(tableProcessorExecutor);
             LOG.info("Table fetcher thread finished.");
           }
         };
 
-    FutureTask<?> fetcherFuture = new FutureTask<>(tableFetcher, null);
-    Thread fetcherThread = new Thread(fetcherFuture, "getTables-fetcher-" + effectiveCatalog);
+    Thread fetcherThread = new Thread(tableFetcher, "getTables-fetcher-" + effectiveCatalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
+        BigQueryJsonResultSet.of(
+            resultSchema, -1, queue, null, new Future<?>[] {new ThreadFuture(fetcherThread)});
 
     fetcherThread.start();
     LOG.info("Started background thread for getTables");
@@ -2111,7 +2135,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            columnExecutor = connection.getExecutorService();
+            columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
 
             for (Dataset dataset : datasetsToScan) {
               if (Thread.currentThread().isInterrupted()) {
@@ -2177,14 +2201,15 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             taskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
+            shutdownExecutor(columnExecutor);
             LOG.info("Column fetcher thread finished.");
           }
         };
 
-    FutureTask<?> fetcherFuture = new FutureTask<>(columnFetcher, null);
-    Thread fetcherThread = new Thread(fetcherFuture, "getColumns-fetcher-" + effectiveCatalog);
+    Thread fetcherThread = new Thread(columnFetcher, "getColumns-fetcher-" + effectiveCatalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
+        BigQueryJsonResultSet.of(
+            resultSchema, -1, queue, null, new Future<?>[] {new ThreadFuture(fetcherThread)});
 
     fetcherThread.start();
     LOG.info("Started background thread for getColumns");
@@ -3692,10 +3717,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
           }
         };
 
-    FutureTask<?> fetcherFuture = new FutureTask<>(schemaFetcher, null);
-    Thread fetcherThread = new Thread(fetcherFuture, "getSchemas-fetcher-" + catalog);
+    Thread fetcherThread = new Thread(schemaFetcher, "getSchemas-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
+        BigQueryJsonResultSet.of(
+            resultSchema, -1, queue, null, new Future<?>[] {new ThreadFuture(fetcherThread)});
 
     fetcherThread.start();
     LOG.info("Started background thread for getSchemas");
@@ -3888,8 +3913,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            apiExecutor = connection.getExecutorService();
-            routineProcessorExecutor = connection.getExecutorService();
+            apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
+            routineProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
 
             for (Dataset dataset : datasetsToScan) {
               if (Thread.currentThread().isInterrupted()) {
@@ -3927,6 +3952,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                 "Finished submitting "
                     + apiFutures.size()
                     + " findMatchingRoutines (for functions) tasks.");
+            apiExecutor.shutdown();
 
             for (Future<List<Routine>> apiFuture : apiFutures) {
               if (Thread.currentThread().isInterrupted()) {
@@ -3980,14 +4006,16 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
+            shutdownExecutor(apiExecutor);
+            shutdownExecutor(routineProcessorExecutor);
             LOG.info("Function fetcher thread finished.");
           }
         };
 
-    FutureTask<?> fetcherFuture = new FutureTask<>(functionFetcher, null);
-    Thread fetcherThread = new Thread(fetcherFuture, "getFunctions-fetcher-" + catalog);
+    Thread fetcherThread = new Thread(functionFetcher, "getFunctions-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
+        BigQueryJsonResultSet.of(
+            resultSchema, -1, queue, null, new Future<?>[] {new ThreadFuture(fetcherThread)});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctions");
@@ -4140,7 +4168,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            listRoutinesExecutor = connection.getExecutorService();
+            listRoutinesExecutor =
+                Executors.newFixedThreadPool(
+                    API_EXECUTOR_POOL_SIZE,
+                    runnable -> new Thread(runnable, "funcol-list-rout" + fetcherThreadNameSuffix));
             List<RoutineId> functionIdsToGet =
                 listMatchingFunctionIdsFromDatasets(
                     datasetsToScan,
@@ -4149,15 +4180,23 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                     listRoutinesExecutor,
                     catalogParam,
                     LOG);
+            shutdownExecutor(listRoutinesExecutor);
+            listRoutinesExecutor = null;
 
             if (functionIdsToGet.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info("Fetcher: No function IDs found or interrupted. Catalog: " + catalogParam);
               return;
             }
 
-            getRoutineDetailsExecutor = connection.getExecutorService();
+            getRoutineDetailsExecutor =
+                Executors.newFixedThreadPool(
+                    this.metadataFetchThreadCount,
+                    runnable ->
+                        new Thread(runnable, "funcol-get-details" + fetcherThreadNameSuffix));
             List<Routine> fullFunctions =
                 fetchFullRoutineDetailsForIds(functionIdsToGet, getRoutineDetailsExecutor, LOG);
+            shutdownExecutor(getRoutineDetailsExecutor);
+            getRoutineDetailsExecutor = null;
 
             if (fullFunctions.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info(
@@ -4165,7 +4204,11 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            processParamsExecutor = connection.getExecutorService();
+            processParamsExecutor =
+                Executors.newFixedThreadPool(
+                    this.metadataFetchThreadCount,
+                    runnable ->
+                        new Thread(runnable, "funcol-proc-params" + fetcherThreadNameSuffix));
             submitFunctionParameterProcessingJobs(
                 fullFunctions,
                 columnNameRegex,
@@ -4216,14 +4259,18 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, resultSchemaFields);
+            if (listRoutinesExecutor != null) shutdownExecutor(listRoutinesExecutor);
+            if (getRoutineDetailsExecutor != null) shutdownExecutor(getRoutineDetailsExecutor);
+            if (processParamsExecutor != null) shutdownExecutor(processParamsExecutor);
             LOG.info("Function column fetcher thread finished for catalog: " + catalogParam);
           }
         };
 
-    FutureTask<?> fetcherFuture = new FutureTask<>(functionColumnFetcher, null);
-    Thread fetcherThread = new Thread(fetcherFuture, "getFunctionColumns-fetcher-" + catalog);
+    Thread fetcherThread =
+        new Thread(functionColumnFetcher, "getFunctionColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
+        BigQueryJsonResultSet.of(
+            resultSchema, -1, queue, null, new Future<?>[] {new ThreadFuture(fetcherThread)});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctionColumns for catalog: " + catalog);
@@ -5225,5 +5272,59 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       LOG.severe(errorMessage, ex);
       throw ex;
     }
+  }
+}
+
+/**
+ * Temporary bridge class to wrap a Thread inside a Future interface.
+ *
+ * @deprecated This class will soon be removed once the DatabaseMetaData execution tasks are
+ *     migrated to use the connection-scoped thread pool.
+ */
+@Deprecated
+class ThreadFuture implements Future<Void> {
+  private final Thread thread;
+
+  public ThreadFuture(Thread thread) {
+    this.thread = thread;
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    if (mayInterruptIfRunning && thread != null) {
+      thread.interrupt();
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return thread != null && thread.isInterrupted();
+  }
+
+  @Override
+  public boolean isDone() {
+    return thread == null || !thread.isAlive();
+  }
+
+  @Override
+  public Void get() throws InterruptedException, ExecutionException {
+    if (thread != null) {
+      thread.join();
+    }
+    return null;
+  }
+
+  @Override
+  public Void get(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    if (thread != null) {
+      unit.timedJoin(thread, timeout);
+      if (thread.isAlive()) {
+        throw new TimeoutException();
+      }
+    }
+    return null;
   }
 }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaData.java
@@ -68,8 +68,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -829,8 +829,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
-            routineProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+            apiExecutor = connection.getExecutorService();
+            routineProcessorExecutor = connection.getExecutorService();
 
             LOG.fine("Submitting parallel findMatchingRoutines tasks...");
             for (Dataset dataset : datasetsToScan) {
@@ -861,7 +861,6 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               apiFutures.add(apiFuture);
             }
             LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingRoutines tasks.");
-            apiExecutor.shutdown();
 
             LOG.fine("Processing results from findMatchingRoutines tasks...");
             for (Future<List<Routine>> apiFuture : apiFutures) {
@@ -936,15 +935,14 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
-            shutdownExecutor(apiExecutor);
-            shutdownExecutor(routineProcessorExecutor);
             LOG.info("Procedure fetcher thread finished.");
           }
         };
 
-    Thread fetcherThread = new Thread(procedureFetcher, "getProcedures-fetcher-" + catalog);
+    FutureTask<?> fetcherFuture = new FutureTask<>(procedureFetcher, null);
+    Thread fetcherThread = new Thread(fetcherFuture, "getProcedures-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedures");
@@ -1107,10 +1105,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            listRoutinesExecutor =
-                Executors.newFixedThreadPool(
-                    API_EXECUTOR_POOL_SIZE,
-                    runnable -> new Thread(runnable, "pcol-list-rout" + fetcherThreadNameSuffix));
+            listRoutinesExecutor = connection.getExecutorService();
             List<RoutineId> procedureIdsToGet =
                 listMatchingProcedureIdsFromDatasets(
                     datasetsToScan,
@@ -1119,22 +1114,15 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                     listRoutinesExecutor,
                     catalogParam,
                     LOG);
-            shutdownExecutor(listRoutinesExecutor);
-            listRoutinesExecutor = null;
 
             if (procedureIdsToGet.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info("Fetcher: No procedure IDs found or interrupted. Catalog: " + catalogParam);
               return;
             }
 
-            getRoutineDetailsExecutor =
-                Executors.newFixedThreadPool(
-                    100,
-                    runnable -> new Thread(runnable, "pcol-get-details" + fetcherThreadNameSuffix));
+            getRoutineDetailsExecutor = connection.getExecutorService();
             List<Routine> fullRoutines =
                 fetchFullRoutineDetailsForIds(procedureIdsToGet, getRoutineDetailsExecutor, LOG);
-            shutdownExecutor(getRoutineDetailsExecutor);
-            getRoutineDetailsExecutor = null;
 
             if (fullRoutines.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info(
@@ -1142,10 +1130,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            processArgsExecutor =
-                Executors.newFixedThreadPool(
-                    this.metadataFetchThreadCount,
-                    runnable -> new Thread(runnable, "pcol-proc-args" + fetcherThreadNameSuffix));
+            processArgsExecutor = connection.getExecutorService();
             submitProcedureArgumentProcessingJobs(
                 fullRoutines,
                 columnNameRegex,
@@ -1196,17 +1181,14 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, resultSchema.getFields());
-            if (listRoutinesExecutor != null) shutdownExecutor(listRoutinesExecutor);
-            if (getRoutineDetailsExecutor != null) shutdownExecutor(getRoutineDetailsExecutor);
-            if (processArgsExecutor != null) shutdownExecutor(processArgsExecutor);
             LOG.info("Procedure column fetcher thread finished for catalog: " + catalogParam);
           }
         };
 
-    Thread fetcherThread =
-        new Thread(procedureColumnFetcher, "getProcedureColumns-fetcher-" + catalog);
+    FutureTask<?> fetcherFuture = new FutureTask<>(procedureColumnFetcher, null);
+    Thread fetcherThread = new Thread(fetcherFuture, "getProcedureColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
 
     fetcherThread.start();
     LOG.info("Started background thread for getProcedureColumns for catalog: " + catalog);
@@ -1767,8 +1749,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
-            tableProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+            apiExecutor = connection.getExecutorService();
+            tableProcessorExecutor = connection.getExecutorService();
 
             LOG.fine("Submitting parallel findMatchingTables tasks...");
             for (Dataset dataset : datasetsToScan) {
@@ -1799,7 +1781,6 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               apiFutures.add(apiFuture);
             }
             LOG.fine("Finished submitting " + apiFutures.size() + " findMatchingTables tasks.");
-            apiExecutor.shutdown();
 
             LOG.fine("Processing results from findMatchingTables tasks...");
             for (Future<List<Table>> apiFuture : apiFutures) {
@@ -1869,15 +1850,14 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
-            shutdownExecutor(apiExecutor);
-            shutdownExecutor(tableProcessorExecutor);
             LOG.info("Table fetcher thread finished.");
           }
         };
 
-    Thread fetcherThread = new Thread(tableFetcher, "getTables-fetcher-" + effectiveCatalog);
+    FutureTask<?> fetcherFuture = new FutureTask<>(tableFetcher, null);
+    Thread fetcherThread = new Thread(fetcherFuture, "getTables-fetcher-" + effectiveCatalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
 
     fetcherThread.start();
     LOG.info("Started background thread for getTables");
@@ -2017,7 +1997,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     populateQueue(catalogRows, queue, schemaFields);
     signalEndOfData(queue, schemaFields);
 
-    return BigQueryJsonResultSet.of(catalogsSchema, catalogRows.size(), queue, null, new Thread[0]);
+    return BigQueryJsonResultSet.of(
+        catalogsSchema, catalogRows.size(), queue, null, new Future<?>[0]);
   }
 
   Schema defineGetCatalogsSchema() {
@@ -2049,7 +2030,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     signalEndOfData(queue, tableTypesSchema.getFields());
 
     return BigQueryJsonResultSet.of(
-        tableTypesSchema, tableTypeRows.size(), queue, null, new Thread[0]);
+        tableTypesSchema, tableTypeRows.size(), queue, null, new Future<?>[0]);
   }
 
   static Schema defineGetTableTypesSchema() {
@@ -2130,7 +2111,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            columnExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+            columnExecutor = connection.getExecutorService();
 
             for (Dataset dataset : datasetsToScan) {
               if (Thread.currentThread().isInterrupted()) {
@@ -2196,14 +2177,14 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             taskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
-            shutdownExecutor(columnExecutor);
             LOG.info("Column fetcher thread finished.");
           }
         };
 
-    Thread fetcherThread = new Thread(columnFetcher, "getColumns-fetcher-" + effectiveCatalog);
+    FutureTask<?> fetcherFuture = new FutureTask<>(columnFetcher, null);
+    Thread fetcherThread = new Thread(fetcherFuture, "getColumns-fetcher-" + effectiveCatalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
 
     fetcherThread.start();
     LOG.info("Started background thread for getColumns");
@@ -2718,7 +2699,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
     populateQueue(typeInfoRows, queue, schemaFields);
     signalEndOfData(queue, schemaFields);
     return BigQueryJsonResultSet.of(
-        typeInfoSchema, typeInfoRows.size(), queue, null, new Thread[0]);
+        typeInfoSchema, typeInfoRows.size(), queue, null, new Future<?>[0]);
   }
 
   Schema defineGetTypeInfoSchema() {
@@ -3711,9 +3692,10 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
           }
         };
 
-    Thread fetcherThread = new Thread(schemaFetcher, "getSchemas-fetcher-" + catalog);
+    FutureTask<?> fetcherFuture = new FutureTask<>(schemaFetcher, null);
+    Thread fetcherThread = new Thread(fetcherFuture, "getSchemas-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
 
     fetcherThread.start();
     LOG.info("Started background thread for getSchemas");
@@ -3832,7 +3814,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
       signalEndOfData(queue, resultSchemaFields);
     }
     return BigQueryJsonResultSet.of(
-        resultSchema, collectedResults.size(), queue, null, new Thread[0]);
+        resultSchema, collectedResults.size(), queue, null, new Future<?>[0]);
   }
 
   Schema defineGetClientInfoPropertiesSchema() {
@@ -3906,8 +3888,8 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            apiExecutor = Executors.newFixedThreadPool(API_EXECUTOR_POOL_SIZE);
-            routineProcessorExecutor = Executors.newFixedThreadPool(this.metadataFetchThreadCount);
+            apiExecutor = connection.getExecutorService();
+            routineProcessorExecutor = connection.getExecutorService();
 
             for (Dataset dataset : datasetsToScan) {
               if (Thread.currentThread().isInterrupted()) {
@@ -3945,7 +3927,6 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                 "Finished submitting "
                     + apiFutures.size()
                     + " findMatchingRoutines (for functions) tasks.");
-            apiExecutor.shutdown();
 
             for (Future<List<Routine>> apiFuture : apiFutures) {
               if (Thread.currentThread().isInterrupted()) {
@@ -3999,15 +3980,14 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, localResultSchemaFields);
-            shutdownExecutor(apiExecutor);
-            shutdownExecutor(routineProcessorExecutor);
             LOG.info("Function fetcher thread finished.");
           }
         };
 
-    Thread fetcherThread = new Thread(functionFetcher, "getFunctions-fetcher-" + catalog);
+    FutureTask<?> fetcherFuture = new FutureTask<>(functionFetcher, null);
+    Thread fetcherThread = new Thread(fetcherFuture, "getFunctions-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctions");
@@ -4160,10 +4140,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            listRoutinesExecutor =
-                Executors.newFixedThreadPool(
-                    API_EXECUTOR_POOL_SIZE,
-                    runnable -> new Thread(runnable, "funcol-list-rout" + fetcherThreadNameSuffix));
+            listRoutinesExecutor = connection.getExecutorService();
             List<RoutineId> functionIdsToGet =
                 listMatchingFunctionIdsFromDatasets(
                     datasetsToScan,
@@ -4172,23 +4149,15 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
                     listRoutinesExecutor,
                     catalogParam,
                     LOG);
-            shutdownExecutor(listRoutinesExecutor);
-            listRoutinesExecutor = null;
 
             if (functionIdsToGet.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info("Fetcher: No function IDs found or interrupted. Catalog: " + catalogParam);
               return;
             }
 
-            getRoutineDetailsExecutor =
-                Executors.newFixedThreadPool(
-                    this.metadataFetchThreadCount,
-                    runnable ->
-                        new Thread(runnable, "funcol-get-details" + fetcherThreadNameSuffix));
+            getRoutineDetailsExecutor = connection.getExecutorService();
             List<Routine> fullFunctions =
                 fetchFullRoutineDetailsForIds(functionIdsToGet, getRoutineDetailsExecutor, LOG);
-            shutdownExecutor(getRoutineDetailsExecutor);
-            getRoutineDetailsExecutor = null;
 
             if (fullFunctions.isEmpty() || Thread.currentThread().isInterrupted()) {
               LOG.info(
@@ -4196,11 +4165,7 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
               return;
             }
 
-            processParamsExecutor =
-                Executors.newFixedThreadPool(
-                    this.metadataFetchThreadCount,
-                    runnable ->
-                        new Thread(runnable, "funcol-proc-params" + fetcherThreadNameSuffix));
+            processParamsExecutor = connection.getExecutorService();
             submitFunctionParameterProcessingJobs(
                 fullFunctions,
                 columnNameRegex,
@@ -4251,17 +4216,14 @@ class BigQueryDatabaseMetaData implements DatabaseMetaData {
             processingTaskFutures.forEach(f -> f.cancel(true));
           } finally {
             signalEndOfData(queue, resultSchemaFields);
-            if (listRoutinesExecutor != null) shutdownExecutor(listRoutinesExecutor);
-            if (getRoutineDetailsExecutor != null) shutdownExecutor(getRoutineDetailsExecutor);
-            if (processParamsExecutor != null) shutdownExecutor(processParamsExecutor);
             LOG.info("Function column fetcher thread finished for catalog: " + catalogParam);
           }
         };
 
-    Thread fetcherThread =
-        new Thread(functionColumnFetcher, "getFunctionColumns-fetcher-" + catalog);
+    FutureTask<?> fetcherFuture = new FutureTask<>(functionColumnFetcher, null);
+    Thread fetcherThread = new Thread(fetcherFuture, "getFunctionColumns-fetcher-" + catalog);
     BigQueryJsonResultSet resultSet =
-        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Thread[] {fetcherThread});
+        BigQueryJsonResultSet.of(resultSchema, -1, queue, null, new Future<?>[] {fetcherFuture});
 
     fetcherThread.start();
     LOG.info("Started background thread for getFunctionColumns for catalog: " + catalog);

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcMdc.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcMdc.java
@@ -29,6 +29,9 @@ import java.util.concurrent.TimeUnit;
 
 /** Lightweight MDC implementation for the BigQuery JDBC driver using InheritableThreadLocal. */
 class BigQueryJdbcMdc {
+  private static final BigQueryJdbcCustomLogger LOG =
+      new BigQueryJdbcCustomLogger(BigQueryJdbcMdc.class.getName());
+
   private static final InheritableThreadLocal<String> currentConnectionId =
       new InheritableThreadLocal<>();
 
@@ -106,6 +109,13 @@ class BigQueryJdbcMdc {
     public void execute(Runnable command) {
       if (command == null) {
         throw new NullPointerException();
+      }
+      int queueSize = getQueue().size();
+      if (queueSize > 0 && queueSize % 10 == 0) {
+        LOG.warning(
+            "Thread pool queue size reached "
+                + queueSize
+                + ". Tasks are waiting for threads to free up.");
       }
       if (command instanceof MdcFutureTask) {
         super.execute(command);

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Future;
 
 /** {@link ResultSet} Implementation for JSON datasource (Using REST APIs) */
 class BigQueryJsonResultSet extends BigQueryBaseResultSet {
@@ -42,7 +43,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   private boolean afterLast = false;
   private final int fromIndex;
   private final int toIndexExclusive;
-  private final Thread[] ownedThreads;
+  private final Future<?>[] ownedFutures;
 
   private BigQueryJsonResultSet(
       Schema schema,
@@ -53,7 +54,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
       BigQueryFieldValueListWrapper cursor,
       int fromIndex,
       int toIndexExclusive,
-      Thread[] ownedThreads,
+      Future<?>[] ownedFutures,
       BigQuery bigQuery) {
     super(bigQuery, statement, schema, isNested);
     this.totalRows = totalRows;
@@ -62,7 +63,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
     this.fromIndex = fromIndex;
     this.toIndexExclusive = toIndexExclusive;
     this.nestedRowIndex = fromIndex - 1;
-    this.ownedThreads = ownedThreads;
+    this.ownedFutures = ownedFutures;
   }
 
   /**
@@ -76,11 +77,11 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
       long totalRows,
       BlockingQueue<BigQueryFieldValueListWrapper> buffer,
       BigQueryStatement statement,
-      Thread[] ownedThreads,
+      Future<?>[] ownedFutures,
       BigQuery bigQuery) {
 
     return new BigQueryJsonResultSet(
-        schema, totalRows, buffer, statement, false, null, -1, -1, ownedThreads, bigQuery);
+        schema, totalRows, buffer, statement, false, null, -1, -1, ownedFutures, bigQuery);
   }
 
   static BigQueryJsonResultSet of(
@@ -88,10 +89,10 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
       long totalRows,
       BlockingQueue<BigQueryFieldValueListWrapper> buffer,
       BigQueryStatement statement,
-      Thread[] ownedThreads) {
+      Future<?>[] ownedFutures) {
 
     return new BigQueryJsonResultSet(
-        schema, totalRows, buffer, statement, false, null, -1, -1, ownedThreads, null);
+        schema, totalRows, buffer, statement, false, null, -1, -1, ownedFutures, null);
   }
 
   BigQueryJsonResultSet() {
@@ -99,7 +100,7 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
     totalRows = 0;
     buffer = null;
     fromIndex = 0;
-    ownedThreads = new Thread[0];
+    ownedFutures = new Future<?>[0];
     toIndexExclusive = 0;
   }
 
@@ -276,10 +277,10 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
   public void close() {
     LOG.fineTrace("close", () -> String.format("Closing BigqueryJsonResultSet %s.", this));
     this.isClosed = true;
-    if (ownedThreads != null) {
-      for (Thread ownedThread : ownedThreads) {
-        if (!ownedThread.isInterrupted()) {
-          ownedThread.interrupt();
+    if (ownedFutures != null) {
+      for (Future<?> ownedFuture : ownedFutures) {
+        if (ownedFuture != null) {
+          ownedFuture.cancel(true);
         }
       }
     }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizers.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigquery.jdbc;
 import com.google.api.core.InternalApi;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
+import java.util.concurrent.Future;
 
 @InternalApi
 class BigQueryResultSetFinalizers {
@@ -27,44 +28,44 @@ class BigQueryResultSetFinalizers {
 
   @InternalApi
   static class ArrowResultSetFinalizer extends PhantomReference<BigQueryArrowResultSet> {
-    Thread ownedThread;
+    Future<?> ownedFuture;
 
     public ArrowResultSetFinalizer(
         BigQueryArrowResultSet referent,
         ReferenceQueue<? super BigQueryArrowResultSet> q,
-        Thread ownedThread) {
+        Future<?> ownedFuture) {
       super(referent, q);
-      this.ownedThread = ownedThread;
+      this.ownedFuture = ownedFuture;
     }
 
     // Free resources. Remove all the hard refs
     public void finalizeResources() {
       LOG.finestTrace("finalizeResources");
-      if (ownedThread != null && !ownedThread.isInterrupted()) {
-        ownedThread.interrupt();
+      if (ownedFuture != null) {
+        ownedFuture.cancel(true);
       }
     }
   }
 
   @InternalApi
   static class JsonResultSetFinalizer extends PhantomReference<BigQueryJsonResultSet> {
-    Thread[] ownedThreads;
+    Future<?>[] ownedFutures;
 
     public JsonResultSetFinalizer(
         BigQueryJsonResultSet referent,
         ReferenceQueue<? super BigQueryJsonResultSet> q,
-        Thread[] ownedThreads) {
+        Future<?>[] ownedFutures) {
       super(referent, q);
-      this.ownedThreads = ownedThreads;
+      this.ownedFutures = ownedFutures;
     }
 
     // Free resources. Remove all the hard refs
     public void finalizeResources() {
       LOG.finestTrace("finalizeResources");
-      if (ownedThreads != null) {
-        for (Thread ownedThread : ownedThreads) {
-          if (!ownedThread.isInterrupted()) {
-            ownedThread.interrupt();
+      if (ownedFutures != null) {
+        for (Future<?> ownedFuture : ownedFutures) {
+          if (ownedFuture != null) {
+            ownedFuture.cancel(true);
           }
         }
       }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -76,7 +76,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadFactory;
 import java.util.logging.Level;
@@ -90,10 +90,7 @@ import java.util.logging.Level;
  */
 public class BigQueryStatement extends BigQueryNoOpsStatement {
 
-  // TODO (obada): Update this after benchmarking
-  private static final int MAX_PROCESS_QUERY_THREADS_CNT = 50;
-  protected static ExecutorService queryTaskExecutor =
-      Executors.newFixedThreadPool(MAX_PROCESS_QUERY_THREADS_CNT);
+  protected final ExecutorService queryTaskExecutor;
   private final BigQueryJdbcCustomLogger LOG = new BigQueryJdbcCustomLogger(this.toString());
   private static final String DEFAULT_DATASET_NAME = "_google_jdbc";
   private static final String DEFAULT_TABLE_NAME = "temp_table_";
@@ -156,6 +153,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     this.connectionId = connection.getConnectionId();
     this.bigQuery = connection.getBigQuery();
     this.querySettings = generateBigQuerySettings();
+    this.queryTaskExecutor = connection.getExecutorService();
   }
 
   private void resetStatementFields() {
@@ -827,7 +825,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       ReadSession readSession = getReadSession(builder.build());
       this.arrowBatchWrapperBlockingQueue = new LinkedBlockingDeque<>(getBufferSize());
       // deserialize and populate the buffer async, so that the client isn't blocked
-      Thread populateBufferWorker =
+      Future<?> populateBufferWorker =
           populateArrowBufferedQueue(
               readSession, this.arrowBatchWrapperBlockingQueue, this.bigQueryReadClient);
 
@@ -853,7 +851,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
 
   /** Asynchronously reads results and populates an arrow record queue */
   @InternalApi
-  Thread populateArrowBufferedQueue(
+  Future<?> populateArrowBufferedQueue(
       ReadSession readSession,
       BlockingQueue<BigQueryArrowBatchWrapper> arrowBatchWrapperBlockingQueue,
       BigQueryReadClient bqReadClient) {
@@ -941,8 +939,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
           }
         };
 
-    Thread populateBufferWorker = JDBC_THREAD_FACTORY.newThread(arrowStreamProcessor);
-    populateBufferWorker.start();
+    Future<?> populateBufferWorker = queryTaskExecutor.submit(arrowStreamProcessor);
     return populateBufferWorker;
   }
 
@@ -1024,7 +1021,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   }
 
   BigQueryJsonResultSet processJsonResultSet(TableResult results) {
-    List<Thread> threadList = new ArrayList<Thread>();
+    List<Future<?>> threadList = new ArrayList<>();
 
     Schema schema = results.getSchema();
     long totalRows = (getMaxRows() > 0) ? getMaxRows() : results.getTotalRows();
@@ -1035,7 +1032,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     JobId jobId = results.getJobId();
     if (jobId != null) {
       // Thread to make rpc calls to fetch data from the server
-      Thread nextPageWorker =
+      Future<?> nextPageWorker =
           runNextPageTaskAsync(
               results,
               results.getNextPageToken(),
@@ -1055,12 +1052,12 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     }
 
     // Thread to parse data received from the server to client library objects
-    Thread populateBufferWorker =
+    Future<?> populateBufferWorker =
         parseAndPopulateRpcDataAsync(
             schema, this.bigQueryFieldValueListWrapperBlockingQueue, rpcResponseQueue);
     threadList.add(populateBufferWorker);
 
-    Thread[] jsonWorkers = threadList.toArray(new Thread[0]);
+    Future<?>[] jsonWorkers = threadList.toArray(new Future<?>[0]);
 
     BigQueryJsonResultSet jsonResultSet =
         BigQueryJsonResultSet.of(
@@ -1102,7 +1099,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   }
 
   @VisibleForTesting
-  Thread runNextPageTaskAsync(
+  Future<?> runNextPageTaskAsync(
       TableResult result,
       String firstPageToken,
       JobId jobId,
@@ -1161,8 +1158,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
           // have finished processing the records and even that will be interrupted
         };
 
-    Thread nextPageWorker = JDBC_THREAD_FACTORY.newThread(nextPageTask);
-    nextPageWorker.start();
+    Future<?> nextPageWorker = queryTaskExecutor.submit(nextPageTask);
     return nextPageWorker;
   }
 
@@ -1171,7 +1167,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
    * bigQueryFieldValueListWrapperBlockingQueue with FieldValueList
    */
   @VisibleForTesting
-  Thread parseAndPopulateRpcDataAsync(
+  Future<?> parseAndPopulateRpcDataAsync(
       Schema schema,
       BlockingQueue<BigQueryFieldValueListWrapper> bigQueryFieldValueListWrapperBlockingQueue,
       BlockingQueue<Tuple<TableResult, Boolean>> rpcResponseQueue) {
@@ -1246,8 +1242,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
           }
         };
 
-    Thread populateBufferWorker = JDBC_THREAD_FACTORY.newThread(populateBufferRunnable);
-    populateBufferWorker.start();
+    Future<?> populateBufferWorker = queryTaskExecutor.submit(populateBufferRunnable);
     return populateBufferWorker;
   }
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSetTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSetTest.java
@@ -237,10 +237,10 @@ public class BigQueryArrowResultSetTest {
         ArrowSchema.newBuilder()
             .setSerializedSchema(serializeSchema(vectorSchemaRoot.getSchema()))
             .build();
-    Thread workerThread = new Thread();
+    java.util.concurrent.Future<?> workerFuture = mock(java.util.concurrent.Future.class);
     bigQueryArrowResultSet =
         BigQueryArrowResultSet.of(
-            QUERY_SCHEMA, arrowSchema, 1, statement, buffer, workerThread, null);
+            QUERY_SCHEMA, arrowSchema, 1, statement, buffer, workerFuture, null);
 
     // nested result set data setup
     JsonStringArrayList<Long> jsonStringArrayList = getJsonStringArrayList();
@@ -275,17 +275,17 @@ public class BigQueryArrowResultSetTest {
         ArrowSchema.newBuilder()
             .setSerializedSchema(serializeSchema(vectorSchemaRoot.getSchema()))
             .build();
-    Thread workerThread = new Thread();
+    java.util.concurrent.Future<?> workerFuture = mock(java.util.concurrent.Future.class);
     // ResultSet with 1 row buffer and 1 total rows.
     BigQueryArrowResultSet bigQueryArrowResultSet2 =
         BigQueryArrowResultSet.of(
-            QUERY_SCHEMA, arrowSchema, 1, statement, buffer, workerThread, null);
+            QUERY_SCHEMA, arrowSchema, 1, statement, buffer, workerFuture, null);
 
     assertThat(resultSetRowCount(bigQueryArrowResultSet2)).isEqualTo(1);
     // ResultSet with 2 rows buffer and 1 total rows.
     bigQueryArrowResultSet2 =
         BigQueryArrowResultSet.of(
-            QUERY_SCHEMA, arrowSchema, 1, statement, bufferWithTwoRows, workerThread, null);
+            QUERY_SCHEMA, arrowSchema, 1, statement, bufferWithTwoRows, workerFuture, null);
 
     assertThat(resultSetRowCount(bigQueryArrowResultSet2)).isEqualTo(1);
   }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryCallableStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryCallableStatementTest.java
@@ -33,6 +33,7 @@ import java.sql.*;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +46,8 @@ public class BigQueryCallableStatementTest {
   @BeforeEach
   public void setUp() throws IOException, SQLException {
     bigQueryConnection = mock(BigQueryConnection.class);
+    ExecutorService mockExecutorService = mock(ExecutorService.class);
+    doReturn(mockExecutorService).when(bigQueryConnection).getExecutorService();
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcMdcTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcMdcTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
@@ -250,5 +251,56 @@ public class BigQueryJdbcMdcTest {
     } finally {
       executor.shutdownNow();
     }
+  }
+
+  @Test
+  public void testConnectionScopedExecutorLifecycle() throws Exception {
+    String url1 =
+        "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;"
+            + "OAuthType=2;ProjectId=Proj1;"
+            + "OAuthAccessToken=redacted;OAuthClientId=redacted;OAuthClientSecret=redacted;"
+            + "metadataFetchThreadCount=5;";
+    String url2 =
+        "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;"
+            + "OAuthType=2;ProjectId=Proj2;"
+            + "OAuthAccessToken=redacted;OAuthClientId=redacted;OAuthClientSecret=redacted;"
+            + "metadataFetchThreadCount=10;";
+
+    BigQueryConnection conn1 = new BigQueryConnection(url1);
+    BigQueryConnection conn2 = new BigQueryConnection(url2);
+
+    try {
+      ExecutorService exec1 = conn1.getExecutorService();
+      ExecutorService exec2 = conn2.getExecutorService();
+
+      assertTrue(exec1 != exec2);
+      assertTrue(exec1 instanceof ThreadPoolExecutor);
+      assertTrue(exec2 instanceof ThreadPoolExecutor);
+
+      assertEquals(5, ((ThreadPoolExecutor) exec1).getCorePoolSize());
+      assertEquals(10, ((ThreadPoolExecutor) exec2).getCorePoolSize());
+
+      BigQueryStatement stmt1 = new BigQueryStatement(conn1);
+      assertTrue(stmt1.queryTaskExecutor == exec1);
+
+      try (BigQueryJdbcMdc.MdcCloseable mdc =
+          BigQueryJdbcMdc.registerInstance(conn1.getConnectionId())) {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<String> workerMdc = new AtomicReference<>();
+        exec1.execute(
+            () -> {
+              workerMdc.set(BigQueryJdbcMdc.getConnectionId());
+              latch.countDown();
+            });
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertEquals(conn1.getConnectionId(), workerMdc.get());
+      }
+    } finally {
+      conn1.close();
+      conn2.close();
+    }
+
+    assertTrue(conn1.getExecutorService().isShutdown());
+    assertTrue(conn2.getExecutorService().isShutdown());
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSetTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSetTest.java
@@ -168,9 +168,9 @@ public class BigQueryJsonResultSetTest {
     statement = mock(BigQueryStatement.class);
     buffer.add(BigQueryFieldValueListWrapper.of(fieldList, fieldValues));
     buffer.add(BigQueryFieldValueListWrapper.of(null, null, true)); // last marker
-    Thread[] workerThreads = {new Thread()};
+    java.util.concurrent.Future<?>[] workerFutures = {mock(java.util.concurrent.Future.class)};
     bigQueryJsonResultSet =
-        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, buffer, statement, workerThreads);
+        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, buffer, statement, workerFutures);
 
     // Buffer with 2 rows.
     bufferWithTwoRows = new LinkedBlockingDeque<>(3);
@@ -196,9 +196,9 @@ public class BigQueryJsonResultSetTest {
 
   private boolean resetResultSet()
       throws SQLException { // re-initialises the resultset and moves the cursor to the first row
-    Thread[] workerThreads = {new Thread()};
+    java.util.concurrent.Future<?>[] workerFutures = {mock(java.util.concurrent.Future.class)};
     bigQueryJsonResultSet =
-        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, buffer, statement, workerThreads);
+        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, buffer, statement, workerFutures);
     return bigQueryJsonResultSet.next(); // move to the first row
   }
 
@@ -214,15 +214,15 @@ public class BigQueryJsonResultSetTest {
 
   @Test
   public void testRowCount() throws SQLException {
-    Thread[] workerThreads = {new Thread()};
+    java.util.concurrent.Future<?>[] workerFutures = {mock(java.util.concurrent.Future.class)};
     // ResultSet with 1 row buffer and 1 total rows.
     BigQueryJsonResultSet bigQueryJsonResultSet2 =
-        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, buffer, statement, workerThreads);
+        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, buffer, statement, workerFutures);
     assertThat(resultSetRowCount(bigQueryJsonResultSet2)).isEqualTo(1);
     // ResultSet with 2 rows buffer and 1 total rows.
     bigQueryJsonResultSet2 =
         BigQueryJsonResultSet.of(
-            QUERY_SCHEMA, 1L, bufferWithTwoRows, statementForTwoRows, workerThreads);
+            QUERY_SCHEMA, 1L, bufferWithTwoRows, statementForTwoRows, workerFutures);
     assertThat(resultSetRowCount(bigQueryJsonResultSet2)).isEqualTo(1);
   }
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizersTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetFinalizersTest.java
@@ -18,50 +18,30 @@ package com.google.cloud.bigquery.jdbc;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class BigQueryResultSetFinalizersTest {
-  Thread arrowWorker;
-  Thread[] jsonWorkers;
+  CompletableFuture<Void> arrowFuture;
+  CompletableFuture<?>[] jsonFutures;
 
   @BeforeEach
   public void setUp() {
-    // create and start the demon threads
-    arrowWorker =
-        new Thread(
-            () -> {
-              while (true) {
-                if (Thread.currentThread().isInterrupted()) {
-                  break;
-                }
-              }
-            });
-    arrowWorker.setDaemon(true);
-    Thread jsonWorker =
-        new Thread(
-            () -> {
-              while (true) {
-                if (Thread.currentThread().isInterrupted()) {
-                  break;
-                }
-              }
-            });
-    jsonWorker.setDaemon(true);
-    jsonWorkers = new Thread[] {jsonWorker};
-    arrowWorker.start();
-    jsonWorker.start();
+    arrowFuture = new CompletableFuture<>();
+    CompletableFuture<Void> jsonFuture = new CompletableFuture<>();
+    jsonFutures = new CompletableFuture<?>[] {jsonFuture};
   }
 
   @Test
   public void testFinalizeResources() {
     BigQueryResultSetFinalizers.ArrowResultSetFinalizer arrowResultSetFinalizer =
-        new BigQueryResultSetFinalizers.ArrowResultSetFinalizer(null, null, arrowWorker);
+        new BigQueryResultSetFinalizers.ArrowResultSetFinalizer(null, null, arrowFuture);
     arrowResultSetFinalizer.finalizeResources();
-    assertThat(arrowWorker.isInterrupted()).isTrue();
+    assertThat(arrowFuture.isCancelled()).isTrue();
     BigQueryResultSetFinalizers.JsonResultSetFinalizer jsonResultSetFinalizer =
-        new BigQueryResultSetFinalizers.JsonResultSetFinalizer(null, null, jsonWorkers);
+        new BigQueryResultSetFinalizers.JsonResultSetFinalizer(null, null, jsonFutures);
     jsonResultSetFinalizer.finalizeResources();
-    assertThat(jsonWorkers[0].isInterrupted()).isTrue();
+    assertThat(jsonFutures[0].isCancelled()).isTrue();
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadataTest.java
@@ -84,9 +84,9 @@ public class BigQueryResultSetMetadataTest {
   @BeforeEach
   public void setUp() throws SQLException {
     statement = mock(BigQueryStatement.class);
-    Thread[] workerThreads = {new Thread()};
+    java.util.concurrent.Future<?>[] workerFutures = {mock(java.util.concurrent.Future.class)};
     BigQueryJsonResultSet bigQueryJsonResultSet =
-        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, null, statement, workerThreads);
+        BigQueryJsonResultSet.of(QUERY_SCHEMA, 1L, null, statement, workerFutures);
     // values for nested types
     resultSetMetaData = bigQueryJsonResultSet.getMetaData();
 
@@ -290,7 +290,11 @@ public class BigQueryResultSetMetadataTest {
     FieldList schemaFields = FieldList.of(field);
     BigQueryJsonResultSet resultSet =
         BigQueryJsonResultSet.of(
-            Schema.of(schemaFields), 1L, null, statement, new Thread[] {new Thread()});
+            Schema.of(schemaFields),
+            1L,
+            null,
+            statement,
+            new java.util.concurrent.Future<?>[] {mock(java.util.concurrent.Future.class)});
     ResultSetMetaData metaData = resultSet.getMetaData();
     assertThat(metaData.isSearchable(1)).isTrue();
   }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -67,6 +67,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.FieldVector;
@@ -150,6 +152,8 @@ public class BigQueryStatementTest {
         .when(bigQueryConnection)
         .getQueryDialect();
     doReturn(1000L).when(bigQueryConnection).getMaxResults();
+    ExecutorService mockExecutorService = mock(ExecutorService.class);
+    doReturn(mockExecutorService).when(bigQueryConnection).getExecutorService();
     bigQueryStatement = new BigQueryStatement(bigQueryConnection);
     VectorSchemaRoot vectorSchemaRoot = getTestVectorSchemaRoot();
     arrowSchema =
@@ -252,8 +256,8 @@ public class BigQueryStatementTest {
     doReturn(readSession)
         .when(bigQueryStatementSpy)
         .getReadSession(any(CreateReadSessionRequest.class));
-    Thread mockWorker = new Thread();
-    doReturn(mockWorker)
+    Future<?> mockFuture = mock(Future.class);
+    doReturn(mockFuture)
         .when(bigQueryStatementSpy)
         .populateArrowBufferedQueue(
             any(ReadSession.class), any(BlockingQueue.class), any(BigQueryReadClient.class));

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/PerConnectionFileHandlerTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/PerConnectionFileHandlerTest.java
@@ -195,7 +195,8 @@ public class PerConnectionFileHandlerTest {
 
       // Instantiate a real BigQueryJsonResultSet (which extends BigQueryBaseResultSet)
       // passing the mock statement carrying connectionId "c789"
-      BigQueryJsonResultSet rs = BigQueryJsonResultSet.of(schema, 0, null, mockStmt, new Thread[0]);
+      BigQueryJsonResultSet rs =
+          BigQueryJsonResultSet.of(schema, 0, null, mockStmt, new java.util.concurrent.Future[0]);
 
       // Calling findColumn(null) throws SQLException because column label is null
       assertThrows(SQLException.class, () -> rs.findColumn(null));


### PR DESCRIPTION

This PR refactors the threading model of the BigQuery JDBC driver to achieve per-connection execution isolation, proper logging context propagation, and reliable resource cleanup. It removes the shared static thread executor and transient pools, replacing them with a connection-scoped execution service and standard JVM concurrency primitives.

## Key Changes

### 1. Per-Connection Thread Isolation
- Added a dynamically sized, connection-scoped `ExecutorService` instance (backed by a custom `MdcThreadPoolExecutor`) to `BigQueryConnection`. 
- Sizing of the thread pool is controlled by the user-defined `metadataFetchThreadCount` connection property.
- Statements and ResultSets running on a connection now submit all queries, pagination, and queue-population tasks to the connection's dedicated executor, eliminating thread contamination across connections.
- Automatically shuts down and awaits termination of the connection executor during `Connection.close()`.

### 2. Database Metadata Concurrency Hardening
- Migrated all background metadata queries in `BigQueryDatabaseMetaData` (e.g., procedures, tables, columns, functions) to run tasks using the connection's executor pool rather than spawning transient thread pools.
- Standardized task tracking by wrapping background runnable fetch loops in standard `FutureTask<?>` instances.
- Removed the custom `ThreadFuture` adapter bridge, aligning metadata background tasks directly with the `Future<?>` representation required by `BigQueryJsonResultSet`.

### 3. MDC Context Propagation and Logging
- Integrated a customized thread pool executor (`MdcThreadPoolExecutor`) that intercepts tasks and wraps them in `MdcFutureTask`.
- Automatically propagates the active `connectionId` MDC logging context from calling threads to background worker threads, ensuring parser and driver logging messages are correctly routed to connection-specific log files.

### 4. ResultSet Finalization Cleanups
- Refactored `BigQueryResultSetFinalizers` (`ArrowResultSetFinalizer` and `JsonResultSetFinalizer`) to track background worker tasks as `Future<?>` rather than raw `Thread` objects.
- Updated GC-polling daemon triggers to call `Future.cancel(true)` instead of `Thread.interrupt()` during garbage collection cleanup.

## Verification
- Added a new unit test suite `BigQueryJdbcMdcTest` to validate pool isolation, dynamic sizing, and MDC context propagation.
- Verified compilation and executed the unit test suite; all 990 tests passed successfully.
