### PR TITLE
feat(gapic-generator): Add NullMarked annotation to generated classes

### DIFF
--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceClient.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -355,6 +356,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class ComplianceClient implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/ComplianceSettings.java
@@ -43,6 +43,7 @@ import com.google.showcase.v1beta1.stub.ComplianceStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -93,6 +94,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class ComplianceSettings extends ClientSettings<ComplianceSettings> {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoClient.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -364,6 +365,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoClient implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/EchoSettings.java
@@ -49,6 +49,7 @@ import com.google.showcase.v1beta1.stub.EchoStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -124,6 +125,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoSettings extends ClientSettings<EchoSettings> {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentityClient.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -286,6 +287,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class IdentityClient implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentitySettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/IdentitySettings.java
@@ -45,6 +45,7 @@ import com.google.showcase.v1beta1.stub.IdentityStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -95,6 +96,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class IdentitySettings extends ClientSettings<IdentitySettings> {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingClient.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -449,6 +450,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class MessagingClient implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/MessagingSettings.java
@@ -50,6 +50,7 @@ import com.google.showcase.v1beta1.stub.MessagingStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -125,6 +126,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class MessagingSettings extends ClientSettings<MessagingSettings> {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceClient.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -309,6 +310,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class SequenceServiceClient implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/SequenceServiceSettings.java
@@ -45,6 +45,7 @@ import com.google.showcase.v1beta1.stub.SequenceServiceStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -96,6 +97,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class SequenceServiceSettings extends ClientSettings<SequenceServiceSettings> {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingClient.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -318,6 +319,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class TestingClient implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/TestingSettings.java
@@ -46,6 +46,7 @@ import com.google.showcase.v1beta1.stub.TestingStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -96,6 +97,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class TestingSettings extends ClientSettings<TestingSettings> {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStub.java
@@ -35,6 +35,7 @@ import com.google.showcase.v1beta1.EnumResponse;
 import com.google.showcase.v1beta1.RepeatRequest;
 import com.google.showcase.v1beta1.RepeatResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class ComplianceStub implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/ComplianceStubSettings.java
@@ -65,6 +65,7 @@ import com.google.showcase.v1beta1.RepeatResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -115,6 +116,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStub.java
@@ -55,6 +55,7 @@ import com.google.showcase.v1beta1.WaitMetadata;
 import com.google.showcase.v1beta1.WaitRequest;
 import com.google.showcase.v1beta1.WaitResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -62,6 +63,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class EchoStub implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/EchoStubSettings.java
@@ -89,6 +89,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -164,6 +165,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceCallableFactory.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcComplianceCallableFactory implements GrpcStubCallableFactory {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcComplianceStub.java
@@ -45,6 +45,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -52,6 +53,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcComplianceStub extends ComplianceStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoCallableFactory.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcEchoCallableFactory implements GrpcStubCallableFactory {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcEchoStub.java
@@ -67,6 +67,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -74,6 +75,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcEchoStub extends EchoStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityCallableFactory.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcIdentityCallableFactory implements GrpcStubCallableFactory {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcIdentityStub.java
@@ -50,6 +50,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -57,6 +58,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcIdentityStub extends IdentityStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingCallableFactory.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcMessagingCallableFactory implements GrpcStubCallableFactory {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcMessagingStub.java
@@ -70,6 +70,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -77,6 +78,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcMessagingStub extends MessagingStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceCallableFactory.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcSequenceServiceCallableFactory implements GrpcStubCallableFactory {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcSequenceServiceStub.java
@@ -54,6 +54,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -61,6 +62,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcSequenceServiceStub extends SequenceServiceStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingCallableFactory.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcTestingCallableFactory implements GrpcStubCallableFactory {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/GrpcTestingStub.java
@@ -57,6 +57,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -64,6 +65,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcTestingStub extends TestingStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceCallableFactory.java
@@ -33,6 +33,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonComplianceCallableFactory

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonComplianceStub.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -59,6 +60,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonComplianceStub extends ComplianceStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoCallableFactory.java
@@ -33,6 +33,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonEchoCallableFactory

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonEchoStub.java
@@ -78,6 +78,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -85,6 +86,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonEchoStub extends EchoStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityCallableFactory.java
@@ -33,6 +33,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonIdentityCallableFactory

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonIdentityStub.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -64,6 +65,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonIdentityStub extends IdentityStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingCallableFactory.java
@@ -33,6 +33,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonMessagingCallableFactory

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonMessagingStub.java
@@ -81,6 +81,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -88,6 +89,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonMessagingStub extends MessagingStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceCallableFactory.java
@@ -33,6 +33,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonSequenceServiceCallableFactory

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonSequenceServiceStub.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -68,6 +69,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonSequenceServiceStub extends SequenceServiceStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingCallableFactory.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingCallableFactory.java
@@ -33,6 +33,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonTestingCallableFactory

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/HttpJsonTestingStub.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -71,6 +72,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonTestingStub extends TestingStub {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStub.java
@@ -40,6 +40,7 @@ import com.google.showcase.v1beta1.ListUsersResponse;
 import com.google.showcase.v1beta1.UpdateUserRequest;
 import com.google.showcase.v1beta1.User;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -47,6 +48,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class IdentityStub implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/IdentityStubSettings.java
@@ -71,6 +71,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -121,6 +122,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStub.java
@@ -61,6 +61,7 @@ import com.google.showcase.v1beta1.StreamBlurbsResponse;
 import com.google.showcase.v1beta1.UpdateBlurbRequest;
 import com.google.showcase.v1beta1.UpdateRoomRequest;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -68,6 +69,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class MessagingStub implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/MessagingStubSettings.java
@@ -93,6 +93,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -168,6 +169,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStub.java
@@ -44,6 +44,7 @@ import com.google.showcase.v1beta1.SequenceReport;
 import com.google.showcase.v1beta1.StreamingSequence;
 import com.google.showcase.v1beta1.StreamingSequenceReport;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -51,6 +52,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class SequenceServiceStub implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/SequenceServiceStubSettings.java
@@ -75,6 +75,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -126,6 +127,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStub.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStub.java
@@ -47,6 +47,7 @@ import com.google.showcase.v1beta1.Session;
 import com.google.showcase.v1beta1.VerifyTestRequest;
 import com.google.showcase.v1beta1.VerifyTestResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -54,6 +55,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class TestingStub implements BackgroundResource {

--- a/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
+++ b/java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/TestingStubSettings.java
@@ -78,6 +78,7 @@ import com.google.showcase.v1beta1.VerifyTestResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -128,6 +129,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/BlurbName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BlurbName implements ResourceName {
   private static final PathTemplate USER_LEGACY_USER_BLURB =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ProfileName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/ProfileName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ProfileName implements ResourceName {
   private static final PathTemplate USER =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RoomName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/RoomName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class RoomName implements ResourceName {
   private static final PathTemplate ROOM = PathTemplate.createWithoutUrlEncoding("rooms/{room}");

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SequenceName implements ResourceName {
   private static final PathTemplate SEQUENCE =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SequenceReportName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SequenceReportName implements ResourceName {
   private static final PathTemplate SEQUENCE =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SessionName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/SessionName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SessionName implements ResourceName {
   private static final PathTemplate SESSION =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class StreamingSequenceName implements ResourceName {
   private static final PathTemplate STREAMING_SEQUENCE =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/StreamingSequenceReportName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class StreamingSequenceReportName implements ResourceName {
   private static final PathTemplate STREAMING_SEQUENCE =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/TestName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TestName implements ResourceName {
   private static final PathTemplate SESSION_TEST =

--- a/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserName.java
+++ b/java-showcase/proto-gapic-showcase-v1beta1/src/main/java/com/google/showcase/v1beta1/UserName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class UserName implements ResourceName {
   private static final PathTemplate USER = PathTemplate.createWithoutUrlEncoding("users/{user}");

--- a/rules_java_gapic/java_gapic.bzl
+++ b/rules_java_gapic/java_gapic.bzl
@@ -288,6 +288,7 @@ def java_gapic_library(
             "@com_google_api_api_common//jar",
             "@com_google_guava_guava//jar",
             "@javax_annotation_javax_annotation_api//jar",
+            "@org_jspecify_jspecify//jar",
         ],
         **kwargs
     )
@@ -307,6 +308,7 @@ def java_gapic_library(
         "@com_google_auth_google_auth_library_oauth2_http//jar",
         "@com_google_http_client_google_http_client//jar",
         "@javax_annotation_javax_annotation_api//jar",
+        "@org_jspecify_jspecify//jar",
     ]
 
     if not transport or transport == "grpc":

--- a/sdk-platform-java/gapic-generator-java/pom.xml
+++ b/sdk-platform-java/gapic-generator-java/pom.xml
@@ -284,6 +284,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>${jspecify.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceCallableFactoryClassComposer.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 public abstract class AbstractServiceCallableFactoryClassComposer implements ClassComposer {
   private final TransportContext transportContext;
@@ -93,6 +94,7 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
 
   protected List<AnnotationNode> createClassAnnotations(Service service, TypeStore typeStore) {
     List<AnnotationNode> annotations = new ArrayList<>();
+    annotations.add(AnnotationNode.withType(typeStore.get("NullMarked")));
     if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(typeStore.get("BetaApi")));
     }
@@ -349,7 +351,8 @@ public abstract class AbstractServiceCallableFactoryClassComposer implements Cla
             UnaryCallSettings.class,
             UnaryCallable.class,
             Generated.class,
-            UnsupportedOperationException.class);
+            UnsupportedOperationException.class,
+            NullMarked.class);
     return new TypeStore(concreteClazzes);
   }
 }

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceClientClassComposer.java
@@ -103,6 +103,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 public abstract class AbstractServiceClientClassComposer implements ClassComposer {
   private static final String CALLABLE_NAME_PATTERN = "%sCallable";
@@ -193,6 +194,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
 
   private static List<AnnotationNode> createClassAnnotations(Service service, TypeStore typeStore) {
     List<AnnotationNode> annotations = new ArrayList<>();
+    annotations.add(AnnotationNode.withType(typeStore.get("NullMarked")));
     if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(typeStore.get("BetaApi")));
     }
@@ -1786,6 +1788,7 @@ public abstract class AbstractServiceClientClassComposer implements ClassCompose
             InterruptedException.class,
             IOException.class,
             MoreExecutors.class,
+            NullMarked.class,
             Objects.class,
             Operation.class,
             OperationFuture.class,

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceSettingsClassComposer.java
@@ -79,6 +79,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 public abstract class AbstractServiceSettingsClassComposer implements ClassComposer {
   private static final String BUILDER_CLASS_NAME = "Builder";
@@ -204,6 +205,7 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
 
   private static List<AnnotationNode> createClassAnnotations(Service service) {
     List<AnnotationNode> annotations = new ArrayList<>();
+    annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("NullMarked")));
     if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("BetaApi")));
     }
@@ -847,7 +849,8 @@ public abstract class AbstractServiceSettingsClassComposer implements ClassCompo
             StreamingCallSettings.class,
             StubSettings.class,
             TransportChannelProvider.class,
-            UnaryCallSettings.class);
+            UnaryCallSettings.class,
+            NullMarked.class);
     return new TypeStore(concreteClazzes);
   }
 

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubClassComposer.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 public abstract class AbstractServiceStubClassComposer implements ClassComposer {
 
@@ -93,6 +94,7 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
 
   private static List<AnnotationNode> createClassAnnotations(Service service, TypeStore typeStore) {
     List<AnnotationNode> annotations = new ArrayList<>();
+    annotations.add(AnnotationNode.withType(typeStore.get("NullMarked")));
     if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(typeStore.get("BetaApi")));
     }
@@ -270,7 +272,8 @@ public abstract class AbstractServiceStubClassComposer implements ClassComposer 
             OperationCallable.class,
             ServerStreamingCallable.class,
             UnaryCallable.class,
-            UnsupportedOperationException.class);
+            UnsupportedOperationException.class,
+            NullMarked.class);
     TypeStore typeStore = new TypeStore(concreteClazzes);
 
     typeStore.put("com.google.longrunning.stub", "OperationsStub");

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractServiceStubSettingsClassComposer.java
@@ -124,6 +124,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
+import org.jspecify.annotations.NullMarked;
 
 public abstract class AbstractServiceStubSettingsClassComposer implements ClassComposer {
   private static final Statement EMPTY_LINE_STATEMENT = EmptyLineStatement.create();
@@ -411,6 +412,7 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
 
   private List<AnnotationNode> createClassAnnotations(Service service) {
     List<AnnotationNode> annotations = new ArrayList<>();
+    annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("NullMarked")));
     if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("BetaApi")));
     }
@@ -2217,7 +2219,8 @@ public abstract class AbstractServiceStubSettingsClassComposer implements ClassC
             SuppressWarnings.class,
             TransportChannelProvider.class,
             UnaryCallSettings.class,
-            UnaryCallable.class);
+            UnaryCallable.class,
+            NullMarked.class);
     return new TypeStore(concreteClazzes);
   }
 

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/common/AbstractTransportServiceStubClassComposer.java
@@ -100,6 +100,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
+import org.jspecify.annotations.NullMarked;
 
 public abstract class AbstractTransportServiceStubClassComposer implements ClassComposer {
   private static final List<String> AIP_STANDARDS_METHODS =
@@ -152,7 +153,8 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
             TimeUnit.class,
             TypeRegistry.class,
             UnaryCallable.class,
-            UnsupportedOperationException.class);
+            UnsupportedOperationException.class,
+            NullMarked.class);
     return new TypeStore(concreteClazzes);
   }
 
@@ -548,6 +550,7 @@ public abstract class AbstractTransportServiceStubClassComposer implements Class
 
   protected List<AnnotationNode> createClassAnnotations(Service service) {
     List<AnnotationNode> annotations = new ArrayList<>();
+    annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("NullMarked")));
     if (!PackageChecker.isGaApi(service.pakkage())) {
       annotations.add(AnnotationNode.withType(FIXED_TYPESTORE.get("BetaApi")));
     }

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/composer/resourcename/ResourceNameHelperClassComposer.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 public class ResourceNameHelperClassComposer {
   private static final String CLASS_NAME_PATTERN = "%sName";
@@ -152,6 +153,7 @@ public class ResourceNameHelperClassComposer {
 
   private static List<AnnotationNode> createClassAnnotations() {
     return Arrays.asList(
+        AnnotationNode.withType(FIXED_TYPESTORE.get("NullMarked")),
         AnnotationNode.builder()
             .setType(FIXED_TYPESTORE.get("Generated"))
             .setDescription("by gapic-generator-java")
@@ -1704,7 +1706,8 @@ public class ResourceNameHelperClassComposer {
             PathTemplate.class,
             Preconditions.class,
             com.google.api.resourcenames.ResourceName.class,
-            ValidationException.class);
+            ValidationException.class,
+            NullMarked.class);
     return new TypeStore(concreteClazzes);
   }
 

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/goldens/GrpcServiceClientWithNestedClassImport.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/engine/writer/goldens/GrpcServiceClientWithNestedClassImport.golden
@@ -8,6 +8,7 @@ import com.google.types.testing.stub.NestedMessageServiceStubSettings;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -95,6 +96,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class NestedMessageServiceClient implements BackgroundResource {
   private final NestedMessageServiceSettings settings;

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/ApiVersionTestingStubSettings.golden
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -76,6 +77,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStubSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/BookshopClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/BookshopClient.golden
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -98,6 +99,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class BookshopClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceClient.golden
@@ -8,6 +8,7 @@ import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -110,6 +111,7 @@ import javax.annotation.Generated;
  *
  * @deprecated This class is deprecated and will be removed in the next major version update.
  */
+@NullMarked
 @Deprecated
 @Generated("by gapic-generator-java")
 public class DeprecatedServiceClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceSettings.golden
@@ -15,6 +15,7 @@ import com.google.testdata.v1.stub.DeprecatedServiceStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -68,6 +69,7 @@ import javax.annotation.Generated;
  *
  * @deprecated This class is deprecated and will be removed in the next major version update.
  */
+@NullMarked
 @Deprecated
 @Generated("by gapic-generator-java")
 public class DeprecatedServiceSettings extends ClientSettings<DeprecatedServiceSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStub.golden
@@ -5,6 +5,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.protobuf.Empty;
 import com.google.testdata.v1.FibonacciRequest;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -14,6 +15,7 @@ import javax.annotation.Generated;
  *
  * @deprecated This class is deprecated and will be removed in the next major version update.
  */
+@NullMarked
 @Deprecated
 @Generated("by gapic-generator-java")
 public abstract class DeprecatedServiceStub implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/DeprecatedServiceStubSettings.golden
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -80,6 +81,7 @@ import javax.annotation.Generated;
  *
  * @deprecated This class is deprecated and will be removed in the next major version update.
  */
+@NullMarked
 @Deprecated
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoClient.golden
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -260,6 +261,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicClient.golden
@@ -10,6 +10,7 @@ import com.google.selective.generate.v1beta1.stub.EchoServiceShouldGenerateParti
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -155,6 +156,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoServiceShouldGeneratePartialUsualClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicClientStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicClientStub.golden
@@ -8,6 +8,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.selective.generate.v1beta1.EchoRequest;
 import com.google.selective.generate.v1beta1.EchoResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -15,6 +16,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class EchoServiceShouldGeneratePartialUsualStub implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicServiceSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicServiceSettings.golden
@@ -17,6 +17,7 @@ import com.google.selective.generate.v1beta1.stub.EchoServiceShouldGenerateParti
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -70,6 +71,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoServiceShouldGeneratePartialUsualSettings

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoServiceSelectiveGapicStubSettings.golden
@@ -28,6 +28,7 @@ import com.google.selective.generate.v1beta1.EchoResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -82,6 +83,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoSettings.golden
@@ -23,6 +23,7 @@ import com.google.showcase.v1beta1.stub.EchoStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -98,6 +99,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoSettings extends ClientSettings<EchoSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStub.golden
@@ -25,6 +25,7 @@ import com.google.showcase.v1beta1.WaitMetadata;
 import com.google.showcase.v1beta1.WaitRequest;
 import com.google.showcase.v1beta1.WaitResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -32,6 +33,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class EchoStub implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/EchoStubSettings.golden
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -129,6 +130,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcAutoPopulateFieldStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcAutoPopulateFieldStub.golden
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -27,6 +28,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcAutoPopulateFieldTestingStub extends AutoPopulateFieldTestingStub {
   private static final MethodDescriptor<

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcBigQueryJobServiceStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcBigQueryJobServiceStub.golden
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -25,6 +26,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcJobServiceStub extends JobServiceStub {
   private static final MethodDescriptor<JobProto.DeleteJobRequest, Empty>

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcCallableNameTypeStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcCallableNameTypeStub.golden
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -23,6 +24,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcCallableNameTypeServiceStub extends CallableNameTypeServiceStub {
   private static final MethodDescriptor<GetApiOperationRequest, ApiOperation>

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcDeprecatedServiceCallableFactory.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcDeprecatedServiceCallableFactory.golden
@@ -18,6 +18,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -27,6 +28,7 @@ import javax.annotation.Generated;
  *
  * @deprecated This class is deprecated and will be removed in the next major version update.
  */
+@NullMarked
 @Deprecated
 @Generated("by gapic-generator-java")
 public class GrpcDeprecatedServiceCallableFactory implements GrpcStubCallableFactory {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcDeprecatedServiceStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcDeprecatedServiceStub.golden
@@ -14,6 +14,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -23,6 +24,7 @@ import javax.annotation.Generated;
  *
  * @deprecated This class is deprecated and will be removed in the next major version update.
  */
+@NullMarked
 @Deprecated
 @Generated("by gapic-generator-java")
 public class GrpcDeprecatedServiceStub extends DeprecatedServiceStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcEchoCallableFactory.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcEchoCallableFactory.golden
@@ -19,6 +19,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -26,6 +27,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcEchoCallableFactory implements GrpcStubCallableFactory {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcEchoStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcEchoStub.golden
@@ -33,6 +33,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcEchoStub extends EchoStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcLoggingStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcLoggingStub.golden
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -38,6 +39,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcLoggingServiceV2Stub extends LoggingServiceV2Stub {
   private static final MethodDescriptor<DeleteLogRequest, Empty> deleteLogMethodDescriptor =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcPublisherStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcPublisherStub.golden
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcPublisherStub extends PublisherStub {
   private static final MethodDescriptor<Topic, Topic> createTopicMethodDescriptor =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcResourceNameExtractorStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcResourceNameExtractorStub.golden
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -36,6 +37,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcResourceNameExtractorTestingStub extends ResourceNameExtractorTestingStub {
   private static final MethodDescriptor<GetFooRequest, Foo> getFooMethodDescriptor =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcRoutingHeadersStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcRoutingHeadersStub.golden
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -27,6 +28,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcExplicitDynamicRoutingHeaderTestingStub
     extends ExplicitDynamicRoutingHeaderTestingStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcTestingStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/GrpcTestingStub.golden
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcTestingStub extends TestingStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/IdentityClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/IdentityClient.golden
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -175,6 +176,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class IdentityClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/JobServiceStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/JobServiceStubSettings.golden
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -86,6 +87,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class JobServiceStubSettings extends StubSettings<JobServiceStubSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/LoggingServiceV2StubSettings.golden
@@ -59,6 +59,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -110,6 +111,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2StubSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/MessagingClient.golden
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -325,6 +326,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class MessagingClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpc/goldens/PublisherStubSettings.golden
@@ -60,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -110,6 +111,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoClient.golden
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -282,6 +283,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoSettings.golden
@@ -24,6 +24,7 @@ import com.google.showcase.grpcrest.v1beta1.stub.EchoStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -99,6 +100,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class EchoSettings extends ClientSettings<EchoSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/EchoStubSettings.golden
@@ -58,6 +58,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -133,6 +134,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoCallableFactory.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoCallableFactory.golden
@@ -19,6 +19,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -26,6 +27,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcEchoCallableFactory implements GrpcStubCallableFactory {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcEchoStub.golden
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcEchoStub extends EchoStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcWickedCallableFactory.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcWickedCallableFactory.golden
@@ -19,6 +19,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -26,6 +27,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcWickedCallableFactory implements GrpcStubCallableFactory {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcWickedStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/GrpcWickedStub.golden
@@ -17,6 +17,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -24,6 +25,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcWickedStub extends WickedStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoCallableFactory.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoCallableFactory.golden
@@ -17,6 +17,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -24,6 +25,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonEchoCallableFactory

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/HttpJsonEchoStub.golden
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -53,6 +54,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonEchoStub extends EchoStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedClient.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedClient.golden
@@ -10,6 +10,7 @@ import com.google.showcase.v1beta1.stub.WickedStubSettings;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -113,6 +114,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class WickedClient implements BackgroundResource {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedSettings.golden
@@ -16,6 +16,7 @@ import com.google.showcase.v1beta1.stub.WickedStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -66,6 +67,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class WickedSettings extends ClientSettings<WickedSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/grpcrest/goldens/WickedStubSettings.golden
@@ -27,6 +27,7 @@ import com.google.showcase.v1beta1.EvilResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -77,6 +78,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/AgentName.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/AgentName.golden
@@ -10,8 +10,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class AgentName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/BillingAccountLocationName.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/BillingAccountLocationName.golden
@@ -9,8 +9,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BillingAccountLocationName implements ResourceName {
   private static final PathTemplate BILLING_ACCOUNT_LOCATION =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/CollisionResourceName.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/CollisionResourceName.golden
@@ -8,8 +8,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ResourceName implements com.google.api.resourcenames.ResourceName {
   private static final PathTemplate PROJECT_LOCATION_DEPLOYMENT_REVISION_RESOURCE =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/FoobarName.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/FoobarName.golden
@@ -10,8 +10,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class FoobarName implements ResourceName {
   private static final PathTemplate PROJECT_FOOBAR =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/SessionName.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/SessionName.golden
@@ -9,8 +9,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SessionName implements ResourceName {
   private static final PathTemplate SESSION =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/TestName.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/resourcename/goldens/TestName.golden
@@ -9,8 +9,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TestName implements ResourceName {
   private static final PathTemplate SESSION_SHARD_ID_TEST_ID =

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceSettings.golden
@@ -15,6 +15,7 @@ import com.google.showcase.v1beta1.stub.ComplianceStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -65,6 +66,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class ComplianceSettings extends ClientSettings<ComplianceSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/ComplianceStubSettings.golden
@@ -29,6 +29,7 @@ import com.google.showcase.v1beta1.RepeatResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -79,6 +80,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonApiVersionTestingStubSettings.golden
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -76,6 +77,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class EchoWithVersionStubSettings extends StubSettings<EchoWithVersionStubSettings> {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonAutoPopulateFieldTestingStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonAutoPopulateFieldTestingStub.golden
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -34,6 +35,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonAutoPopulateFieldTestingStub extends AutoPopulateFieldTestingStub {
   private static final TypeRegistry typeRegistry = TypeRegistry.newBuilder().build();

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceCallableFactory.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceCallableFactory.golden
@@ -17,6 +17,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -24,6 +25,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonComplianceCallableFactory

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonComplianceStub.golden
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -33,6 +34,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonComplianceStub extends ComplianceStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonEchoStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonEchoStub.golden
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -52,6 +53,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonEchoStub extends EchoStub {

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonResourceNameExtractorStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonResourceNameExtractorStub.golden
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonResourceNameExtractorTestingStub extends ResourceNameExtractorTestingStub {
   private static final TypeRegistry typeRegistry = TypeRegistry.newBuilder().build();

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonRoutingHeadersStub.golden
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/composer/rest/goldens/HttpJsonRoutingHeadersStub.golden
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -33,6 +34,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonExplicitDynamicRoutingHeaderTestingStub
     extends ExplicitDynamicRoutingHeaderTestingStub {

--- a/sdk-platform-java/gax-java/dependencies.properties
+++ b/sdk-platform-java/gax-java/dependencies.properties
@@ -81,6 +81,7 @@ maven.org_slf4j_slf4j_api=org.slf4j:slf4j-api:2.0.16
 maven.com_google_protobuf_protobuf_java_util=com.google.protobuf:protobuf-java-util:3.25.5
 
 # Testing maven artifacts
+maven.org_jspecify_jspecify=org.jspecify:jspecify:1.0.0
 maven.junit_junit=junit:junit:4.13.2
 maven.org_mockito_mockito_core=org.mockito:mockito-core:4.11.0
 maven.org_mockito_mockito_junit_jupiter=org.mockito:mockito-junit-jupiter:4.11.0

--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/poms/cloud_pom.xml.j2
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/poms/cloud_pom.xml.j2
@@ -43,6 +43,11 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>${jspecify.version}</version>
+    </dependency>
 {% for module in proto_modules %}
     <dependency>
       <groupId>{{module.group_id}}</groupId>

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceClient.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -142,6 +143,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ConnectionServiceClient implements BackgroundResource {
   private final ConnectionServiceSettings settings;

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceSettings.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/ConnectionServiceSettings.java
@@ -35,6 +35,7 @@ import com.google.cloud.apigeeconnect.v1.stub.ConnectionServiceStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -86,6 +87,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ConnectionServiceSettings extends ClientSettings<ConnectionServiceSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/EndpointName.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/EndpointName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class EndpointName implements ResourceName {
   private static final PathTemplate PROJECT_ENDPOINT =

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherClient.java
@@ -23,6 +23,7 @@ import com.google.cloud.apigeeconnect.v1.stub.TetherStubSettings;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -118,6 +119,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TetherClient implements BackgroundResource {
   private final TetherSettings settings;

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherSettings.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/TetherSettings.java
@@ -31,6 +31,7 @@ import com.google.cloud.apigeeconnect.v1.stub.TetherStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -81,6 +82,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TetherSettings extends ClientSettings<TetherSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStub.java
@@ -23,6 +23,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.apigeeconnect.v1.ListConnectionsRequest;
 import com.google.cloud.apigeeconnect.v1.ListConnectionsResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -30,6 +31,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class ConnectionServiceStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/ConnectionServiceStubSettings.java
@@ -56,6 +56,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -108,6 +109,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class ConnectionServiceStubSettings extends StubSettings<ConnectionServiceStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcConnectionServiceCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcConnectionServiceStub.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcConnectionServiceStub extends ConnectionServiceStub {
   private static final MethodDescriptor<ListConnectionsRequest, ListConnectionsResponse>

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcTetherCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherStub.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/GrpcTetherStub.java
@@ -30,6 +30,7 @@ import io.grpc.protobuf.ProtoUtils;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -37,6 +38,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcTetherStub extends TetherStub {
   private static final MethodDescriptor<EgressResponse, EgressRequest> egressMethodDescriptor =

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceCallableFactory.java
@@ -32,6 +32,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -39,6 +40,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonConnectionServiceCallableFactory
     implements HttpJsonStubCallableFactory<Operation, OperationsStub> {

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/HttpJsonConnectionServiceStub.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -47,6 +48,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonConnectionServiceStub extends ConnectionServiceStub {
   private static final TypeRegistry typeRegistry = TypeRegistry.newBuilder().build();

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStub.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStub.java
@@ -21,6 +21,7 @@ import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.cloud.apigeeconnect.v1.EgressRequest;
 import com.google.cloud.apigeeconnect.v1.EgressResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -28,6 +29,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class TetherStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/apigeeconnect/src/com/google/cloud/apigeeconnect/v1/stub/TetherStubSettings.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -92,6 +93,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class TetherStubSettings extends StubSettings<TetherStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceClient.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -482,6 +483,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class AssetServiceClient implements BackgroundResource {
   private final AssetServiceSettings settings;

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceSettings.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/AssetServiceSettings.java
@@ -41,6 +41,7 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -116,6 +117,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class AssetServiceSettings extends ClientSettings<AssetServiceSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FeedName.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FeedName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class FeedName implements ResourceName {
   private static final PathTemplate PROJECT_FEED =

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FolderName.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/FolderName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class FolderName implements ResourceName {
   private static final PathTemplate FOLDER =

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/OrganizationName.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/OrganizationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class OrganizationName implements ResourceName {
   private static final PathTemplate ORGANIZATION =

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/ProjectName.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/ProjectName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ProjectName implements ResourceName {
   private static final PathTemplate PROJECT =

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/SavedQueryName.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/SavedQueryName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SavedQueryName implements ResourceName {
   private static final PathTemplate PROJECT_SAVED_QUERY =

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStub.java
@@ -63,6 +63,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.Empty;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -70,6 +71,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class AssetServiceStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/AssetServiceStubSettings.java
@@ -100,6 +100,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -177,6 +178,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcAssetServiceCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/GrpcAssetServiceStub.java
@@ -73,6 +73,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -80,6 +81,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcAssetServiceStub extends AssetServiceStub {
   private static final MethodDescriptor<ExportAssetsRequest, Operation>

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceCallableFactory.java
@@ -32,6 +32,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -39,6 +40,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonAssetServiceCallableFactory
     implements HttpJsonStubCallableFactory<Operation, OperationsStub> {

--- a/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/asset/src/com/google/cloud/asset/v1/stub/HttpJsonAssetServiceStub.java
@@ -82,6 +82,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -89,6 +90,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonAssetServiceStub extends AssetServiceStub {
   private static final TypeRegistry typeRegistry =

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/bigtable/v2/InstanceName.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/bigtable/v2/InstanceName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class InstanceName implements ResourceName {
   private static final PathTemplate PROJECT_INSTANCE =

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/bigtable/v2/TableName.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/bigtable/v2/TableName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TableName implements ResourceName {
   private static final PathTemplate PROJECT_INSTANCE_TABLE =

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataClient.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -235,6 +236,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BaseBigtableDataClient implements BackgroundResource {
   private final BaseBigtableDataSettings settings;

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/BaseBigtableDataSettings.java
@@ -45,6 +45,7 @@ import com.google.cloud.bigtable.data.v2.stub.BigtableStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -96,6 +97,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BaseBigtableDataSettings extends ClientSettings<BaseBigtableDataSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStub.java
@@ -34,6 +34,7 @@ import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.SampleRowKeysRequest;
 import com.google.bigtable.v2.SampleRowKeysResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class BigtableStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/BigtableStubSettings.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -106,6 +107,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class BigtableStubSettings extends StubSettings<BigtableStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcBigtableCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
+++ b/sdk-platform-java/test/integration/goldens/bigtable/src/com/google/cloud/bigtable/data/v2/stub/GrpcBigtableStub.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -53,6 +54,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcBigtableStub extends BigtableStub {
   private static final MethodDescriptor<ReadRowsRequest, ReadRowsResponse>

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesClient.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -186,6 +187,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class AddressesClient implements BackgroundResource {
   private final AddressesSettings settings;

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesSettings.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/AddressesSettings.java
@@ -35,6 +35,7 @@ import com.google.cloud.compute.v1small.stub.AddressesStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -110,6 +111,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class AddressesSettings extends ClientSettings<AddressesSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsClient.java
@@ -23,6 +23,7 @@ import com.google.cloud.compute.v1small.stub.RegionOperationsStubSettings;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -136,6 +137,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class RegionOperationsClient implements BackgroundResource {
   private final RegionOperationsSettings settings;

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsSettings.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/RegionOperationsSettings.java
@@ -30,6 +30,7 @@ import com.google.cloud.compute.v1small.stub.RegionOperationsStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -81,6 +82,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class RegionOperationsSettings extends ClientSettings<RegionOperationsSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStub.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStub.java
@@ -30,6 +30,7 @@ import com.google.cloud.compute.v1small.InsertAddressRequest;
 import com.google.cloud.compute.v1small.ListAddressesRequest;
 import com.google.cloud.compute.v1small.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -37,6 +38,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class AddressesStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/AddressesStubSettings.java
@@ -64,6 +64,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -139,6 +140,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class AddressesStubSettings extends StubSettings<AddressesStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesCallableFactory.java
@@ -31,6 +31,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.compute.v1small.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -38,6 +39,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonAddressesCallableFactory
     implements HttpJsonStubCallableFactory<Operation, RegionOperationsStub> {

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonAddressesStub.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -58,6 +59,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonAddressesStub extends AddressesStub {
   private static final TypeRegistry typeRegistry =

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsCallableFactory.java
@@ -32,6 +32,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -39,6 +40,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonRegionOperationsCallableFactory
     implements HttpJsonStubCallableFactory<Operation, OperationsStub> {

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/HttpJsonRegionOperationsStub.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -53,6 +54,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonRegionOperationsStub extends RegionOperationsStub {
   private static final TypeRegistry typeRegistry = TypeRegistry.newBuilder().build();

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStub.java
@@ -23,6 +23,7 @@ import com.google.cloud.compute.v1small.GetRegionOperationRequest;
 import com.google.cloud.compute.v1small.Operation;
 import com.google.cloud.compute.v1small.WaitRegionOperationRequest;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -30,6 +31,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class RegionOperationsStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/compute/src/com/google/cloud/compute/v1small/stub/RegionOperationsStubSettings.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -94,6 +95,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class RegionOperationsStubSettings extends StubSettings<RegionOperationsStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsClient.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -198,6 +199,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class IamCredentialsClient implements BackgroundResource {
   private final IamCredentialsSettings settings;

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsSettings.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/IamCredentialsSettings.java
@@ -32,6 +32,7 @@ import com.google.cloud.iam.credentials.v1.stub.IamCredentialsStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -84,6 +85,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class IamCredentialsSettings extends ClientSettings<IamCredentialsSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/ServiceAccountName.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/ServiceAccountName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ServiceAccountName implements ResourceName {
   private static final PathTemplate PROJECT_SERVICE_ACCOUNT =

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcIamCredentialsCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsStub.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/GrpcIamCredentialsStub.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -45,6 +46,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcIamCredentialsStub extends IamCredentialsStub {
   private static final MethodDescriptor<GenerateAccessTokenRequest, GenerateAccessTokenResponse>

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsCallableFactory.java
@@ -32,6 +32,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -39,6 +40,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonIamCredentialsCallableFactory
     implements HttpJsonStubCallableFactory<Operation, OperationsStub> {

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsStub.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/HttpJsonIamCredentialsStub.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -51,6 +52,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonIamCredentialsStub extends IamCredentialsStub {
   private static final TypeRegistry typeRegistry = TypeRegistry.newBuilder().build();

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStub.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStub.java
@@ -27,6 +27,7 @@ import com.google.cloud.iam.credentials.v1.SignBlobResponse;
 import com.google.cloud.iam.credentials.v1.SignJwtRequest;
 import com.google.cloud.iam.credentials.v1.SignJwtResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -34,6 +35,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class IamCredentialsStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/credentials/src/com/google/cloud/iam/credentials/v1/stub/IamCredentialsStubSettings.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -104,6 +105,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class IamCredentialsStubSettings extends StubSettings<IamCredentialsStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
+++ b/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicyClient.java
@@ -23,6 +23,7 @@ import com.google.iam.v1.stub.IAMPolicyStubSettings;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -164,6 +165,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class IAMPolicyClient implements BackgroundResource {
   private final IAMPolicySettings settings;

--- a/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicySettings.java
+++ b/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/IAMPolicySettings.java
@@ -30,6 +30,7 @@ import com.google.iam.v1.stub.IAMPolicyStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -80,6 +81,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class IAMPolicySettings extends ClientSettings<IAMPolicySettings> {
 

--- a/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcIAMPolicyCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyStub.java
+++ b/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/GrpcIAMPolicyStub.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcIAMPolicyStub extends IAMPolicyStub {
   private static final MethodDescriptor<SetIamPolicyRequest, Policy> setIamPolicyMethodDescriptor =

--- a/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStub.java
+++ b/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStub.java
@@ -24,6 +24,7 @@ import com.google.iam.v1.SetIamPolicyRequest;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -31,6 +32,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class IAMPolicyStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/iam/src/com/google/iam/v1/stub/IAMPolicyStubSettings.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -95,6 +96,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class IAMPolicyStubSettings extends StubSettings<IAMPolicyStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyName.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class CryptoKeyName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_KEY_RING_CRYPTO_KEY =

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyVersionName.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/CryptoKeyVersionName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class CryptoKeyVersionName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_KEY_RING_CRYPTO_KEY_CRYPTO_KEY_VERSION =

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/ImportJobName.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/ImportJobName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ImportJobName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_KEY_RING_IMPORT_JOB =

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceClient.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -630,6 +631,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class KeyManagementServiceClient implements BackgroundResource {
   private final KeyManagementServiceSettings settings;

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceSettings.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyManagementServiceSettings.java
@@ -45,6 +45,7 @@ import com.google.iam.v1.TestIamPermissionsResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -97,6 +98,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class KeyManagementServiceSettings extends ClientSettings<KeyManagementServiceSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyRingName.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/KeyRingName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class KeyRingName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_KEY_RING =

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/LocationName.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/LocationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LocationName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION =

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcKeyManagementServiceCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/GrpcKeyManagementServiceStub.java
@@ -80,6 +80,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -87,6 +88,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcKeyManagementServiceStub extends KeyManagementServiceStub {
   private static final MethodDescriptor<ListKeyRingsRequest, ListKeyRingsResponse>

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStub.java
@@ -69,6 +69,7 @@ import com.google.iam.v1.Policy;
 import com.google.iam.v1.TestIamPermissionsRequest;
 import com.google.iam.v1.TestIamPermissionsResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -76,6 +77,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class KeyManagementServiceStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/kms/src/com/google/cloud/kms/v1/stub/KeyManagementServiceStubSettings.java
@@ -97,6 +97,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -149,6 +150,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class KeyManagementServiceStubSettings

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceClient.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -351,6 +352,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LibraryServiceClient implements BackgroundResource {
   private final LibraryServiceSettings settings;

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceSettings.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/LibraryServiceSettings.java
@@ -52,6 +52,7 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -104,6 +105,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LibraryServiceSettings extends ClientSettings<LibraryServiceSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcLibraryServiceCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/GrpcLibraryServiceStub.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -56,6 +57,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private static final MethodDescriptor<CreateShelfRequest, Shelf> createShelfMethodDescriptor =

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceCallableFactory.java
@@ -32,6 +32,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -39,6 +40,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonLibraryServiceCallableFactory
     implements HttpJsonStubCallableFactory<Operation, OperationsStub> {

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/HttpJsonLibraryServiceStub.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -62,6 +63,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class HttpJsonLibraryServiceStub extends LibraryServiceStub {
   private static final TypeRegistry typeRegistry = TypeRegistry.newBuilder().build();

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStub.java
@@ -38,6 +38,7 @@ import com.google.example.library.v1.Shelf;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.protobuf.Empty;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -45,6 +46,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class LibraryServiceStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/cloud/example/library/v1/stub/LibraryServiceStubSettings.java
@@ -70,6 +70,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -122,6 +123,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class LibraryServiceStubSettings extends StubSettings<LibraryServiceStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/example/library/v1/BookName.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/example/library/v1/BookName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BookName implements ResourceName {
   private static final PathTemplate SHELF_BOOK =

--- a/sdk-platform-java/test/integration/goldens/library/src/com/google/example/library/v1/ShelfName.java
+++ b/sdk-platform-java/test/integration/goldens/library/src/com/google/example/library/v1/ShelfName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ShelfName implements ResourceName {
   private static final PathTemplate SHELF_ID =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigClient.java
@@ -86,6 +86,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -630,6 +631,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ConfigClient implements BackgroundResource {
   private final ConfigSettings settings;

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigSettings.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/ConfigSettings.java
@@ -77,6 +77,7 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -152,6 +153,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ConfigSettings extends ClientSettings<ConfigSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingClient.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -228,6 +229,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LoggingClient implements BackgroundResource {
   private final LoggingSettings settings;

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingSettings.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/LoggingSettings.java
@@ -49,6 +49,7 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -99,6 +100,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LoggingSettings extends ClientSettings<LoggingSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsClient.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -207,6 +208,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class MetricsClient implements BackgroundResource {
   private final MetricsSettings settings;

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsSettings.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/MetricsSettings.java
@@ -41,6 +41,7 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -91,6 +92,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class MetricsSettings extends ClientSettings<MetricsSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2Stub.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2Stub.java
@@ -66,6 +66,7 @@ import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.Empty;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -73,6 +74,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class ConfigServiceV2Stub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/ConfigServiceV2StubSettings.java
@@ -96,6 +96,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -173,6 +174,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class ConfigServiceV2StubSettings extends StubSettings<ConfigServiceV2StubSettings> {

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2CallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2CallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcConfigServiceV2CallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2Stub.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcConfigServiceV2Stub.java
@@ -76,6 +76,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -83,6 +84,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcConfigServiceV2Stub extends ConfigServiceV2Stub {
   private static final MethodDescriptor<ListBucketsRequest, ListBucketsResponse>

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2CallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2CallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcLoggingServiceV2CallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcLoggingServiceV2Stub.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -54,6 +55,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcLoggingServiceV2Stub extends LoggingServiceV2Stub {
   private static final MethodDescriptor<DeleteLogRequest, Empty> deleteLogMethodDescriptor =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2CallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2CallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcMetricsServiceV2CallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2Stub.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/GrpcMetricsServiceV2Stub.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -47,6 +48,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcMetricsServiceV2Stub extends MetricsServiceV2Stub {
   private static final MethodDescriptor<ListLogMetricsRequest, ListLogMetricsResponse>

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2Stub.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2Stub.java
@@ -36,6 +36,7 @@ import com.google.logging.v2.WriteLogEntriesRequest;
 import com.google.logging.v2.WriteLogEntriesResponse;
 import com.google.protobuf.Empty;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -43,6 +44,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class LoggingServiceV2Stub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/LoggingServiceV2StubSettings.java
@@ -75,6 +75,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -126,6 +127,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class LoggingServiceV2StubSettings extends StubSettings<LoggingServiceV2StubSettings> {

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2Stub.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2Stub.java
@@ -29,6 +29,7 @@ import com.google.logging.v2.LogMetric;
 import com.google.logging.v2.UpdateLogMetricRequest;
 import com.google.protobuf.Empty;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -36,6 +37,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class MetricsServiceV2Stub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/cloud/logging/v2/stub/MetricsServiceV2StubSettings.java
@@ -57,6 +57,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -108,6 +109,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class MetricsServiceV2StubSettings extends StubSettings<MetricsServiceV2StubSettings> {

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountLocationName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountLocationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BillingAccountLocationName implements ResourceName {
   private static final PathTemplate BILLING_ACCOUNT_LOCATION =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/BillingAccountName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BillingAccountName implements ResourceName {
   private static final PathTemplate BILLING_ACCOUNT =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/CmekSettingsName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/CmekSettingsName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class CmekSettingsName implements ResourceName {
   private static final PathTemplate PROJECT =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/FolderLocationName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/FolderLocationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class FolderLocationName implements ResourceName {
   private static final PathTemplate FOLDER_LOCATION =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/FolderName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/FolderName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class FolderName implements ResourceName {
   private static final PathTemplate FOLDER =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LocationName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LocationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LocationName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogBucketName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogBucketName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LogBucketName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_BUCKET =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogExclusionName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogExclusionName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LogExclusionName implements ResourceName {
   private static final PathTemplate PROJECT_EXCLUSION =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogMetricName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogMetricName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LogMetricName implements ResourceName {
   private static final PathTemplate PROJECT_METRIC =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LogName implements ResourceName {
   private static final PathTemplate PROJECT_LOG =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogSinkName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogSinkName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LogSinkName implements ResourceName {
   private static final PathTemplate PROJECT_SINK =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogViewName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/LogViewName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LogViewName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_BUCKET_VIEW =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationLocationName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationLocationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class OrganizationLocationName implements ResourceName {
   private static final PathTemplate ORGANIZATION_LOCATION =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/OrganizationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class OrganizationName implements ResourceName {
   private static final PathTemplate ORGANIZATION =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/ProjectName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/ProjectName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ProjectName implements ResourceName {
   private static final PathTemplate PROJECT =

--- a/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/SettingsName.java
+++ b/sdk-platform-java/test/integration/goldens/logging/src/com/google/logging/v2/SettingsName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SettingsName implements ResourceName {
   private static final PathTemplate PROJECT =

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceClient.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -358,6 +359,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SchemaServiceClient implements BackgroundResource {
   private final SchemaServiceSettings settings;

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceSettings.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SchemaServiceSettings.java
@@ -55,6 +55,7 @@ import com.google.pubsub.v1.ValidateSchemaResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -105,6 +106,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SchemaServiceSettings extends ClientSettings<SchemaServiceSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminClient.java
@@ -65,6 +65,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -480,6 +481,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SubscriptionAdminClient implements BackgroundResource {
   private final SubscriptionAdminSettings settings;

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminSettings.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/SubscriptionAdminSettings.java
@@ -63,6 +63,7 @@ import com.google.pubsub.v1.UpdateSubscriptionRequest;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -114,6 +115,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SubscriptionAdminSettings extends ClientSettings<SubscriptionAdminSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminClient.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -334,6 +335,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TopicAdminClient implements BackgroundResource {
   private final TopicAdminSettings settings;

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminSettings.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/TopicAdminSettings.java
@@ -56,6 +56,7 @@ import com.google.pubsub.v1.UpdateTopicRequest;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -106,6 +107,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TopicAdminSettings extends ClientSettings<TopicAdminSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcPublisherCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherStub.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcPublisherStub.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -61,6 +62,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcPublisherStub extends PublisherStub {
   private static final MethodDescriptor<Topic, Topic> createTopicMethodDescriptor =

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcSchemaServiceCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSchemaServiceStub.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -61,6 +62,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcSchemaServiceStub extends SchemaServiceStub {
   private static final MethodDescriptor<CreateSchemaRequest, Schema> createSchemaMethodDescriptor =

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcSubscriberCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberStub.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/GrpcSubscriberStub.java
@@ -62,6 +62,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -69,6 +70,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcSubscriberStub extends SubscriberStub {
   private static final MethodDescriptor<Subscription, Subscription>

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStub.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStub.java
@@ -43,6 +43,7 @@ import com.google.pubsub.v1.PublishResponse;
 import com.google.pubsub.v1.Topic;
 import com.google.pubsub.v1.UpdateTopicRequest;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -50,6 +51,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class PublisherStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/PublisherStubSettings.java
@@ -81,6 +81,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -131,6 +132,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class PublisherStubSettings extends StubSettings<PublisherStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStub.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStub.java
@@ -43,6 +43,7 @@ import com.google.pubsub.v1.ValidateMessageResponse;
 import com.google.pubsub.v1.ValidateSchemaRequest;
 import com.google.pubsub.v1.ValidateSchemaResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -50,6 +51,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class SchemaServiceStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SchemaServiceStubSettings.java
@@ -70,6 +70,7 @@ import com.google.pubsub.v1.ValidateSchemaResponse;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -121,6 +122,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class SchemaServiceStubSettings extends StubSettings<SchemaServiceStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStub.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStub.java
@@ -51,6 +51,7 @@ import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.UpdateSnapshotRequest;
 import com.google.pubsub.v1.UpdateSubscriptionRequest;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -58,6 +59,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class SubscriberStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/cloud/pubsub/v1/stub/SubscriberStubSettings.java
@@ -79,6 +79,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -130,6 +131,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class SubscriberStubSettings extends StubSettings<SubscriberStubSettings> {

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/ProjectName.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/ProjectName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ProjectName implements ResourceName {
   private static final PathTemplate PROJECT =

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SchemaName.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SchemaName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SchemaName implements ResourceName {
   private static final PathTemplate PROJECT_SCHEMA =

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SnapshotName.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SnapshotName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SnapshotName implements ResourceName {
   private static final PathTemplate PROJECT_SNAPSHOT =

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SubscriptionName.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/SubscriptionName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class SubscriptionName implements ResourceName {
   private static final PathTemplate PROJECT_SUBSCRIPTION =

--- a/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/TopicName.java
+++ b/sdk-platform-java/test/integration/goldens/pubsub/src/com/google/pubsub/v1/TopicName.java
@@ -26,8 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class TopicName implements ResourceName {
   private static final PathTemplate PROJECT_TOPIC =

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisClient.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -371,6 +372,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class CloudRedisClient implements BackgroundResource {

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/CloudRedisSettings.java
@@ -39,6 +39,7 @@ import com.google.protobuf.Empty;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -114,6 +115,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class CloudRedisSettings extends ClientSettings<CloudRedisSettings> {

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/InstanceName.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/InstanceName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class InstanceName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_INSTANCE =

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/LocationName.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/LocationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class LocationName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION =

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStub.java
@@ -41,6 +41,7 @@ import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.Any;
 import com.google.protobuf.Empty;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -48,6 +49,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public abstract class CloudRedisStub implements BackgroundResource {

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/CloudRedisStubSettings.java
@@ -74,6 +74,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -149,6 +150,7 @@ import javax.annotation.Generated;
  *     .build();
  * }</pre>
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisCallableFactory.java
@@ -35,6 +35,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -42,6 +43,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcCloudRedisCallableFactory implements GrpcStubCallableFactory {

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/GrpcCloudRedisStub.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -58,6 +59,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class GrpcCloudRedisStub extends CloudRedisStub {

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisCallableFactory.java
@@ -33,6 +33,7 @@ import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -40,6 +41,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonCloudRedisCallableFactory

--- a/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisStub.java
+++ b/sdk-platform-java/test/integration/goldens/redis/src/com/google/cloud/redis/v1beta1/stub/HttpJsonCloudRedisStub.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -69,6 +70,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @BetaApi
 @Generated("by gapic-generator-java")
 public class HttpJsonCloudRedisStub extends CloudRedisStub {

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/BucketName.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/BucketName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class BucketName implements ResourceName {
   private static final PathTemplate PROJECT_BUCKET =

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/CryptoKeyName.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/CryptoKeyName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class CryptoKeyName implements ResourceName {
   private static final PathTemplate PROJECT_LOCATION_KEY_RING_CRYPTO_KEY =

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/NotificationName.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/NotificationName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class NotificationName implements ResourceName {
   private static final PathTemplate PROJECT_BUCKET_NOTIFICATION =

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/ProjectName.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/ProjectName.java
@@ -25,8 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
+@NullMarked
 @Generated("by gapic-generator-java")
 public class ProjectName implements ResourceName {
   private static final PathTemplate PROJECT =

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/StorageClient.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -667,6 +668,7 @@ import javax.annotation.Generated;
  *
  * <p>Please refer to the GitHub repository's samples for more quickstart code snippets.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class StorageClient implements BackgroundResource {
   private final StorageSettings settings;

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/StorageSettings.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/StorageSettings.java
@@ -44,6 +44,7 @@ import com.google.storage.v2.stub.StorageStubSettings;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -94,6 +95,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class StorageSettings extends ClientSettings<StorageSettings> {
 

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageCallableFactory.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageCallableFactory.java
@@ -34,6 +34,7 @@ import com.google.api.gax.rpc.UnaryCallable;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -41,6 +42,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcStorageCallableFactory implements GrpcStubCallableFactory {
 

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageStub.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/GrpcStorageStub.java
@@ -87,6 +87,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -94,6 +95,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public class GrpcStorageStub extends StorageStub {
   private static final MethodDescriptor<DeleteBucketRequest, Empty> deleteBucketMethodDescriptor =

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStub.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStub.java
@@ -75,6 +75,7 @@ import com.google.storage.v2.UpdateObjectRequest;
 import com.google.storage.v2.WriteObjectRequest;
 import com.google.storage.v2.WriteObjectResponse;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -82,6 +83,7 @@ import javax.annotation.Generated;
  *
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 public abstract class StorageStub implements BackgroundResource {
 

--- a/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
+++ b/sdk-platform-java/test/integration/goldens/storage/src/com/google/storage/v2/stub/StorageStubSettings.java
@@ -103,6 +103,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jspecify.annotations.NullMarked;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS.
 /**
@@ -153,6 +154,7 @@ import javax.annotation.Generated;
  * Guide](https://docs.cloud.google.com/java/docs/client-retries) for additional support in setting
  * retries.
  */
+@NullMarked
 @Generated("by gapic-generator-java")
 @SuppressWarnings("CanonicalDuration")
 public class StorageStubSettings extends StubSettings<StorageStubSettings> {


### PR DESCRIPTION
This PR updates the gapic-generator-java to add the JSpecify @NullMarked annotation to all generated class declarations. Adding @NullMarked at the class level defines the class scope as null-safe, establishing that all unannotated types in method signatures (parameters and return types) are nonnull able by default. This is the first phase in onboarding the generated client libraries to compile-time safety validation, see design doc for more details: [go/sdk:java-jspecify-null-annotations-gapic](http://goto.google.com/sdk:java-jspecify-null-annotations-gapic)

Classes Annotated:
- Client Classes: AbstractServiceClientClassComposer
- Settings Classes: AbstractServiceSettingsClassComposer and AbstractServiceStubSettingsClassComposer
- Stub Classes: AbstractServiceStubClassComposer and AbstractTransportServiceStubClassComposer
- Callable Factories: AbstractServiceCallableFactoryClassComposer
- Resource Names: ResourceNameHelperClassComposer, CommonStrings

Implementation Changes:
- Added JSpecify import statements to class-level generation templates
- Registered NullMarked.class and Nullable.class in TypeStore across all class composers to ensure references compile and resolve properly

Verification/Testing:
- Please refer to this doc: https://docs.google.com/document/d/1h126pbTGqSwtJyl35E2_vQjM9gNtmWETYCM7PObcvmQ/edit?tab=t.0#heading=h.s4q06jxocx8b 

Revisions:
- Mainly to fix the autogenerator, not related to logic: added goldens + dependencies for the build

Next Steps:
- In the next PR, will add @Nullable annotations