### PR TITLE
chore(ci): update_librarian_googleapis workflow run librarian at version in config

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -57,15 +57,18 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '>=1.20.2'
-    - name: Run librarian update
+    - name: Get librarian version
+      id: librarian
       run: |
         version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-        go run "github.com/googleapis/librarian/cmd/librarian@${version}" update sources.googleapis
+        echo "version=${version}" >> $GITHUB_OUTPUT
+    - name: Run librarian update
+      run: |
+        go run "github.com/googleapis/librarian/cmd/librarian@${{ steps.librarian.outputs.version }}" update sources.googleapis
     - name: Get latest commit
       id: commit
       run: |
-        version=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-        new_commit=$(go run "github.com/googleapis/librarian/cmd/librarian@${version}" config get sources.googleapis.commit)
+        new_commit=$(go run "github.com/googleapis/librarian/cmd/librarian@${{ steps.librarian.outputs.version }}" config get sources.googleapis.commit)
         echo "new_commit=${new_commit}" >> $GITHUB_OUTPUT
         echo "short_commit=${new_commit:0:7}" >> $GITHUB_OUTPUT
     # TODO(https://github.com/googleapis/librarian/issues/6220): Remove this step.
@@ -115,14 +118,14 @@ jobs:
     - name: Run librarian install
       if: steps.detect_librarian.outputs.has_changes == 'true'
       run: |
-        go run github.com/googleapis/librarian/cmd/librarian@latest install
+        go run "github.com/googleapis/librarian/cmd/librarian@${{ steps.librarian.outputs.version }}" install
         echo "$HOME/.cache/librarian/bin/java_tools/bin" >> $GITHUB_PATH
       env:
         PYTHONPATH: ${{ github.workspace }}/sdk-platform-java/hermetic_build/library_generation/owlbot
     - name: Generate Libraries
       if: steps.detect_librarian.outputs.has_changes == 'true'
       run: |
-        go run github.com/googleapis/librarian/cmd/librarian@latest generate --all
+        go run "github.com/googleapis/librarian/cmd/librarian@${{ steps.librarian.outputs.version }}" generate --all
     - name: Commit and Create PR
       if: steps.detect_librarian.outputs.has_changes == 'true'
       env:


### PR DESCRIPTION
Fix workflow to run librarian at version configured in librarian.yaml consistently.

Fixes https://github.com/googleapis/librarian/issues/6466