### PR TITLE
test(auth): Assert IOException on custom universe domain with delegation

### DIFF
--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -1762,6 +1762,16 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertNull(newAccessToken);
   }
 
+  @Test
+  void getRequestMetadata_withUniverseAndDelegation_throws() {
+    ServiceAccountCredentials credentials =
+        createDefaultBuilderWithKey(OAuth2Utils.privateKeyFromPkcs8(PRIVATE_KEY_PKCS8))
+            .setUniverseDomain("example.com")
+            .setServiceAccountUser("user@example.com")
+            .build();
+    assertThrows(IOException.class, () -> credentials.getRequestMetadata(CALL_URI));
+  }
+
   private void verifyJwtAccess(Map<String, List<String>> metadata, String expectedScopeClaim)
       throws IOException {
     assertNotNull(metadata);


### PR DESCRIPTION
This commit adds a test case to ServiceAccountCredentialsTest to verify that configuring a custom Universe Domain along with Domain-Wide Delegation safely throws the expected IOException. Domain-wide delegation is not supported outside of the default Google universe.

This brings the Java library's test suite into alignment with the expected auth specification. Other Google Cloud client libraries like Go, Node.js, and Python natively assert that this configuration combination throws a validation error during credential initialization or token generation.