### PR TITLE
chore: update regen workflow

### DIFF
--- a/.github/workflows/librarian_generation_check.yaml
+++ b/.github/workflows/librarian_generation_check.yaml
@@ -65,4 +65,8 @@ jobs:
         librarian generate --all
     - name: Check for generated code changes
       run: |
-        git diff --exit-code
+        if [ -n "$(git status --porcelain)" ]; then
+          git status
+          echo "Regeneration produced code changes! Please run 'librarian generate --all' to update the generated files."
+          exit 1
+        fi


### PR DESCRIPTION
Currently, the regeneration check workflow uses `git diff --exit-code`
to verify if code regeneration produced any differences. However, `git
diff` only checks tracked files. If the regeneration process creates new
files (such as newly generated client files that were
previously excluded), they remain untracked and the check passes without
reporting a failure.

Change the check to use `git status --porcelain` to detect any changes
(including modifications, deletions, and untracked files).

Add instructions on how to resolve the failure.