### PR TITLE
test(auth): Assert self-signed JWT is used by ImpersonatedCredentials

### DIFF
--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -514,6 +514,19 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
     assertEquals(ACCESS_TOKEN, targetCredentials.refreshAccessToken().getTokenValue());
     assertEquals(
         DEFAULT_IMPERSONATION_URL, mockTransportFactory.getTransport().getRequest().getUrl());
+
+    String authHeader = mockTransportFactory.getTransport().getRequest().getHeaders().getAuthorization();
+    assertNotNull(authHeader);
+    assertTrue(authHeader.startsWith("Bearer "));
+    String assertion = authHeader.substring("Bearer ".length());
+    // Parse the JWT to verify it is indeed a self-signed JWT (has 3 parts)
+    String[] parts = assertion.split("\\.");
+    assertEquals(3, parts.length, "Authorization header must be a self-signed JWT");
+
+    // Verify the payload to ensure it is the locally generated self-signed JWT
+    String payload = new String(java.util.Base64.getUrlDecoder().decode(parts[1]), java.nio.charset.StandardCharsets.UTF_8);
+    assertTrue(payload.contains("\"iss\":\"" + SA_CLIENT_EMAIL + "\""), "JWT must be issued by the source service account");
+    assertTrue(payload.contains("\"aud\":\"" + DEFAULT_IMPERSONATION_URL + "\""), "JWT audience must be the impersonation endpoint");
   }
 
   @Test()


### PR DESCRIPTION
This commit adds an assertion to ImpersonatedCredentialsTest to verify that when a ServiceAccountJwtAccessCredentials is used as the source credential, the actual HTTP request to the impersonation endpoint correctly sends the generated self-signed JWT in the Authorization header.

This brings the Java library's test suite into alignment with the expected auth specification, validating that source credentials properly inject their authentication headers during token exchanges.