### PR TITLE
feat(bigquery-jdbc): configure protobuf plugin and add clientanalytics.proto

### DIFF
--- a/java-bigquery-jdbc/pom.xml
+++ b/java-bigquery-jdbc/pom.xml
@@ -34,6 +34,13 @@
   </properties>
 
   <build>
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.7.1</version>
+      </extension>
+    </extensions>
     <resources>
       <resource>
         <directory>src/main/resources</directory>
@@ -193,6 +200,23 @@
                       </filter>
                   </filters>
                 </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.xolstice.maven.plugins</groupId>
+            <artifactId>protobuf-maven-plugin</artifactId>
+            <version>0.6.1</version>
+            <configuration>
+              <protocArtifact>com.google.protobuf:protoc:3.25.5:exe:${os.detected.classifier}</protocArtifact>
+              <checkStaleness>true</checkStaleness>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>compile</goal>
+                  <goal>test-compile</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>

--- a/java-bigquery-jdbc/src/main/proto/google/cloud/bigquery/jdbc/telemetry/v1/clientanalytics.proto
+++ b/java-bigquery-jdbc/src/main/proto/google/cloud/bigquery/jdbc/telemetry/v1/clientanalytics.proto
@@ -1,0 +1,41 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.bigquery.jdbc.telemetry.v1;
+
+option java_multiple_files = true;
+option java_package = "com.google.cloud.bigquery.jdbc.telemetry.v1";
+option java_outer_classname = "ClientAnalyticsProto";
+
+message LogRequest {
+  ClientInfo client_info = 1;
+  int32 log_source = 2;
+  repeated LogEvent log_events = 3;
+  int64 request_time_ms = 4;
+}
+
+message ClientInfo {
+  int32 client_type = 1;
+}
+
+message LogResponse {
+  int64 next_request_wait_millis = 1;
+}
+
+message LogEvent {
+  int64 event_time_ms = 1;
+  bytes source_extension = 6;
+}


### PR DESCRIPTION
b/527947900

* **Build Configuration (`java-bigquery-jdbc/pom.xml`)**:
  * Configured `os-maven-plugin` to detect platform-specific system variables (e.g. `${os.detected.classifier}`).
  * Added `protobuf-maven-plugin` bound to the compilation lifecycle, utilizing `protoc:3.25.5` for generating Java classes from protobuf sources.
* **Telemetry Schema (`google/cloud/bigquery/jdbc/telemetry/v1/clientanalytics.proto`)**:
  * Defined proto3 schema wrapper messages (`LogRequest`, `ClientInfo`, `LogEvent`, `LogResponse`) for recording and reporting client-side telemetry events to the backend log collector.
