### PR TITLE
chore: prevent update_librarian_googleapis.yaml triggered from fork

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -22,6 +22,8 @@ on:
       - '.github/workflows/update_librarian_googleapis.yaml'
 jobs:
   update-librarian-googleapis:
+  # This condition blocks the job from running on any fork
+    if: github.repository_owner == 'googleapis'
     runs-on: ubuntu-24.04
     defaults:
       run:


### PR DESCRIPTION
Add an if condition to avoid this workflow triggered from fork.