### PR TITLE
chore(bigquery-jdbc): update integration tests to handle different cancellation

### DIFF
--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -233,8 +233,10 @@ public class ITNightlyBigQueryTest {
             });
     t.start();
     // Allow thread to actually initiate the query
-    // Even when job is created, we might be using `query` API which means if we cancle within first 10 seconds,
-    // it is similar to Optional job cancellation. Need to wait until after we're in "Wait for job completion" mode.
+    // Even when job is created, we might be using `query` API which means if we cancle within first
+    // 10 seconds,
+    // it is similar to Optional job cancellation. Need to wait until after we're in "Wait for job
+    // completion" mode.
     Thread.sleep(15000);
     bigQueryStatement.cancel();
     // Wait until background thread is finished

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -227,7 +227,6 @@ public class ITNightlyBigQueryTest {
               SQLException e =
                   assertThrows(
                       SQLException.class, () -> bigQueryStatement.execute(query300Seconds));
-              System.out.println(e.getMessage());
               assertTrue(e.getMessage().contains("User requested cancellation"));
               threadException.set(false);
             });

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -227,12 +227,15 @@ public class ITNightlyBigQueryTest {
               SQLException e =
                   assertThrows(
                       SQLException.class, () -> bigQueryStatement.execute(query300Seconds));
+              System.out.println(e.getMessage());
               assertTrue(e.getMessage().contains("User requested cancellation"));
               threadException.set(false);
             });
     t.start();
     // Allow thread to actually initiate the query
-    Thread.sleep(3000);
+    // Even when job is created, we might be using `query` API which means if we cancle within first 10 seconds,
+    // it is similar to Optional job cancellation. Need to wait until after we're in "Wait for job completion" mode.
+    Thread.sleep(15000);
     bigQueryStatement.cancel();
     // Wait until background thread is finished
     t.join();

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -331,13 +331,9 @@ public class ITStatementTest {
     assertEquals(0, statement.getQueryTimeout());
     statement.setQueryTimeout(1);
     assertEquals(1, statement.getQueryTimeout());
-    try {
-      statement.executeQuery(selectQuery);
-    } catch (SQLException e) {
-      assertEquals(
-          "BigQueryException during runQuery\nJob execution was cancelled: Job timed out",
-          e.getMessage());
-    }
+    SQLException e =
+        assertThrows(SQLException.class, () -> statement.executeQuery(selectQuery));
+    assertEquals("BigQueryException during runQuery\nJob execution was cancelled: Job timed out", e.getMessage());
     statement.close();
     connection.close();
   }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -334,7 +334,9 @@ public class ITStatementTest {
     try {
       statement.executeQuery(selectQuery);
     } catch (SQLException e) {
-      assertEquals("BigQueryException during runQuery\nJob execution was cancelled: Job timed out", e.getMessage());
+      assertEquals(
+          "BigQueryException during runQuery\nJob execution was cancelled: Job timed out",
+          e.getMessage());
     }
     statement.close();
     connection.close();

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -334,8 +334,7 @@ public class ITStatementTest {
     try {
       statement.executeQuery(selectQuery);
     } catch (SQLException e) {
-      assertTrue(true);
-      assertEquals("SQL execution canceled", e.getMessage());
+      assertEquals("BigQueryException during runQuery\nJob execution was cancelled: Job timed out", e.getMessage());
     }
     statement.close();
     connection.close();

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -331,9 +331,10 @@ public class ITStatementTest {
     assertEquals(0, statement.getQueryTimeout());
     statement.setQueryTimeout(1);
     assertEquals(1, statement.getQueryTimeout());
-    SQLException e =
-        assertThrows(SQLException.class, () -> statement.executeQuery(selectQuery));
-    assertEquals("BigQueryException during runQuery\nJob execution was cancelled: Job timed out", e.getMessage());
+    SQLException e = assertThrows(SQLException.class, () -> statement.executeQuery(selectQuery));
+    assertEquals(
+        "BigQueryException during runQuery\nJob execution was cancelled: Job timed out",
+        e.getMessage());
     statement.close();
     connection.close();
   }


### PR DESCRIPTION
Due to https://github.com/googleapis/google-cloud-java/commit/64cde7f23a2a0186664bc459e5e91d773ebb0b29 now `jobs.query` API is used even if we request job creation (Previously it falls back to `jobs.insert`). Due to this, updating integration test with new error/timeout values.