### PR TITLE
chore(ci): print git diff on librarian check failure

### DIFF
--- a/.github/workflows/librarian_generation_check.yaml
+++ b/.github/workflows/librarian_generation_check.yaml
@@ -73,6 +73,9 @@ jobs:
       run: |
         if [ -n "$(git status --porcelain)" ]; then
           git status
+          echo "==================== GIT DIFF ===================="
+          git diff
+          echo "=================================================="
           echo "Regeneration produced code changes! Please run 'librarian generate --all' to update the generated files."
           exit 1
         fi


### PR DESCRIPTION
 Update the `Check for generated code changes` step in the`librarian_generation_check.yaml` workflow to print the `git diff` to the console when changes are detected. This will help identify which files were modified and what the changes are directly from the CI logs.

Fixes https://github.com/googleapis/librarian/issues/6406
