### PR TITLE
feat: use self-signed JWTs in Spanner MutableCredentials

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MutableCredentials.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/MutableCredentials.java
@@ -58,7 +58,9 @@ public class MutableCredentials extends Credentials {
       throw new IllegalArgumentException("Scopes must not be empty");
     }
     this.scopes = new java.util.HashSet<>(scopes);
-    delegate = (ServiceAccountCredentials) credentials.createScoped(this.scopes);
+    delegate =
+        ((ServiceAccountCredentials) credentials.createScoped(this.scopes))
+            .createWithUseJwtAccessWithScope(true);
   }
 
   /**
@@ -74,7 +76,9 @@ public class MutableCredentials extends Credentials {
    */
   public void updateCredentials(@Nonnull ServiceAccountCredentials credentials) {
     Objects.requireNonNull(credentials, "credentials must not be null");
-    delegate = (ServiceAccountCredentials) credentials.createScoped(scopes);
+    delegate =
+        ((ServiceAccountCredentials) credentials.createScoped(scopes))
+            .createWithUseJwtAccessWithScope(true);
   }
 
   @Override

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MutableCredentialsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MutableCredentialsTest.java
@@ -86,6 +86,8 @@ public class MutableCredentialsTest {
   public void testCreateMutableCredentialsWithDefaultScopes() throws IOException {
     Set<String> defaultScopes = SpannerOptions.SCOPES;
     when(initialCredentials.createScoped(defaultScopes)).thenReturn(initialScopedCredentials);
+    when(initialScopedCredentials.createWithUseJwtAccessWithScope(true))
+        .thenReturn(initialScopedCredentials);
     when(initialScopedCredentials.getAuthenticationType()).thenReturn(initialAuthType);
     when(initialScopedCredentials.getRequestMetadata(any(URI.class))).thenReturn(initialMetadata);
     when(initialScopedCredentials.getUniverseDomain()).thenReturn(initialUniverseDomain);
@@ -172,6 +174,8 @@ public class MutableCredentialsTest {
 
   private void setupInitialCredentials() throws IOException {
     when(initialCredentials.createScoped(scopes)).thenReturn(initialScopedCredentials);
+    when(initialScopedCredentials.createWithUseJwtAccessWithScope(true))
+        .thenReturn(initialScopedCredentials);
     when(initialCredentials.createScoped(Collections.emptyList()))
         .thenReturn(initialScopedCredentials);
     when(initialScopedCredentials.getAuthenticationType()).thenReturn(initialAuthType);
@@ -185,6 +189,8 @@ public class MutableCredentialsTest {
 
   private void setupUpdatedCredentials() throws IOException {
     when(updatedCredentials.createScoped(scopes)).thenReturn(updatedScopedCredentials);
+    when(updatedScopedCredentials.createWithUseJwtAccessWithScope(true))
+        .thenReturn(updatedScopedCredentials);
     when(updatedScopedCredentials.getAuthenticationType()).thenReturn(updatedAuthType);
     when(updatedScopedCredentials.getRequestMetadata(any(URI.class))).thenReturn(updatedMetadata);
     when(updatedScopedCredentials.getUniverseDomain()).thenReturn(updatedUniverseDomain);


### PR DESCRIPTION
See https://google.aip.dev/auth/4111 - this should improve efficiency/reliability by avoiding OAuth token exchange

Related #13338 will enable self-signed JWTs in [SpannerOptions](https://github.com/googleapis/google-cloud-java/blob/main/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java)