### PR TITLE
chore(ci): turn off nightly generation_config.yaml update job

### DIFF
--- a/.github/workflows/update_generation_config.yaml
+++ b/.github/workflows/update_generation_config.yaml
@@ -15,8 +15,6 @@
 # downstream client libraries before they are released.
 name: Update generation configuration
 on:
-  schedule:
-  - cron: '0 2 * * *'
   workflow_dispatch:
 jobs:
   update-generation-config:


### PR DESCRIPTION
Turn off the scheduled run for job that updates googleapis_commitish inside generation_config.yaml. This is to stop nightly generation PRs like https://github.com/googleapis/google-cloud-java/pull/13370 to avoid confusion.
For more context, read [doc](https://docs.google.com/document/d/1-c-xATdvRVBilMAPEp-iuA8h85GiGcBAXg3J_Bk2Cuc/edit?tab=t.z60mo0pujx3h).

Note this does not turns down hermetic build code generation workflow:
- This [workflow](https://github.com/googleapis/google-cloud-java/blob/main/.github/workflows/update_librarian_googleapis.yaml) that updates googleapis commit for librarian.yaml now also updates generation_config.yaml. So hermetic build code generation is triggered on that PR. Instead of nightly generation PR, a generation PR like https://github.com/googleapis/google-cloud-java/pull/13385 should contain the same contents.
- If needed, manual trigger is still possible.


For https://github.com/googleapis/librarian/issues/6220