### PR TITLE
test(auth): Assert IOException on invalid or malformed private keys

### DIFF
--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/OAuth2UtilsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/OAuth2UtilsTest.java
@@ -41,6 +41,20 @@ import org.junit.jupiter.api.Test;
 class OAuth2UtilsTest {
 
   @Test
+  void testPrivateKeyFromPkcs8_invalidKey() {
+    String invalidKey = "-----BEGIN PRIVATE KEY-----\n" +
+        "INVALID_KEY_DATA\n" +
+        "-----END PRIVATE KEY-----\n";
+    assertThrows(java.io.IOException.class, () -> OAuth2Utils.privateKeyFromPkcs8(invalidKey));
+  }
+
+  @Test
+  void testPrivateKeyFromPkcs8_malformedPem() {
+    String malformedKey = "just some random string";
+    assertThrows(java.io.IOException.class, () -> OAuth2Utils.privateKeyFromPkcs8(malformedKey));
+  }
+
+  @Test
   void testValidCredentials() {
     String username = "testUser";
     String password = "testPassword";


### PR DESCRIPTION
This commit adds edge-case parsing tests in OAuth2UtilsTest.java to verify that providing an invalid private key or a structurally malformed PEM string safely triggers an IOException (e.g., 'Invalid PKCS#8 data.') rather than causing unexpected crashes.

This brings the Java library's test suite into alignment with the expected auth specification. Other Google Cloud client libraries like Go, Node.js, and Python natively assert that invalid cryptographic key formats are gracefully caught and surfaced as validation errors.