### PR TITLE
fix(spanner): remove explicit tink version to resolve dependency convergence conflict

### DIFF
--- a/java-spanner/google-cloud-spanner/pom.xml
+++ b/java-spanner/google-cloud-spanner/pom.xml
@@ -539,7 +539,6 @@
     <dependency>
       <groupId>com.google.crypto.tink</groupId>
       <artifactId>tink</artifactId>
-      <version>1.13.0</version>
     </dependency>
   </dependencies>
   <profiles>


### PR DESCRIPTION
This PR removes the explicit Tink version declaration inside `java-spanner/google-cloud-spanner/pom.xml` to allow it to use the managed version from `third-party-dependencies/pom.xml`. This resolves the dependency convergence check failures in the CI.