### PR TITLE
test: introduce awaitility to sdk-platform-java

### DIFF
--- a/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
+++ b/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
@@ -38,6 +38,7 @@
     <threetenbp.version>1.7.0</threetenbp.version>
     <junit.version>5.11.4</junit.version>
     <mockito.version>4.11.0</mockito.version>
+    <awaitility.version>4.3.0</awaitility.version>
     <slf4j.version>2.0.16</slf4j.version>
     <!--  skipping clirr check for protobuf 4.x upgrade -->
     <clirr.skip>true</clirr.skip>

--- a/sdk-platform-java/gax-java/dependencies.properties
+++ b/sdk-platform-java/gax-java/dependencies.properties
@@ -96,3 +96,5 @@ maven.io_opentelemetry_opentelemetry_sdk=io.opentelemetry:opentelemetry-sdk:1.57
 maven.io_opentelemetry_opentelemetry_sdk_common=io.opentelemetry:opentelemetry-sdk-common:1.57.0
 maven.io_opentelemetry_opentelemetry_sdk_metrics=io.opentelemetry:opentelemetry-sdk-metrics:1.57.0
 maven.com_google_guava_guava_testlib=com.google.guava:guava-testlib:32.1.3-jre
+maven.org_awaitility_awaitility=org.awaitility:awaitility:4.3.0
+

--- a/sdk-platform-java/gax-java/gax/BUILD.bazel
+++ b/sdk-platform-java/gax-java/gax/BUILD.bazel
@@ -49,6 +49,7 @@ _TEST_COMPILE_DEPS = [
     "@io_opentelemetry_opentelemetry_sdk_metrics//jar",
     "@io_opentelemetry_opentelemetry_sdk_common//jar",
     "@com_google_guava_guava_testlib//jar",
+    "@org_awaitility_awaitility//jar",
 ]
 
 java_library(

--- a/sdk-platform-java/gax-java/gax/pom.xml
+++ b/sdk-platform-java/gax-java/gax/pom.xml
@@ -112,6 +112,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
       <scope>runtime</scope>

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -30,6 +30,7 @@
 package com.google.api.gax.batching;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,7 +38,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
-import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -196,12 +196,16 @@ class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(3));
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the executor to push the batch
-    await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
 
     batcher.add(SimpleBatch.fromInteger(7));
     batcher.add(SimpleBatch.fromInteger(9));
     // Give time for the executor to push the batch
-    await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(2));
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(2));
 
     batcher.add(SimpleBatch.fromInteger(11));
 
@@ -228,7 +232,9 @@ class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(3));
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the delay to trigger and push the batch
-    await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
 
     batcher.add(SimpleBatch.fromInteger(11));
 

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -37,6 +37,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -44,6 +45,7 @@ import com.google.api.core.ApiFutures;
 import com.google.api.gax.batching.FlowController.FlowControlException;
 import com.google.api.gax.batching.FlowController.LimitExceededBehavior;
 import com.google.common.collect.ImmutableList;
+import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -194,14 +196,12 @@ class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(3));
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the executor to push the batch
-    Thread.sleep(100);
-    assertThat(receiver.getBatches()).hasSize(1);
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
 
     batcher.add(SimpleBatch.fromInteger(7));
     batcher.add(SimpleBatch.fromInteger(9));
     // Give time for the executor to push the batch
-    Thread.sleep(100);
-    assertThat(receiver.getBatches()).hasSize(2);
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(2));
 
     batcher.add(SimpleBatch.fromInteger(11));
 
@@ -228,8 +228,7 @@ class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(3));
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the delay to trigger and push the batch
-    Thread.sleep(500);
-    assertThat(receiver.getBatches()).hasSize(1);
+    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
 
     batcher.add(SimpleBatch.fromInteger(11));
 

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/ThresholdBatcherTest.java
@@ -196,12 +196,12 @@ class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(3));
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the executor to push the batch
-    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
+    await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
 
     batcher.add(SimpleBatch.fromInteger(7));
     batcher.add(SimpleBatch.fromInteger(9));
     // Give time for the executor to push the batch
-    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(2));
+    await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(2));
 
     batcher.add(SimpleBatch.fromInteger(11));
 
@@ -228,7 +228,7 @@ class ThresholdBatcherTest {
     batcher.add(SimpleBatch.fromInteger(3));
     batcher.add(SimpleBatch.fromInteger(5));
     // Give time for the delay to trigger and push the batch
-    await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
+    await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> assertThat(receiver.getBatches()).hasSize(1));
 
     batcher.add(SimpleBatch.fromInteger(11));
 

--- a/sdk-platform-java/gax-java/pom.xml
+++ b/sdk-platform-java/gax-java/pom.xml
@@ -36,6 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <awaitility.version>4.3.0</awaitility.version>
   </properties>
 
   <modules>

--- a/sdk-platform-java/gax-java/pom.xml
+++ b/sdk-platform-java/gax-java/pom.xml
@@ -36,7 +36,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <awaitility.version>4.3.0</awaitility.version>
   </properties>
 
   <modules>

--- a/sdk-platform-java/gax-java/pom.xml
+++ b/sdk-platform-java/gax-java/pom.xml
@@ -175,6 +175,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${awaitility.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This PR
- Introduces awaitility version 4.3.0 to gapic-generator-java-pom-parent and gax-java. 
- Migrate one test ThresholdBatcherTest to use it as an example.

This is the first PR of b/505479343. Follow up PRs would migrate all tests in sdk-platform-java to use awaitility.