### PR TITLE
fix(spanner): fail fast when inline-begin DML returns no transaction id

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -49,6 +49,7 @@ import com.google.spanner.v1.ExecuteSqlRequest.QueryMode;
 import com.google.spanner.v1.MultiplexedSessionPrecommitToken;
 import com.google.spanner.v1.RequestOptions;
 import com.google.spanner.v1.ResultSet;
+import com.google.spanner.v1.ResultSetMetadata;
 import com.google.spanner.v1.ResultSetStats;
 import com.google.spanner.v1.RollbackRequest;
 import com.google.spanner.v1.Transaction;
@@ -742,7 +743,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     @Override
     public void onTransactionMetadata(Transaction transaction, boolean shouldIncludeId) {
       Preconditions.checkNotNull(transaction);
-      if (transaction.getId() != ByteString.EMPTY) {
+      if (!transaction.getId().isEmpty()) {
         // A transaction has been returned by a statement that was executed. Set the id of the
         // transaction on this instance and release the lock to allow other statements to proceed.
         if ((transactionIdFuture == null || !this.transactionIdFuture.isDone())
@@ -754,6 +755,18 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         // The statement should have returned a transaction.
         throw SpannerExceptionFactory.newSpannerException(
             ErrorCode.FAILED_PRECONDITION, AbstractReadContext.NO_TRANSACTION_RETURNED_MSG);
+      }
+    }
+
+    private boolean hasNonEmptyTransactionId(ResultSetMetadata metadata) {
+      return metadata.hasTransaction() && !metadata.getTransaction().getId().isEmpty();
+    }
+
+    private void throwIfBeginDidNotReturnTransaction(
+        TransactionSelector transactionSelector, boolean sawNonEmptyTransactionId) {
+      if (transactionSelector.hasBegin() && !sawNonEmptyTransactionId) {
+        throw SpannerExceptionFactory.newSpannerException(
+            ErrorCode.FAILED_PRECONDITION, NO_TRANSACTION_RETURNED_MSG);
       }
     }
 
@@ -980,7 +993,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
         com.google.spanner.v1.ResultSet resultSet =
             rpc.executeQuery(builder.build(), getTransactionChannelHint(), isRouteToLeader());
         session.markUsed(clock.instant());
-        if (resultSet.getMetadata().hasTransaction()) {
+        boolean sawNonEmptyTransactionId = hasNonEmptyTransactionId(resultSet.getMetadata());
+        if (sawNonEmptyTransactionId) {
           onTransactionMetadata(
               resultSet.getMetadata().getTransaction(), builder.getTransaction().hasBegin());
         }
@@ -988,6 +1002,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           throw new IllegalArgumentException(
               "DML response missing stats possibly due to non-DML statement as input");
         }
+        throwIfBeginDidNotReturnTransaction(builder.getTransaction(), sawNonEmptyTransactionId);
         if (resultSet.hasPrecommitToken()) {
           onPrecommitToken(resultSet.getPrecommitToken());
         }
@@ -1037,12 +1052,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                         ErrorCode.INVALID_ARGUMENT,
                         "DML response missing stats possibly due to non-DML statement as input");
                   }
-                  if (builder.getTransaction().hasBegin()
-                      && !(input.getMetadata().hasTransaction()
-                          && input.getMetadata().getTransaction().getId() != ByteString.EMPTY)) {
-                    throw SpannerExceptionFactory.newSpannerException(
-                        ErrorCode.FAILED_PRECONDITION, NO_TRANSACTION_RETURNED_MSG);
-                  }
+                  throwIfBeginDidNotReturnTransaction(
+                      builder.getTransaction(), hasNonEmptyTransactionId(input.getMetadata()));
                   // For standard DML, using the exact row count.
                   return input.getStats().getRowCountExact();
                 },
@@ -1116,9 +1127,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
               rpc.executeBatchDml(builder.build(), getTransactionChannelHint());
           session.markUsed(clock.instant());
           long[] results = new long[response.getResultSetsCount()];
+          boolean sawNonEmptyTransactionId = false;
           for (int i = 0; i < response.getResultSetsCount(); ++i) {
             results[i] = response.getResultSets(i).getStats().getRowCountExact();
-            if (response.getResultSets(i).getMetadata().hasTransaction()) {
+            if (hasNonEmptyTransactionId(response.getResultSets(i).getMetadata())) {
+              sawNonEmptyTransactionId = true;
               onTransactionMetadata(
                   response.getResultSets(i).getMetadata().getTransaction(),
                   builder.getTransaction().hasBegin());
@@ -1139,6 +1152,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                 response.getStatus().getMessage(),
                 results);
           }
+          throwIfBeginDidNotReturnTransaction(builder.getTransaction(), sawNonEmptyTransactionId);
           return results;
         } catch (Throwable e) {
           throw onError(
@@ -1187,9 +1201,11 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                 response,
                 batchDmlResponse -> {
                   long[] results = new long[batchDmlResponse.getResultSetsCount()];
+                  boolean sawNonEmptyTransactionId = false;
                   for (int i = 0; i < batchDmlResponse.getResultSetsCount(); ++i) {
                     results[i] = batchDmlResponse.getResultSets(i).getStats().getRowCountExact();
-                    if (batchDmlResponse.getResultSets(i).getMetadata().hasTransaction()) {
+                    if (hasNonEmptyTransactionId(batchDmlResponse.getResultSets(i).getMetadata())) {
+                      sawNonEmptyTransactionId = true;
                       onTransactionMetadata(
                           batchDmlResponse.getResultSets(i).getMetadata().getTransaction(),
                           builder.getTransaction().hasBegin());
@@ -1208,6 +1224,8 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                         batchDmlResponse.getStatus().getMessage(),
                         results);
                   }
+                  throwIfBeginDidNotReturnTransaction(
+                      builder.getTransaction(), sawNonEmptyTransactionId);
                   return results;
                 },
                 MoreExecutors.directExecutor());

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/InlineBeginTransactionTest.java
@@ -1677,6 +1677,10 @@ public class InlineBeginTransactionTest {
       }
     }
 
+    static void useShortTransactionWait(TransactionContext transaction) {
+      ((TransactionContextImpl) transaction).waitForTransactionTimeoutMillis = 1L;
+    }
+
     @Test
     public void testQueryWithInlineBeginDidNotReturnTransaction() {
       runWithIgnoreInlineBegin(
@@ -1738,7 +1742,11 @@ public class InlineBeginTransactionTest {
                     () ->
                         client
                             .readWriteTransaction()
-                            .run(transaction -> transaction.executeUpdate(UPDATE_STATEMENT)));
+                            .run(
+                                transaction -> {
+                                  useShortTransactionWait(transaction);
+                                  return transaction.executeUpdate(UPDATE_STATEMENT);
+                                }));
             assertEquals(ErrorCode.FAILED_PRECONDITION, e.getErrorCode());
             assertThat(e.getMessage()).contains(AbstractReadContext.NO_TRANSACTION_RETURNED_MSG);
             assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -1760,6 +1768,7 @@ public class InlineBeginTransactionTest {
                             .readWriteTransaction()
                             .run(
                                 transaction -> {
+                                  useShortTransactionWait(transaction);
                                   transaction.batchUpdate(
                                       Collections.singletonList(UPDATE_STATEMENT));
                                   return null;
@@ -1831,9 +1840,11 @@ public class InlineBeginTransactionTest {
                         client
                             .readWriteTransaction()
                             .run(
-                                transaction ->
-                                    SpannerApiFutures.get(
-                                        transaction.executeUpdateAsync(UPDATE_STATEMENT))));
+                                transaction -> {
+                                  useShortTransactionWait(transaction);
+                                  return SpannerApiFutures.get(
+                                      transaction.executeUpdateAsync(UPDATE_STATEMENT));
+                                }));
             assertEquals(ErrorCode.FAILED_PRECONDITION, e.getErrorCode());
             assertThat(e.getMessage()).contains(AbstractReadContext.NO_TRANSACTION_RETURNED_MSG);
             assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);
@@ -1854,10 +1865,12 @@ public class InlineBeginTransactionTest {
                         client
                             .readWriteTransaction()
                             .run(
-                                transaction ->
-                                    SpannerApiFutures.get(
-                                        transaction.batchUpdateAsync(
-                                            Collections.singletonList(UPDATE_STATEMENT)))));
+                                transaction -> {
+                                  useShortTransactionWait(transaction);
+                                  return SpannerApiFutures.get(
+                                      transaction.batchUpdateAsync(
+                                          Collections.singletonList(UPDATE_STATEMENT)));
+                                }));
             assertEquals(ErrorCode.FAILED_PRECONDITION, e.getErrorCode());
             assertThat(e.getMessage()).contains(AbstractReadContext.NO_TRANSACTION_RETURNED_MSG);
             assertThat(countRequests(BeginTransactionRequest.class)).isEqualTo(0);

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MockSpannerServiceImpl.java
@@ -813,6 +813,10 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
     ignoreInlineBeginRequest.set(ignore);
   }
 
+  private boolean shouldOmitInlineBeginTransaction(TransactionSelector transactionSelector) {
+    return ignoreInlineBeginRequest.get() && transactionSelector.hasBegin();
+  }
+
   public void freeze() {
     synchronized (lock) {
       freezeLock = new CountDownLatch(1);
@@ -1100,12 +1104,12 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
                             .setRowCountExact(result.getUpdateCount())
                             .build())
                     .setMetadata(
-                        ResultSetMetadata.newBuilder()
-                            .setTransaction(
-                                ignoreInlineBeginRequest.get()
-                                    ? Transaction.getDefaultInstance()
-                                    : Transaction.newBuilder().setId(transactionId).build())
-                            .build());
+                        shouldOmitInlineBeginTransaction(request.getTransaction())
+                            ? ResultSetMetadata.getDefaultInstance()
+                            : ResultSetMetadata.newBuilder()
+                                .setTransaction(
+                                    Transaction.newBuilder().setId(transactionId).build())
+                                .build());
             if (session.getMultiplexed() && isReadWriteTransaction(transactionId)) {
               resultSetBuilder.setPrecommitToken(getResultSetPrecommitToken(transactionId));
             }
@@ -1131,13 +1135,12 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
       Session session) {
     ResultSetMetadata metadata = resultSet.getMetadata();
     if (transactionId != null) {
-      metadata =
-          metadata.toBuilder()
-              .setTransaction(
-                  ignoreInlineBeginRequest.get()
-                      ? Transaction.getDefaultInstance()
-                      : Transaction.newBuilder().setId(transactionId).build())
-              .build();
+      if (!shouldOmitInlineBeginTransaction(transactionSelector)) {
+        metadata =
+            metadata.toBuilder()
+                .setTransaction(Transaction.newBuilder().setId(transactionId).build())
+                .build();
+      }
     } else if (transactionSelector.hasBegin() || transactionSelector.hasSingleUse()) {
       Transaction transaction = getTemporaryTransactionOrNull(transactionSelector);
       metadata = metadata.toBuilder().setTransaction(transaction).build();
@@ -1234,12 +1237,11 @@ public class MockSpannerServiceImpl extends SpannerImplBase implements MockGrpcS
             ResultSet.newBuilder()
                 .setStats(ResultSetStats.newBuilder().setRowCountExact(updateCount).build())
                 .setMetadata(
-                    ResultSetMetadata.newBuilder()
-                        .setTransaction(
-                            ignoreInlineBeginRequest.get()
-                                ? Transaction.getDefaultInstance()
-                                : Transaction.newBuilder().setId(transactionId).build())
-                        .build())
+                    shouldOmitInlineBeginTransaction(request.getTransaction())
+                        ? ResultSetMetadata.getDefaultInstance()
+                        : ResultSetMetadata.newBuilder()
+                            .setTransaction(Transaction.newBuilder().setId(transactionId).build())
+                            .build())
                 .build());
       }
       builder.setStatus(status);


### PR DESCRIPTION
Sync executeUpdate/executeBatchUpdate and async batchUpdateAsync left transactionIdFuture unresolved when a begin-requesting DML response carried no transaction metadata, so commit blocked on the 60s wait and surfaced DEADLINE_EXCEEDED. Mirror executeUpdateAsync: raise FAILED_PRECONDITION via onError so the future resolves and the transaction retries or propagates. Use getId().isEmpty() consistently and add regression coverage via a mock omit-transaction hook.