### PR TITLE
chore: update librarian to v0.21.1-0.20260617000028-820646f3db93

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.20.0
+version: v0.21.1-0.20260617000028-820646f3db93
 repo: googleapis/google-cloud-java
 sources:
   googleapis:


### PR DESCRIPTION
Weekly update of librarian version and re-generate. Use pseudo version because v0.21.0 has a known issue for Java.
Command used:

```
go run github.com/googleapis/librarian/cmd/librarian@latest update version

# Get the updated version
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)

# Regenerate everything to pick up librarian / sdk.yaml changes.
go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
```