### PR TITLE
chore(java-firestore): re-generate readme after version bump

### DIFF
--- a/java-firestore/README.md
+++ b/java-firestore/README.md
@@ -56,13 +56,13 @@ implementation 'com.google.cloud:google-cloud-firestore'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-firestore:3.43.0'
+implementation 'com.google.cloud:google-cloud-firestore:3.43.1'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.43.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-firestore" % "3.43.1"
 ```
 
 ## Authentication
@@ -201,7 +201,7 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-firestore/latest/history
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-firestore.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-firestore/3.43.0
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-firestore/3.43.1
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles


### PR DESCRIPTION
Code generated from `go run github.com/googleapis/librarian/cmd/librarian@${V} generate firestore`. This is due to https://github.com/googleapis/google-cloud-java/pull/13398 bumps version but does not regenerate.

Fix https://github.com/googleapis/google-cloud-java/issues/13438