### PR TITLE
chore(bigquery-jdbc): fix flaky testSetTimeout test

### DIFF
--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
@@ -34,7 +34,7 @@ import java.util.List;
 public class ITBase extends BigQueryJdbcBaseTest {
 
   // This query takes 300 seconds to complete
-  protected final String query300seconds =
+  public static final String query300seconds =
       "DECLARE DELAY_TIME DATETIME; SET DELAY_TIME = DATETIME_ADD(CURRENT_DATETIME, INTERVAL 300"
           + " SECOND); WHILE CURRENT_DATETIME < DELAY_TIME DO  END WHILE;";
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
@@ -33,6 +33,11 @@ import java.util.List;
 
 public class ITBase extends BigQueryJdbcBaseTest {
 
+  // This query takes 300 seconds to complete
+  protected final String query300seconds =
+      "DECLARE DELAY_TIME DATETIME; SET DELAY_TIME = DATETIME_ADD(CURRENT_DATETIME, INTERVAL 300"
+          + " SECOND); WHILE CURRENT_DATETIME < DELAY_TIME DO  END WHILE;";
+
   private static String sharedDataset;
   private static String sharedDataset2;
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -1674,12 +1674,4 @@ public class ITNightlyBigQueryTest extends ITBase {
     Job stubJob = bigQuery.getJob(job.getJobId());
     return stubJob.getStatistics().getSessionInfo().getSessionId();
   }
-
-  private int resultSetRowCount(ResultSet resultSet) throws SQLException {
-    int rowCount = 0;
-    while (resultSet.next()) {
-      rowCount++;
-    }
-    return rowCount;
-  }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class ITNightlyBigQueryTest {
+public class ITNightlyBigQueryTest extends ITBase {
   static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
   static Connection bigQueryConnection;
   static Statement bigQueryStatement;
@@ -215,18 +215,13 @@ public class ITNightlyBigQueryTest {
         DriverManager.getConnection(connection_uri + ";JobCreationMode=1", new Properties());
     Statement bigQueryStatement = bigQueryConnection.createStatement();
 
-    // This query takes 300 seconds to complete
-    String query300Seconds =
-        "DECLARE DELAY_TIME DATETIME; SET DELAY_TIME = DATETIME_ADD(CURRENT_DATETIME, INTERVAL 300"
-            + " SECOND); WHILE CURRENT_DATETIME < DELAY_TIME DO  END WHILE;";
-
     // Query will be started in the background thread & we will call cancel from current thread.
     Thread t =
         new Thread(
             () -> {
               SQLException e =
                   assertThrows(
-                      SQLException.class, () -> bigQueryStatement.execute(query300Seconds));
+                      SQLException.class, () -> bigQueryStatement.execute(query300seconds));
               assertTrue(e.getMessage().contains("User requested cancellation"));
               threadException.set(false);
             });
@@ -254,18 +249,13 @@ public class ITNightlyBigQueryTest {
         DriverManager.getConnection(connection_uri + ";JobCreationMode=2", new Properties());
     Statement bigQueryStatement = bigQueryConnection.createStatement();
 
-    // This query takes 300 seconds to complete
-    String query300Seconds =
-        "DECLARE DELAY_TIME DATETIME; SET DELAY_TIME = DATETIME_ADD(CURRENT_DATETIME, INTERVAL 300"
-            + " SECOND); WHILE CURRENT_DATETIME < DELAY_TIME DO  END WHILE;";
-
     // Query will be started in the background thread & we will call cancel from current thread.
     Thread t =
         new Thread(
             () -> {
               SQLException e =
                   assertThrows(
-                      SQLException.class, () -> bigQueryStatement.execute(query300Seconds));
+                      SQLException.class, () -> bigQueryStatement.execute(query300seconds));
               assertTrue(e.getMessage().contains("Query was cancelled."));
               threadException.set(false);
             });

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -221,7 +221,7 @@ public class ITNightlyBigQueryTest extends ITBase {
             () -> {
               SQLException e =
                   assertThrows(
-                      SQLException.class, () -> bigQueryStatement.execute(query300seconds));
+                      SQLException.class, () -> bigQueryStatement.execute(ITBase.query300seconds));
               assertTrue(e.getMessage().contains("User requested cancellation"));
               threadException.set(false);
             });
@@ -255,7 +255,7 @@ public class ITNightlyBigQueryTest extends ITBase {
             () -> {
               SQLException e =
                   assertThrows(
-                      SQLException.class, () -> bigQueryStatement.execute(query300seconds));
+                      SQLException.class, () -> bigQueryStatement.execute(ITBase.query300seconds));
               assertTrue(e.getMessage().contains("Query was cancelled."));
               threadException.set(false);
             });

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.bigquery.jdbc.it;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -321,9 +322,7 @@ public class ITStatementTest extends ITBase {
     assertEquals(1, statement.getQueryTimeout());
     SQLException e =
         assertThrows(SQLException.class, () -> statement.executeQuery(ITBase.query300seconds));
-    assertEquals(
-        "BigQueryException during runQuery\nJob execution was cancelled: Job timed out",
-        e.getMessage());
+    assertThat(e.getMessage()).contains("Job execution was cancelled: Job timed out");
     statement.close();
     connection.close();
   }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -122,7 +122,7 @@ public class ITStatementTest extends ITBase {
     // setMaxRows Test
     statement.setMaxRows(5);
     ResultSet maxRowsResultSet = statement.executeQuery(selectQuery);
-    assertEquals(5, getSizeOfResultSet(maxRowsResultSet));
+    assertEquals(5, resultSetRowCount(maxRowsResultSet));
 
     try {
       statement.setMaxRows(0);

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -244,14 +244,6 @@ public class ITStatementTest extends ITBase {
     connection.close();
   }
 
-  private int resultSetRowCount(ResultSet resultSet) throws SQLException {
-    int rowCount = 0;
-    while (resultSet.next()) {
-      rowCount++;
-    }
-    return rowCount;
-  }
-
   @Test
   public void testStringColumnLength() throws SQLException {
     String TABLE_NAME = "StringColumnLengthTable";

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class ITStatementTest {
+public class ITStatementTest extends ITBase {
   private static final String DEFAULT_CATALOG = ServiceOptions.getDefaultProjectId();
   private static String DATASET;
   private static Random random = new Random();
@@ -323,15 +323,12 @@ public class ITStatementTest {
     Connection connection = DriverManager.getConnection(ITBase.connectionUrl);
     Statement statement = connection.createStatement();
 
-    String selectQuery =
-        "SELECT views FROM bigquery-public-data.wikipedia.pageviews_2020 WHERE datehour >="
-            + " '2020-01-01' LIMIT 9000000";
-
     // statement.execute(selectQuery);
     assertEquals(0, statement.getQueryTimeout());
     statement.setQueryTimeout(1);
     assertEquals(1, statement.getQueryTimeout());
-    SQLException e = assertThrows(SQLException.class, () -> statement.executeQuery(selectQuery));
+    SQLException e =
+        assertThrows(SQLException.class, () -> statement.executeQuery(query300seconds));
     assertEquals(
         "BigQueryException during runQuery\nJob execution was cancelled: Job timed out",
         e.getMessage());
@@ -386,14 +383,6 @@ public class ITStatementTest {
       statement.close();
     }
     connection.close();
-  }
-
-  int getSizeOfResultSet(ResultSet resultSet) throws SQLException {
-    int count = 0;
-    while (resultSet.next()) {
-      count++;
-    }
-    return count;
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITStatementTest.java
@@ -328,7 +328,7 @@ public class ITStatementTest extends ITBase {
     statement.setQueryTimeout(1);
     assertEquals(1, statement.getQueryTimeout());
     SQLException e =
-        assertThrows(SQLException.class, () -> statement.executeQuery(query300seconds));
+        assertThrows(SQLException.class, () -> statement.executeQuery(ITBase.query300seconds));
     assertEquals(
         "BigQueryException during runQuery\nJob execution was cancelled: Job timed out",
         e.getMessage());


### PR DESCRIPTION
Seems like BQ can cache results of existing query, so timeout is not reliable. This query is guaranteed to run for 300 seconds, so it will ensure job is killed by timeout.