### PR TITLE
fix(bigquery-jdbc): fix shading exclusions and telemetry credentials

### DIFF
--- a/java-bigquery-jdbc/pom.xml
+++ b/java-bigquery-jdbc/pom.xml
@@ -87,6 +87,9 @@
                 <ignoredUnusedDeclaredDependency>io.opentelemetry.contrib:opentelemetry-gcp-auth-extension</ignoredUnusedDeclaredDependency>
                 <ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-exporter-otlp</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
+            <ignoredDependencies>
+                <ignoredDependency>io.opentelemetry:opentelemetry-sdk-logs</ignoredDependency>
+            </ignoredDependencies>
         </configuration>
       </plugin>
       <plugin>

--- a/java-bigquery-jdbc/pom.xml
+++ b/java-bigquery-jdbc/pom.xml
@@ -179,8 +179,8 @@
                           version mismatches, but this is a necessary trade-off for the OpenTelemetry 
                           integration to function correctly across different applications.
                         -->
-                        <exclude>io.opentelemetry.api.*</exclude>
-                        <exclude>io.opentelemetry.context.*</exclude>
+                        <exclude>io.opentelemetry.api.**</exclude>
+                        <exclude>io.opentelemetry.context.**</exclude>
                       </excludes>
                     </relocation>
                     <relocation>
@@ -383,6 +383,10 @@
       <artifactId>opentelemetry-sdk-extension-autoconfigure-spi</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-logs</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.opentelemetry.contrib</groupId>
       <artifactId>opentelemetry-gcp-auth-extension</artifactId>
       <version>1.56.0-alpha</version>
@@ -440,11 +444,6 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-testing</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.opentelemetry</groupId>
-      <artifactId>opentelemetry-sdk-logs</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -209,7 +209,9 @@ public class BigQueryJdbcOpenTelemetry {
 
   private static Credentials resolveCredentialsFromString(String credsString) {
     Map<String, String> authProperties = new java.util.HashMap<>();
-    authProperties.put(BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME, "0"); // Service Account
+    authProperties.put(
+        BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME,
+        BigQueryJdbcOAuthUtility.AuthType.GOOGLE_SERVICE_ACCOUNT.name()); // Service Account
 
     byte[] credsBytes = credsString.getBytes(StandardCharsets.UTF_8);
     if (BigQueryJdbcOAuthUtility.isJson(credsBytes)) {


### PR DESCRIPTION
b/524234554

This PR fixes two issues in the OpenTelemetry implementation within the BigQuery JDBC driver:
1. **Shading/Relocation namespace exclusions**: Corrects the API shading rules to recursively exclude nested OpenTelemetry API subpackages. This resolves dependency conflicts and `AbstractMethodError` crashes when client applications inject custom OTel SDK instances.
2. **Telemetry Credentials Resolution bug**: Fixes an `IllegalArgumentException` thrown when parsing OAuth authentication types during zero-config credentials initialization.