### PR TITLE
chore: manual fix released versions in librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -512,6 +512,7 @@ libraries:
       api_description_override: The BigLake API provides access to BigLake Metastore, a serverless, fully managed, and highly available metastore for open-source data that can be used for querying Apache Iceberg tables in BigQuery.
       name_pretty_override: BigLake
       product_documentation_override: https://cloud.google.com/biglake
+      released_version: 0.81.1
   - name: bigquery-data-exchange
     version: 2.89.0-SNAPSHOT
     apis:
@@ -1564,7 +1565,6 @@ libraries:
       name_pretty_override: Error Reporting
       product_documentation_override: https://cloud.google.com/error-reporting
       billing_not_required: true
-      released_version: 0.215.0-beta-SNAPSHOT
   - name: essential-contacts
     version: 2.94.0-SNAPSHOT
     apis:
@@ -1678,6 +1678,7 @@ libraries:
       name_pretty_override: Cloud Firestore
       product_documentation_override: https://cloud.google.com/firestore
       recommended_package: com.google.cloud.firestore
+      released_version: 3.43.1
       transport_override: grpc
       skip_pom_updates: true
   - name: functions

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -510,9 +510,9 @@ libraries:
       - path: google/cloud/bigquery/biglake/v1alpha1
     java:
       api_description_override: The BigLake API provides access to BigLake Metastore, a serverless, fully managed, and highly available metastore for open-source data that can be used for querying Apache Iceberg tables in BigQuery.
+      released_version: 0.81.1
       name_pretty_override: BigLake
       product_documentation_override: https://cloud.google.com/biglake
-      released_version: 0.81.1
   - name: bigquery-data-exchange
     version: 2.89.0-SNAPSHOT
     apis:
@@ -1674,11 +1674,11 @@ libraries:
         - google-cloud-firestore
         - google-cloud-firestore-bom
       issue_tracker_override: https://issuetracker.google.com/savedsearches/5337669
+      released_version: 3.43.1
       library_type_override: GAPIC_COMBO
       name_pretty_override: Cloud Firestore
       product_documentation_override: https://cloud.google.com/firestore
       recommended_package: com.google.cloud.firestore
-      released_version: 3.43.1
       transport_override: grpc
       skip_pom_updates: true
   - name: functions


### PR DESCRIPTION
Put in manual fix in librarian.yaml for released_version for firestore, biglake and errorreporting.
This is a temporarily fix to unblock development in google-cloud-java, track remaining work in https://github.com/googleapis/librarian/issues/6419.

Fixes https://github.com/googleapis/google-cloud-java/issues/13447