### PR TITLE
feat(storage): respect com.google.cloud.storage.Hasher.read system property in JSON read paths

### DIFF
--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpDownloadSessionBuilder.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpDownloadSessionBuilder.java
@@ -58,7 +58,7 @@ final class HttpDownloadSessionBuilder {
 
     private ReadableByteChannelSessionBuilder(BlobReadChannelContext blobReadChannelContext) {
       this.blobReadChannelContext = blobReadChannelContext;
-      this.hasher = Hasher.defaultHasher();
+      this.hasher = Hasher.readHasher();
       this.autoGzipDecompression = false;
     }
 

--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageRpcHasherHelper.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/HttpStorageRpcHasherHelper.java
@@ -40,7 +40,7 @@ public final class HttpStorageRpcHasherHelper {
   private final Hasher hasher;
 
   private HttpStorageRpcHasherHelper() {
-    hasher = Hasher.defaultHasher();
+    hasher = Hasher.readHasher();
   }
 
   /**

--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ReadAsSeekableChannel.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/ReadAsSeekableChannel.java
@@ -46,8 +46,7 @@ import javax.annotation.concurrent.Immutable;
 public final class ReadAsSeekableChannel extends ReadProjectionConfig<SeekableByteChannel> {
 
   static final ReadAsSeekableChannel INSTANCE =
-      new ReadAsSeekableChannel(
-          Hasher.readHasher(), LinearExponentialRangeSpecFunction.INSTANCE);
+      new ReadAsSeekableChannel(Hasher.readHasher(), LinearExponentialRangeSpecFunction.INSTANCE);
 
   private final Hasher hasher;
   private final RangeSpecFunction rangeSpecFunction;


### PR DESCRIPTION
This PR changes the checksum verification on JSON read paths to use `Hasher.readHasher()` instead of `Hasher.defaultHasher()`. This respects the system property `com.google.cloud.storage.Hasher.read` to allow disabling of client-side checksums on JSON read paths.

[Generated-by: AI]