### PR TITLE
fix(bigquery-jdbc): ensure test uses unique dataset & cleans up

### DIFF
--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
@@ -120,6 +120,10 @@ public class ITBase extends BigQueryJdbcBaseTest {
           + DDL_IT_CALLABLE_STMT_PROC_DML_DELETE_TEST
           + DDL_IT_CALLABLE_STMT_PROC_TEST;
 
+  public static String getUniqueDatasetName(String prefix) {
+    return prefix + +System.currentTimeMillis() + "_" + (100 + new java.util.Random().nextInt(900));
+  }
+
   public static synchronized String getSharedDataset() {
     if (sharedDataset == null) {
       sharedDataset =

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBase.java
@@ -121,7 +121,7 @@ public class ITBase extends BigQueryJdbcBaseTest {
           + DDL_IT_CALLABLE_STMT_PROC_TEST;
 
   public static String getUniqueDatasetName(String prefix) {
-    return prefix + +System.currentTimeMillis() + "_" + (100 + new java.util.Random().nextInt(900));
+    return prefix + System.currentTimeMillis() + "_" + (100 + new java.util.Random().nextInt(900));
   }
 
   public static synchronized String getSharedDataset() {

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
@@ -1768,7 +1768,7 @@ public class ITBigQueryJDBCTest extends ITBase {
       assertTrue(result);
     } finally {
       // clean up
-      bigQueryStatement.execute(String.format("DROP SCHEMA %s CASCADE;", largeResultDataset));
+      bigQueryStatement.execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE;", largeResultDataset));
     }
   }
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
@@ -1743,30 +1743,33 @@ public class ITBigQueryJDBCTest extends ITBase {
   public void testDestinationTableAndDestinationDatasetThatDoesNotExistsCreates()
       throws SQLException {
     // setup
+    String largeResultDataset = ITBase.getUniqueDatasetName("FakeDataset");
     String connection_uri =
-        ITBigQueryJDBCTest.connection_uri
-            + "QueryDialect=BIG_QUERY;"
-            + "AllowLargeResults=1;"
-            + "LargeResultTable=FakeTable;"
-            + "LargeResultDataset=FakeDataset;";
+        String.format(
+            ITBigQueryJDBCTest.connection_uri
+                + "QueryDialect=BIG_QUERY;"
+                + "AllowLargeResults=1;"
+                + "LargeResultTable=FakeTable;"
+                + "LargeResultDataset=%s;",
+            largeResultDataset);
     String selectLegacyQuery =
         "SELECT * FROM [bigquery-public-data.deepmind_alphafold.metadata] LIMIT 200;";
     Driver driver = BigQueryDriver.getRegisteredDriver();
-    Connection connection = driver.connect(connection_uri, new Properties());
-    Statement statement = connection.createStatement();
+    try (Connection connection = driver.connect(connection_uri, new Properties())) {
+      Statement statement = connection.createStatement();
 
-    // act
-    ResultSet resultSet = statement.executeQuery(selectLegacyQuery);
+      // act
+      ResultSet resultSet = statement.executeQuery(selectLegacyQuery);
 
-    // assertion
-    assertNotNull(resultSet);
-    String separateQuery = "SELECT * FROM FakeDataset.FakeTable;";
-    boolean result = bigQueryStatement.execute(separateQuery);
-    assertTrue(result);
-
-    // clean up
-    bigQueryStatement.execute("DROP SCHEMA FakeDataset CASCADE;");
-    connection.close();
+      // assertion
+      assertNotNull(resultSet);
+      String separateQuery = String.format("SELECT * FROM %s.FakeTable;", largeResultDataset);
+      boolean result = bigQueryStatement.execute(separateQuery);
+      assertTrue(result);
+    } finally {
+      // clean up
+      bigQueryStatement.execute(String.format("DROP SCHEMA %s CASCADE;", largeResultDataset));
+    }
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
@@ -1768,7 +1768,8 @@ public class ITBigQueryJDBCTest extends ITBase {
       assertTrue(result);
     } finally {
       // clean up
-      bigQueryStatement.execute(String.format("DROP SCHEMA IF EXISTS %s CASCADE;", largeResultDataset));
+      bigQueryStatement.execute(
+          String.format("DROP SCHEMA IF EXISTS %s CASCADE;", largeResultDataset));
     }
   }
 


### PR DESCRIPTION
testDestinationTableAndDestinationDatasetThatDoesNotExistsCreates was always using the same dataset. The moment this dataset was created in EU & likely failed to cleanup broke the test.