### PR TITLE
chore: fix google-cloud-pom-parent version in gapic-libraries-bom

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>google-cloud-pom-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.87.0</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.87.1</version><!-- {x-version-update:google-cloud-java:current} -->
     <relativePath>../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Update google-cloud-pom-parent version in gapic-libraries-bom. Followup to https://github.com/googleapis/google-cloud-java/pull/13445.

Fixes https://github.com/googleapis/google-cloud-java/issues/13447