### PR TITLE
refactor(showcase): migrate Thread.sleep to Awaitility in integration tests

### DIFF
--- a/java-showcase/gapic-showcase/pom.xml
+++ b/java-showcase/gapic-showcase/pom.xml
@@ -256,6 +256,12 @@
       <version>${slf4j2-logback.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
   <profiles>

--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITClientShutdown.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITClientShutdown.java
@@ -24,6 +24,7 @@ import com.google.showcase.v1beta1.BlockResponse;
 import com.google.showcase.v1beta1.EchoClient;
 import com.google.showcase.v1beta1.EchoRequest;
 import com.google.showcase.v1beta1.it.util.TestClientInitializer;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.threeten.bp.Duration;
@@ -143,12 +144,10 @@ class ITClientShutdown {
     // check that everything is properly terminated after close() is called.
     echoClient.close();
 
-    // Loop until the client has terminated successfully. For tests that use this,
-    // try to ensure there is a timeout associated, otherwise this may run forever.
-    // Future enhancement: Use awaitility instead of busy waiting
-    while (!echoClient.isTerminated()) {
-      Thread.sleep(500L);
-    }
+    Awaitility.await()
+        .atMost(java.time.Duration.ofMillis(DEFAULT_CLIENT_TERMINATION_MS))
+        .pollInterval(java.time.Duration.ofMillis(500))
+        .until(echoClient::isTerminated);
     // The busy-wait time won't be accurate, so account for a bit of buffer
     long end = System.currentTimeMillis();
 

--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITCompositeTracer.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITCompositeTracer.java
@@ -49,9 +49,11 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -124,13 +126,12 @@ class ITCompositeTracer {
                   .get(AttributeKey.stringKey(ObservabilityAttributes.SERVER_ADDRESS_ATTRIBUTE)))
           .isEqualTo(SHOWCASE_SERVER_ADDRESS);
 
-      Thread.sleep(100);
       // Verify metric name and one basic attribute server.address
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(10))
+          .pollInterval(Duration.ofMillis(100))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> actualMetrics = metricReader.collectAllMetrics();
-      for (int i = 0; i < 10 && actualMetrics.isEmpty(); i++) {
-        Thread.sleep(1000L);
-        actualMetrics = metricReader.collectAllMetrics();
-      }
 
       assertThat(actualMetrics).isNotEmpty();
       MetricData metricData =

--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITOtelGoldenMetrics.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITOtelGoldenMetrics.java
@@ -63,6 +63,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Collection;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,7 +107,10 @@ class ITOtelGoldenMetrics {
       // This is implemented by adding a TraceFinisher to ApiFuture as a callback in
       // TracedUnaryCallable,
       // which could be executed in a different thread.
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).isNotEmpty();
 
@@ -192,7 +196,10 @@ class ITOtelGoldenMetrics {
           UnavailableException.class,
           () -> client.echo(EchoRequest.newBuilder().setContent("metrics-test").build()));
 
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).isNotEmpty();
 
@@ -224,7 +231,10 @@ class ITOtelGoldenMetrics {
 
       client.echo(EchoRequest.newBuilder().setContent("metrics-test").build());
 
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).isNotEmpty();
 
@@ -366,7 +376,10 @@ class ITOtelGoldenMetrics {
           UnavailableException.class,
           () -> client.echo(EchoRequest.newBuilder().setContent("metrics-test").build()));
 
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).isNotEmpty();
 
@@ -415,7 +428,10 @@ class ITOtelGoldenMetrics {
           Exception.class,
           () -> client.echo(EchoRequest.newBuilder().setContent("metrics-test").build()));
 
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).isNotEmpty();
 
@@ -458,7 +474,10 @@ class ITOtelGoldenMetrics {
           Exception.class,
           () -> client.echo(EchoRequest.newBuilder().setContent("metrics-test").build()));
 
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).isNotEmpty();
 
@@ -538,7 +557,10 @@ class ITOtelGoldenMetrics {
 
       assertThat(attemptCount.get()).isEqualTo(3);
 
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).hasSize(1);
 
@@ -709,7 +731,10 @@ class ITOtelGoldenMetrics {
 
       assertThat(requestCount.get()).isEqualTo(3);
 
-      Thread.sleep(100);
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .pollInterval(Duration.ofMillis(10))
+          .until(() -> !metricReader.collectAllMetrics().isEmpty());
       Collection<MetricData> metrics = metricReader.collectAllMetrics();
       assertThat(metrics).hasSize(1);
 

--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITOtelMetrics.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITOtelMetrics.java
@@ -83,6 +83,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -296,18 +297,21 @@ class ITOtelMetrics {
    */
   private List<MetricData> getMetricDataList(InMemoryMetricReader metricReader)
       throws InterruptedException {
-    for (int i = 0; i < NUM_DEFAULT_FLUSH_ATTEMPTS; i++) {
-      Thread.sleep(1000L);
-      List<MetricData> metricData = new ArrayList<>(metricReader.collectAllMetrics());
-      // Depending on the OpenTelemetry instance (i.e. OpenTelemetry, GrpcOpenTelemetry, etc.)
-      // there may be additional metrics recorded. Only check to ensure the Gax Metrics
-      // are recorded properly. Any additional metrics are fine to be passed.
-      if (metricData.size() >= NUM_GAX_OTEL_METRICS && areAllGaxMetricsRecorded(metricData)) {
-        return metricData;
-      }
+    try {
+      Awaitility.await()
+          .atMost(java.time.Duration.ofSeconds(NUM_DEFAULT_FLUSH_ATTEMPTS))
+          .pollInterval(java.time.Duration.ofSeconds(1))
+          .until(
+              () -> {
+                List<MetricData> metricData = new ArrayList<>(metricReader.collectAllMetrics());
+                return metricData.size() >= NUM_GAX_OTEL_METRICS
+                    && areAllGaxMetricsRecorded(metricData);
+              });
+      return new ArrayList<>(metricReader.collectAllMetrics());
+    } catch (org.awaitility.core.ConditionTimeoutException e) {
+      Assertions.fail("Unable to collect all the GAX metrics required for the test", e);
+      return new ArrayList<>();
     }
-    Assertions.fail("Unable to collect all the GAX metrics required for the test");
-    return new ArrayList<>();
   }
 
   private boolean areAllGaxMetricsRecorded(List<MetricData> metricData) {
@@ -370,7 +374,7 @@ class ITOtelMetrics {
     UnaryCallable<BlockRequest, BlockResponse> blockCallable = grpcClient.blockCallable();
     ApiFuture<BlockResponse> blockResponseApiFuture = blockCallable.futureCall(blockRequest);
     // Sleep 1s before cancelling to let the request go through
-    Thread.sleep(1000);
+    Awaitility.await().pollDelay(java.time.Duration.ofSeconds(1)).until(() -> true);
     blockResponseApiFuture.cancel(true);
 
     List<MetricData> actualMetricDataList = getMetricDataList();
@@ -397,7 +401,7 @@ class ITOtelMetrics {
     UnaryCallable<BlockRequest, BlockResponse> blockCallable = httpClient.blockCallable();
     ApiFuture<BlockResponse> blockResponseApiFuture = blockCallable.futureCall(blockRequest);
     // Sleep 1s before cancelling to let the request go through
-    Thread.sleep(1000);
+    Awaitility.await().pollDelay(java.time.Duration.ofSeconds(1)).until(() -> true);
     blockResponseApiFuture.cancel(true);
 
     List<MetricData> actualMetricDataList = getMetricDataList();


### PR DESCRIPTION
Migrates all remaining usages of Thread.sleep to Awaitility in the java-showcase module, improving test reliability and reducing unnecessary busy wait delays.