### PR TITLE
test(auth): add caching call-count assertions and fix mock expiration

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -453,7 +453,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
         OAuth2Utils.validateString(responseData, "access_token", PARSE_ERROR_PREFIX);
     int expiresInSeconds =
         OAuth2Utils.validateInt32(responseData, "expires_in", PARSE_ERROR_PREFIX);
-    long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000;
+    long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000L;
 
     return new AccessToken(accessToken, new Date(expiresAtMilliseconds));
   }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -193,7 +193,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
         OAuth2Utils.validateString(responseData, "access_token", PARSE_ERROR_PREFIX);
     int expiresInSeconds =
         OAuth2Utils.validateInt32(responseData, "expires_in", PARSE_ERROR_PREFIX);
-    long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000;
+    long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000L;
     String scopes =
         OAuth2Utils.validateOptionalString(
             responseData, OAuth2Utils.TOKEN_RESPONSE_SCOPE, PARSE_ERROR_PREFIX);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -67,6 +67,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -421,14 +422,14 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
   @Test
   void getRequestMetadata_multipleCalls_usesCachedToken() throws IOException {
-    final int[] requestCount = new int[1];
+    final AtomicInteger requestCount = new AtomicInteger(0);
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport =
         new MockMetadataServerTransport(SCOPE_TO_ACCESS_TOKEN_MAP) {
           @Override
           public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
             if (url.startsWith(ComputeEngineCredentials.getTokenServerEncodedUrl())) {
-              requestCount[0]++;
+              requestCount.incrementAndGet();
             }
             return super.buildRequest(method, url);
           }
@@ -440,11 +441,11 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
-    assertEquals(1, requestCount[0]);
+    assertEquals(1, requestCount.get());
 
     Map<String, List<String>> metadata2 = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata2, ACCESS_TOKEN);
-    assertEquals(1, requestCount[0]);
+    assertEquals(1, requestCount.get());
   }
 
   @Test

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -420,6 +420,34 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
+  void getRequestMetadata_multipleCalls_usesCachedToken() throws IOException {
+    final int[] requestCount = new int[1];
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    transportFactory.transport =
+        new MockMetadataServerTransport(SCOPE_TO_ACCESS_TOKEN_MAP) {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            if (url.startsWith(ComputeEngineCredentials.getTokenServerEncodedUrl())) {
+              requestCount[0]++;
+            }
+            return super.buildRequest(method, url);
+          }
+        };
+    transportFactory.transport.setServiceAccountEmail(SA_CLIENT_EMAIL);
+
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+    assertEquals(1, requestCount[0]);
+
+    Map<String, List<String>> metadata2 = credentials.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata2, ACCESS_TOKEN);
+    assertEquals(1, requestCount[0]);
+  }
+
+  @Test
   void getRequestMetadata_missingServiceAccount_throws() {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -213,7 +213,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
           refreshContents.put(
               "access_token", scopesToAccessToken.get("[" + urlParsed.get(1) + "]"));
         }
-        refreshContents.put("expires_in", 3600000);
+        refreshContents.put("expires_in", 3600);
         refreshContents.put("token_type", "Bearer");
         String refreshText = refreshContents.toPrettyString();
 


### PR DESCRIPTION
Other client libraries (such as Rust and .NET) safely verify caching logic by asserting exactly one outbound HTTP request is made regardless of the number of credential calls. Added `getRequestMetadata_multipleCalls_usesCachedToken` to enforce this.

Adding this test exposed a long-standing bug in the test framework: `MockMetadataServerTransport` was erroneously returning `expires_in` as 3,600,000 (mistakenly assuming it was milliseconds instead of seconds). This caused a 32-bit integer overflow in the parser (`expiresInSeconds * 1000` > 2.14B), which instantly expired the mock token and silently bypassed the cache during tests.

Fixed the mock to correctly return 3600 seconds, and defensively promoted the production code parser multiplication to a 64-bit `long` to prevent any potential future overflows.