### PR TITLE
test(gax): fix flakiness in BatcherImplTest.testElementsNotLeaking

### DIFF
--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
@@ -516,7 +516,6 @@ class BatcherImplTest {
 
   /** Validates that the elements are not leaking to multiple batches */
   @Test
-  @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
   void testElementsNotLeaking() throws Exception {
     ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
     ScheduledExecutorService multiThreadExecutor = Executors.newScheduledThreadPool(20);
@@ -567,6 +566,7 @@ class BatcherImplTest {
       }
 
       // Closing the resources
+      await().atMost(Duration.ofSeconds(10)).until(future::isDone);
       future.get();
       assertThat(isDuplicateElement.get()).isFalse();
       singleThreadExecutor.shutdown();

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/batching/BatcherImplTest.java
@@ -566,8 +566,7 @@ class BatcherImplTest {
       }
 
       // Closing the resources
-      await().atMost(Duration.ofSeconds(10)).until(future::isDone);
-      future.get();
+      future.get(10, TimeUnit.SECONDS);
       assertThat(isDuplicateElement.get()).isFalse();
       singleThreadExecutor.shutdown();
       multiThreadExecutor.shutdown();


### PR DESCRIPTION
Increase the timeout and use Awaitility to wait for the background task to complete. This avoids timing out on slower machines (like macOS Intel).

Fixes https://github.com/googleapis/google-cloud-java/issues/13565