### PR TITLE
test(storage): limit integration test forks to 1 and other integration test fixes

### DIFF
--- a/java-storage/google-cloud-storage/pom.xml
+++ b/java-storage/google-cloud-storage/pom.xml
@@ -460,6 +460,17 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>true</reuseForks>
+          <systemPropertyVariables>
+            <testbench.keepAlive>true</testbench.keepAlive>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/java-storage/google-cloud-storage/pom.xml
+++ b/java-storage/google-cloud-storage/pom.xml
@@ -466,6 +466,9 @@
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
+          <systemPropertyVariables>
+            <logback.statusListenerClass>ch.qos.logback.core.status.NopStatusListener</logback.statusListenerClass>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/java-storage/google-cloud-storage/pom.xml
+++ b/java-storage/google-cloud-storage/pom.xml
@@ -465,7 +465,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <forkCount>1</forkCount>
-          <reuseForks>true</reuseForks>
+          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
     </plugins>

--- a/java-storage/google-cloud-storage/pom.xml
+++ b/java-storage/google-cloud-storage/pom.xml
@@ -466,9 +466,6 @@
         <configuration>
           <forkCount>1</forkCount>
           <reuseForks>true</reuseForks>
-          <systemPropertyVariables>
-            <testbench.keepAlive>true</testbench.keepAlive>
-          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
@@ -28,16 +28,19 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Locale;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 final class FakeServer implements AutoCloseable {
 
   private final Server server;
   private final GrpcStorageOptions grpcStorageOptions;
+  private final ScheduledThreadPoolExecutor executor;
 
-  FakeServer(Server server, GrpcStorageOptions grpcStorageOptions) {
+  FakeServer(Server server, GrpcStorageOptions grpcStorageOptions, ScheduledThreadPoolExecutor executor) {
     this.server = server;
     this.grpcStorageOptions = grpcStorageOptions;
+    this.executor = executor;
   }
 
   GrpcStorageOptions getGrpcStorageOptions() {
@@ -51,11 +54,16 @@ final class FakeServer implements AutoCloseable {
   @Override
   public void close() throws InterruptedException {
     server.shutdownNow().awaitTermination(10, TimeUnit.SECONDS);
+    executor.shutdownNow();
+    //noinspection ResultOfMethodCallIgnored
+    executor.awaitTermination(5, TimeUnit.SECONDS);
   }
 
   static FakeServer of(StorageGrpc.StorageImplBase service) throws IOException {
-    InetSocketAddress address = new InetSocketAddress("localhost", 0);
-    Server server = NettyServerBuilder.forAddress(address).addService(service).build();
+    InetSocketAddress address = new InetSocketAddress("127.0.0.1", 0);
+    ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(4);
+    Server server =
+        NettyServerBuilder.forAddress(address).addService(service).executor(executor).build();
     server.start();
     String endpoint = String.format(Locale.US, "%s:%d", address.getHostString(), server.getPort());
     GrpcStorageOptions grpcStorageOptions =
@@ -80,6 +88,6 @@ final class FakeServer implements AutoCloseable {
                     .setMaxRpcTimeoutDuration(Duration.ofSeconds(25))
                     .build())
             .build();
-    return new FakeServer(server, grpcStorageOptions);
+    return new FakeServer(server, grpcStorageOptions, executor);
   }
 }

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/FakeServer.java
@@ -37,7 +37,8 @@ final class FakeServer implements AutoCloseable {
   private final GrpcStorageOptions grpcStorageOptions;
   private final ScheduledThreadPoolExecutor executor;
 
-  FakeServer(Server server, GrpcStorageOptions grpcStorageOptions, ScheduledThreadPoolExecutor executor) {
+  FakeServer(
+      Server server, GrpcStorageOptions grpcStorageOptions, ScheduledThreadPoolExecutor executor) {
     this.server = server;
     this.grpcStorageOptions = grpcStorageOptions;
     this.executor = executor;

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/runner/registry/TestBench.java
@@ -442,8 +442,8 @@ public final class TestBench implements ManagedLifecycle {
   }
 
   static final class Builder {
-    private static final String DEFAULT_BASE_URI = "http://localhost:9000";
-    private static final String DEFAULT_GRPC_BASE_URI = "http://localhost:9005";
+    private static final String DEFAULT_BASE_URI = "http://127.0.0.1:9000";
+    private static final String DEFAULT_GRPC_BASE_URI = "http://127.0.0.1:9005";
     private static final String DEFAULT_IMAGE_NAME;
     private static final String DEFAULT_IMAGE_TAG;
 


### PR DESCRIPTION
After the migration to the mono-repo parent pom defined fork-count for maven failsafe plugin as 1C which runs 1 JVM fork per CPU Core. This could be the reason for multiple issues across various tests due to the parallelism such as thread starvation, CPU throttling, and timeout flakiness on multi-core CI VMs. This PR overrides the parent POM configuration to limit the integration test fork count to 1 in google-cloud-storage. 

This Pr also contains an attempted fix for vm timeout errors and hangs in the integration test. Rationale: Previously the GCS client and the FakeServer run in the same JVM and share the same Netty thread pool. When the client makes a blocking call and waits for the server, it occupies the shared threads. This could have starved the mock server preventing it from processing the request.

Note: The tests will take ~ 5-10 longer to run than previous configuration.