### PR TITLE
refactor(auth): use @InternalApi annotation instead of comments

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/DefaultMtlsProviderFactory.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/DefaultMtlsProviderFactory.java
@@ -30,8 +30,10 @@
 
 package com.google.auth.mtls;
 
+import com.google.api.core.InternalApi;
 import java.io.IOException;
 
+@InternalApi
 public class DefaultMtlsProviderFactory {
 
   /**
@@ -39,9 +41,6 @@ public class DefaultMtlsProviderFactory {
    * com.google.auth.mtls.X509Provider}. If the certificate source is unavailable, it falls back to
    * creating a {@link SecureConnectProvider}. If the secure connect provider also fails, it throws
    * a {@link com.google.auth.mtls.CertificateSourceUnavailableException}.
-   *
-   * <p>This is only meant to be used internally by Google Cloud libraries, and the public facing
-   * methods may be changed without notice, and have no guarantee of backwards compatibility.
    *
    * @return an instance of {@link MtlsProvider}.
    * @throws com.google.auth.mtls.CertificateSourceUnavailableException if neither provider can be

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/SecureConnectProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/SecureConnectProvider.java
@@ -33,6 +33,7 @@ package com.google.auth.mtls;
 import com.google.api.client.json.JsonParser;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.util.SecurityUtils;
+import com.google.api.core.InternalApi;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.FileInputStream;
@@ -46,9 +47,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * This class implements {@link MtlsProvider} for the Google Auth library transport layer via {@link
- * ContextAwareMetadataJson}. This is only meant to be used internally by Google Cloud libraries,
- * and the public facing methods may be changed without notice, and have no guarantee of backwards
- * compatibility.
+ * ContextAwareMetadataJson}.
  *
  * <p>Note: This implementation is derived from the existing "MtlsProvider" found in the Gax
  * library, with two notable differences: 1) All logic associated with parsing environment variables
@@ -60,6 +59,7 @@ import java.util.concurrent.TimeUnit;
  * <p>Additionally, this implementation will replace the existing "MtlsProvider" in the Gax library.
  * The Gax library version of MtlsProvider will be marked as deprecated.
  */
+@InternalApi
 public class SecureConnectProvider implements MtlsProvider {
   interface ProcessProvider {
     public Process createProcess(InputStream metadata) throws IOException;

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/X509Provider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/X509Provider.java
@@ -45,9 +45,7 @@ import java.security.KeyStore;
 
 /**
  * This class implements {@link MtlsProvider} for the Google Auth library transport layer via {@link
- * WorkloadCertificateConfiguration}. This is only meant to be used internally by Google Cloud
- * libraries, and the public facing methods may be changed without notice, and have no guarantee of
- * backwards compatibility.
+ * WorkloadCertificateConfiguration}.
  */
 @InternalApi
 public class X509Provider implements MtlsProvider {

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -69,15 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Internal utilities for the com.google.auth.oauth2 namespace.
- *
- * <p>These classes are marked public but should be treated effectively as internal classes only.
- * They are not subject to any backwards compatibility guarantees and might change or be removed at
- * any time. They are provided only as a convenience for other libraries within the {@code
- * com.google.auth} family. Application developers should avoid using these classes directly; they
- * are not part of the public API.
- */
+/** Internal utilities for the com.google.auth.oauth2 namespace. */
 @InternalApi
 public class OAuth2Utils {
 


### PR DESCRIPTION
Use the Java SDK `@InternalApi` instead of comments nested in the javadocs. This follows the convention throughout the Java SDK to denote classes that users should not use.