### PR TITLE
chore(ci): add note to PR body created by update_librarian_googleapis.yaml

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -128,7 +128,10 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
         PR_TITLE: "chore: update googleapis commitish to ${{ steps.commit.outputs.short_commit }}"
-        PR_BODY: "Updated googleapis commitish in librarian.yaml and generation_config.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}"
+        PR_BODY: |
+          Updated googleapis commitish in librarian.yaml and generation_config.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}
+
+          💡 **Note:** Please merge or close this PR so that the daily update workflow can continue to run successfully. Alternatively, you can manually trigger the workflow once this PR is resolved.
       run: |
         set -x
         

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -131,7 +131,7 @@ jobs:
         PR_BODY: |
           Updated googleapis commitish in librarian.yaml and generation_config.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}
 
-          💡 **Note:** Please merge or close this PR so that the daily update workflow can continue to run successfully. Alternatively, you can manually trigger the workflow once this PR is merged or closed.
+          💡 **Note:** Please merge or close this PR so that the daily update workflow can continue to run successfully the next day. Alternatively, you can manually trigger the workflow once this PR is merged or closed.
       run: |
         set -x
         

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -131,7 +131,7 @@ jobs:
         PR_BODY: |
           Updated googleapis commitish in librarian.yaml and generation_config.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}
 
-          💡 **Note:** Please merge or close this PR so that the daily update workflow can continue to run successfully. Alternatively, you can manually trigger the workflow once this PR is resolved.
+          💡 **Note:** Please merge or close this PR so that the daily update workflow can continue to run successfully. Alternatively, you can manually trigger the workflow once this PR is merged or closed.
       run: |
         set -x
         


### PR DESCRIPTION
Add a note to the PR body created by update_librarian_googleapis.yaml, with instruction to either close or merge in PR. 

For simplicity, this workflow does not update the PR once created. This instruction let people know reading the PR what to do to unblock the next scheduled run if they don't want to merge in.