### PR TITLE
build(pom): remove overridden URLs pointing to archived repos

### DIFF
--- a/java-bigtable/google-cloud-bigtable-emulator-core/pom.xml
+++ b/java-bigtable/google-cloud-bigtable-emulator-core/pom.xml
@@ -18,13 +18,6 @@
     A Java wrapper for the Cloud Bigtable emulator.
   </description>
 
-  <url>https://github.com/googleapis/java-bigtable</url>
-  <scm>
-    <connection>scm:git:git@github.com:googleapis/java-bigtable.git</connection>
-    <developerConnection>scm:git:git@github.com:googleapis/java-bigtable.git</developerConnection>
-    <url>https://github.com/googleapis/java-bigtable</url>
-    <tag>HEAD</tag>
-  </scm>
   <developers>
     <developer>
       <id>igorberstein</id>

--- a/java-bigtable/google-cloud-bigtable-emulator/pom.xml
+++ b/java-bigtable/google-cloud-bigtable-emulator/pom.xml
@@ -7,7 +7,6 @@
   <artifactId>google-cloud-bigtable-emulator</artifactId>
   <version>0.217.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable-emulator:current} -->
   <name>Google Cloud Java - Bigtable Emulator</name>
-  <url>https://github.com/googleapis/java-bigtable</url>
   <description>
     A Java wrapper for the Cloud Bigtable emulator.
   </description>
@@ -16,12 +15,6 @@
     <artifactId>google-cloud-bigtable-parent</artifactId>
     <version>2.80.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   </parent>
-  <scm>
-    <connection>scm:git:git@github.com:googleapis/java-bigtable.git</connection>
-    <developerConnection>scm:git:git@github.com:googleapis/java-bigtable.git</developerConnection>
-    <url>https://github.com/googleapis/java-bigtable</url>
-    <tag>HEAD</tag>
-  </scm>
 
   <developers>
     <developer>

--- a/java-bigtable/google-cloud-bigtable/pom.xml
+++ b/java-bigtable/google-cloud-bigtable/pom.xml
@@ -5,7 +5,6 @@
   <version>2.80.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Bigtable</name>
-  <url>https://github.com/googleapis/java-bigtable</url>
   <description>
     Java idiomatic client for Google Cloud Bigtable.
   </description>

--- a/java-bigtable/test-proxy/pom.xml
+++ b/java-bigtable/test-proxy/pom.xml
@@ -6,7 +6,6 @@
   <version>0.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Google Cloud Bigtable Test Proxy</name>
-  <url>https://github.com/googleapis/java-bigtable</url>
   <description>Cloud Bigtable Java Client test proxy for running conformance tests.</description>
 
   <parent>

--- a/java-firestore/google-cloud-firestore-admin/pom.xml
+++ b/java-firestore/google-cloud-firestore-admin/pom.xml
@@ -7,7 +7,6 @@
   <version>3.44.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore-admin:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Firestore Admin Client</name>
-  <url>https://github.com/googleapis/java-firestore</url>
   <description>
     Java idiomatic client for Google Cloud Firestore Admin API.
   </description>

--- a/java-firestore/google-cloud-firestore/pom.xml
+++ b/java-firestore/google-cloud-firestore/pom.xml
@@ -5,7 +5,6 @@
   <version>3.44.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Firestore</name>
-  <url>https://github.com/googleapis/java-firestore</url>
   <description>
     Java idiomatic client for Google Cloud Firestore.
   </description>

--- a/java-logging/google-cloud-logging/pom.xml
+++ b/java-logging/google-cloud-logging/pom.xml
@@ -6,7 +6,6 @@
   <version>3.35.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Logging</name>
-  <url>https://github.com/googleapis/java-logging</url>
   <description>Java idiomatic client for Cloud Logging</description>
   <parent>
     <groupId>com.google.cloud</groupId>

--- a/java-pubsub/google-cloud-pubsub/pom.xml
+++ b/java-pubsub/google-cloud-pubsub/pom.xml
@@ -6,7 +6,6 @@
   <version>1.152.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsub:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Pub/Sub</name>
-  <url>https://github.com/googleapis/java-pubsub</url>
   <description>Java idiomatic client for Google Cloud Pub/Sub</description>
   <parent>
     <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-java/issues/13551

Remove overridden <url> and <scm> tags in child POMs to inherit the correct monorepo root URL from parents. This should inherit the values from the root modules and point to the monorepo