### PR TITLE
deps: Add org.bouncycastle:bcprov-jdk18on to java-shared-dependencies

### DIFF
--- a/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -42,10 +42,10 @@
     <flogger.version>0.8</flogger.version>
     <arrow.version>17.0.0</arrow.version>
     <dev.cel.version>0.6.0</dev.cel.version>
+    <bouncycastle.version>1.80</bouncycastle.version>
     <com.google.crypto.tink.version>1.16.0</com.google.crypto.tink.version>
     <io.opentelemetry.contrib.opentelemetry-gcp-resources.version>1.45.0-alpha</io.opentelemetry.contrib.opentelemetry-gcp-resources.version>
     <json.version>20250517</json.version>
-    <bouncycastle.version>1.80</bouncycastle.version>
   </properties>
 
   <dependencyManagement>

--- a/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -45,10 +45,16 @@
     <com.google.crypto.tink.version>1.16.0</com.google.crypto.tink.version>
     <io.opentelemetry.contrib.opentelemetry-gcp-resources.version>1.45.0-alpha</io.opentelemetry.contrib.opentelemetry-gcp-resources.version>
     <json.version>20250517</json.version>
+    <bouncycastle.version>1.80</bouncycastle.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.arrow</groupId>
         <artifactId>arrow-memory-core</artifactId>

--- a/sdk-platform-java/java-shared-dependencies/upper-bound-check/pom.xml
+++ b/sdk-platform-java/java-shared-dependencies/upper-bound-check/pom.xml
@@ -247,5 +247,9 @@
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This adds BouncyCastle to the shared dependency BOM. It is required to implement the OPAQUE PAKE protocol for Spanner Omni authentication (which relies on Argon2id and low-level Elliptic Curve math not available in standard Java/Tink).

Bug: b/526057728