### PR TITLE
test(pubsub): disable flaky tests in PublisherImplTest

### DIFF
--- a/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -593,6 +593,7 @@ public class PublisherImplTest {
     shutdownTestPublisher(publisher);
   }
 
+  @Ignore("https://github.com/googleapis/google-cloud-java/issues/13394")
   @Test
   public void testPublishThrowExceptionForUnsubmittedOrderingKeyMessage() throws Exception {
     Publisher publisher =

--- a/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -64,6 +64,7 @@ import java.util.concurrent.TimeUnit;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -512,6 +513,7 @@ public class PublisherImplTest {
    *   <li>publish with key orderA, which should now succeed
    * </ol>
    */
+  @Ignore("https://github.com/googleapis/google-cloud-java/issues/13394")
   @Test
   public void testResumePublish() throws Exception {
     Publisher publisher =


### PR DESCRIPTION
This PR disables `PublisherImplTest.testResumePublish` and `PublisherImplTest.testPublishThrowExceptionForUnsubmittedOrderingKeyMessage` which causes 6-hour timeouts in release runs under Java 8 due to a deadlock. See Issue #13394 for more details.