### PR TITLE
ci: use cloud-java-bot for manual runs in librarian check

### DIFF
--- a/.github/workflows/librarian_generation_check.yaml
+++ b/.github/workflows/librarian_generation_check.yaml
@@ -96,13 +96,16 @@ jobs:
         fi
     - name: Commit and push changes (manual run only)
       if: ${{ github.event_name == 'workflow_dispatch' }}
+      env:
+        GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       run: |
         if [ -n "$(git status --porcelain)" ]; then
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          [ -z "$(git config user.email)" ] && git config --global user.email "cloud-java-bot@google.com"
+          [ -z "$(git config user.name)" ] && git config --global user.name "cloud-java-bot"
           git add -A
           git commit -m "chore: regenerate libraries"
-          git push
+          git remote set-url origin https://cloud-java-bot:${GH_TOKEN}@github.com/${{ github.repository }}.git
+          git push origin HEAD:${{ github.ref }}
         else
           echo "No changes to commit"
         fi


### PR DESCRIPTION
Updates the `librarian_generation_check.yaml` workflow to use `cloud-java-bot` credentials and the `CLOUD_JAVA_BOT_GITHUB_TOKEN` secret when committing and pushing changes.

This should resolve Google CLA check failures that occur when the workflow is run manually, which previously used the default `github-actions[bot]` identity.

Fixes https://github.com/googleapis/librarian/issues/6568