### PR TITLE
test(bigquerystorage): create sessions using await() to address flakiness

### DIFF
--- a/google-cloud-jar-parent/pom.xml
+++ b/google-cloud-jar-parent/pom.xml
@@ -72,12 +72,6 @@
 
       <!-- Test dependencies -->
       <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>4.3.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.2</version>

--- a/google-cloud-jar-parent/pom.xml
+++ b/google-cloud-jar-parent/pom.xml
@@ -72,6 +72,12 @@
 
       <!-- Test dependencies -->
       <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>4.3.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.13.2</version>

--- a/java-bigquerystorage/google-cloud-bigquerystorage/pom.xml
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/pom.xml
@@ -198,6 +198,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/it/ITBigQueryStorageTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/it/ITBigQueryStorageTest.java
@@ -81,9 +81,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalTypes;
@@ -1233,13 +1233,19 @@ class ITBigQueryStorageTest {
           TableReadOptions.newBuilder().setRowRestriction(filter).build());
     }
 
-    final CreateReadSessionRequest request = createSessionRequestBuilder.build();
-    ReadSession session =
-        await()
-            .atMost(Duration.ofSeconds(30))
-            .pollInterval(Duration.ofSeconds(1))
-            .ignoreException(NotFoundException.class)
-            .until(() -> client.createReadSession(request), Objects::nonNull);
+    CreateReadSessionRequest request = createSessionRequestBuilder.build();
+    AtomicReference<ReadSession> sessionRef = new AtomicReference<>();
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofSeconds(1))
+        // retry if the newly-created table has not yet fully propagated
+        .ignoreException(NotFoundException.class)
+        .until(
+            () -> {
+              sessionRef.set(client.createReadSession(request));
+              return true;
+            });
+    ReadSession session = sessionRef.get();
     assertEquals(
         1,
         session.getStreamsCount(),

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/it/ITBigQueryStorageTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/it/ITBigQueryStorageTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery.storage.v1beta1.it;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.UnauthenticatedException;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -79,6 +81,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -1230,7 +1233,13 @@ class ITBigQueryStorageTest {
           TableReadOptions.newBuilder().setRowRestriction(filter).build());
     }
 
-    ReadSession session = client.createReadSession(createSessionRequestBuilder.build());
+    final CreateReadSessionRequest request = createSessionRequestBuilder.build();
+    ReadSession session =
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .pollInterval(Duration.ofSeconds(1))
+            .ignoreException(NotFoundException.class)
+            .until(() -> client.createReadSession(request), Objects::nonNull);
     assertEquals(
         1,
         session.getStreamsCount(),

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryStorageTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryStorageTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery.storage.v1beta2.it;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.NotFoundException;
 import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.UnauthenticatedException;
 import com.google.auth.oauth2.ServiceAccountCredentials;
@@ -76,6 +78,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.logging.Logger;
 import org.apache.avro.Conversions;
@@ -1211,7 +1214,13 @@ class ITBigQueryStorageTest {
           .setReadOptions(TableReadOptions.newBuilder().setRowRestriction(filter).build());
     }
 
-    ReadSession session = client.createReadSession(createSessionRequestBuilder.build());
+    final CreateReadSessionRequest request = createSessionRequestBuilder.build();
+    ReadSession session =
+        await()
+            .atMost(Duration.ofSeconds(30))
+            .pollInterval(Duration.ofSeconds(1))
+            .ignoreException(NotFoundException.class)
+            .until(() -> client.createReadSession(request), Objects::nonNull);
     assertEquals(
         1,
         session.getStreamsCount(),

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryStorageTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/it/ITBigQueryStorageTest.java
@@ -78,8 +78,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalTypes;
@@ -1214,13 +1214,19 @@ class ITBigQueryStorageTest {
           .setReadOptions(TableReadOptions.newBuilder().setRowRestriction(filter).build());
     }
 
-    final CreateReadSessionRequest request = createSessionRequestBuilder.build();
-    ReadSession session =
-        await()
-            .atMost(Duration.ofSeconds(30))
-            .pollInterval(Duration.ofSeconds(1))
-            .ignoreException(NotFoundException.class)
-            .until(() -> client.createReadSession(request), Objects::nonNull);
+    CreateReadSessionRequest request = createSessionRequestBuilder.build();
+    AtomicReference<ReadSession> sessionRef = new AtomicReference<>();
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofSeconds(1))
+        // retry if the newly-created table has not yet fully propagated
+        .ignoreException(NotFoundException.class)
+        .until(
+            () -> {
+              sessionRef.set(client.createReadSession(request));
+              return true;
+            });
+    ReadSession session = sessionRef.get();
     assertEquals(
         1,
         session.getStreamsCount(),


### PR DESCRIPTION
Recurring test flakes (#11964, #12981) have resulted when metadata for tables created via bigquery.googleapis.com are not immediately available for reading via bigquerystorage.googleapis.com. This PR introduces Awaitility to bigquerystorage and uses it in the flaky ITBigQueryStorageTest classes to retry creating ReadSessions when they fail with NotFoundExceptions.

Fixes #11964