### PR TITLE
fix(release): check remote tags using git ls-remote to prevent already exists error

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -20,8 +20,6 @@ jobs:
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
-    - name: Fetch all tags
-      run: git fetch --tags
     - name: Create additional tags
       shell: bash
       run: |
@@ -29,8 +27,8 @@ jobs:
         for ARTIFACT_ID in "${ARTIFACT_IDS[@]}"; do
           VERSION=$(grep "^${ARTIFACT_ID}:" versions.txt | cut -d':' -f2 | tr -d '[:space:]')
           TAG_NAME="${ARTIFACT_ID}/v$VERSION"
-          if git show-ref --tags | grep -q "refs/tags/$TAG_NAME"; then
-            echo "Tag $TAG_NAME already exists. Skipping."
+          if git ls-remote --tags origin | grep -q "refs/tags/$TAG_NAME"; then
+            echo "Tag $TAG_NAME already exists on remote. Skipping."
             continue
           fi
           git tag $TAG_NAME


### PR DESCRIPTION
Fixes tag creation failure during partial releases when the tag already exists on remote.

Tested on forked repo, see b/514712247#comment3