### PR TITLE
chore(ci): update librarian googleapis PR to create separate commit for config changes and code changes

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -85,6 +85,7 @@ jobs:
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
     - name: Install protoc
+      if: steps.detect_librarian.outputs.has_changes == 'true'
       run: |
         set -e
         VERSION="33.2"
@@ -93,11 +94,13 @@ jobs:
         sudo unzip -o /tmp/protoc.zip
         protoc --version
     - uses: actions/setup-java@v4
+      if: steps.detect_librarian.outputs.has_changes == 'true'
       with:
         java-version: "17"
         distribution: "temurin"
         cache: "maven"
     - name: Verify Java and Maven installation
+      if: steps.detect_librarian.outputs.has_changes == 'true'
       run: |
         java -version
         if ! command -v mvn &> /dev/null; then
@@ -105,10 +108,12 @@ jobs:
         fi
         mvn -version
     - uses: actions/setup-python@v5
+      if: steps.detect_librarian.outputs.has_changes == 'true'
       with:
         python-version: "3.12"
         cache: 'pip'
     - name: Run librarian install
+      if: steps.detect_librarian.outputs.has_changes == 'true'
       run: |
         go run github.com/googleapis/librarian/cmd/librarian@latest install
         echo "$HOME/java_tools/bin" >> $GITHUB_PATH
@@ -116,19 +121,10 @@ jobs:
         PYTHONPATH: ${{ github.workspace }}/sdk-platform-java/hermetic_build/library_generation/owlbot
     - name: Generate Libraries
       if: steps.detect_librarian.outputs.has_changes == 'true'
-      id: generate
       run: |
         go run github.com/googleapis/librarian/cmd/librarian@latest generate --all
-        git add .
-        changed_files=$(git diff --cached --name-only)
-        if [[ "${changed_files}" == "" ]]; then
-          echo "has_changes=false" >> $GITHUB_OUTPUT
-          echo "No changes in libraries"
-        else
-          echo "has_changes=true" >> $GITHUB_OUTPUT
-        fi
     - name: Commit and Create PR
-      if: steps.detect_librarian.outputs.has_changes == 'true' || steps.generate.outputs.has_changes == 'true'
+      if: steps.detect_librarian.outputs.has_changes == 'true'
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
         PR_TITLE: "chore: update googleapis commitish to ${{ steps.commit.outputs.short_commit }}"
@@ -139,7 +135,7 @@ jobs:
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           echo "=== PR Test: DRY RUN MODE ACTIVE ==="
           echo "Would have checked out branch: update-librarian-googleapis-main"
-          echo "Would have committed with title: $PR_TITLE"
+          echo "Would have committed configs with title: $PR_TITLE"
           echo "Would have pushed branch and created PR."
           exit 0
         fi
@@ -153,8 +149,22 @@ jobs:
         # Create and switch to the branch (force checkout -B to discard any local state on this branch name if it existed)
         git checkout -B "${current_branch}"
         
-        # Commit the changes (they are already staged by the Detect Changes step!)
-        git commit -m "${PR_TITLE}"
+        # 1. Commit Config Changes
+        # Ensure they are staged
+        git add librarian.yaml generation_config.yaml
+        if ! git diff --cached --quiet; then
+          git commit -m "${PR_TITLE}"
+        else
+          echo "No config changes to commit"
+        fi
+        
+        # 2. Commit Generated Code
+        git add .
+        if ! git diff --cached --quiet; then
+          git commit -m "chore: generate libraries"
+        else
+          echo "No generated code changes to commit"
+        fi
         
         # Push to remote (force push to overwrite any stale branch on remote)
         git remote add remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${{ github.repository }}.git" || git remote set-url remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${{ github.repository }}.git"


### PR DESCRIPTION
Followup to https://github.com/googleapis/google-cloud-java/pull/13337, makes separate commit for config changes and generate code changes. 
Also removed redundant `changed_files` check in generate step, and skip setting up steps for generate if no config change.

Fix https://github.com/googleapis/librarian/issues/6219