### PR TITLE
docs: fix broken links in README.md files for handwritten libraries

### DIFF
--- a/java-admanager/.repo-metadata.json
+++ b/java-admanager/.repo-metadata.json
@@ -9,7 +9,7 @@
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-admanager",
-  "distribution_name": "com.google.api-ads:ad-manager",
+  "distribution_name": "com.google.api-ad:ad-manager",
   "api_id": "admanager.googleapis.com",
   "library_type": "GAPIC_AUTO",
   "requires_billing": true

--- a/java-admanager/README.md
+++ b/java-admanager/README.md
@@ -20,7 +20,7 @@ If you are using Maven, add this to your pom.xml file:
 
 ```xml
 <dependency>
-  <groupId>com.google.api-ads</groupId>
+  <groupId>com.google.api-ad</groupId>
   <artifactId>ad-manager</artifactId>
   <version>0.53.0</version>
 </dependency>
@@ -29,13 +29,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.api-ads:ad-manager:0.53.0'
+implementation 'com.google.api-ad:ad-manager:0.53.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.api-ads" % "ad-manager" % "0.53.0"
+libraryDependencies += "com.google.api-ad" % "ad-manager" % "0.53.0"
 ```
 
 ## Authentication
@@ -157,8 +157,8 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [product-docs]: https://developers.google.com/ad-manager/api/beta
 [javadocs]: https://cloud.google.com/java/docs/reference/ad-manager/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-preview-yellow
-[maven-version-image]: https://img.shields.io/maven-central/v/com.google.api-ads/ad-manager.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.api-ads/ad-manager/0.53.0
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.api-ad/ad-manager.svg
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.api-ad/ad-manager/0.53.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AdBreakServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AdBreakServiceStubSettings.java
@@ -294,7 +294,7 @@ public class AdBreakServiceStubSettings extends StubSettings<AdBreakServiceStubS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AdReviewCenterAdServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AdReviewCenterAdServiceStubSettings.java
@@ -374,7 +374,7 @@ public class AdReviewCenterAdServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AdUnitServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AdUnitServiceStubSettings.java
@@ -408,7 +408,7 @@ public class AdUnitServiceStubSettings extends StubSettings<AdUnitServiceStubSet
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ApplicationServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ApplicationServiceStubSettings.java
@@ -339,7 +339,7 @@ public class ApplicationServiceStubSettings extends StubSettings<ApplicationServ
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AudienceSegmentServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/AudienceSegmentServiceStubSettings.java
@@ -290,7 +290,7 @@ public class AudienceSegmentServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/BandwidthGroupServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/BandwidthGroupServiceStubSettings.java
@@ -281,7 +281,7 @@ public class BandwidthGroupServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/BrowserLanguageServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/BrowserLanguageServiceStubSettings.java
@@ -290,7 +290,7 @@ public class BrowserLanguageServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/BrowserServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/BrowserServiceStubSettings.java
@@ -269,7 +269,7 @@ public class BrowserServiceStubSettings extends StubSettings<BrowserServiceStubS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CmsMetadataKeyServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CmsMetadataKeyServiceStubSettings.java
@@ -309,7 +309,7 @@ public class CmsMetadataKeyServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CmsMetadataValueServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CmsMetadataValueServiceStubSettings.java
@@ -318,7 +318,7 @@ public class CmsMetadataValueServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CompanyServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CompanyServiceStubSettings.java
@@ -269,7 +269,7 @@ public class CompanyServiceStubSettings extends StubSettings<CompanyServiceStubS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContactServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContactServiceStubSettings.java
@@ -307,7 +307,7 @@ public class ContactServiceStubSettings extends StubSettings<ContactServiceStubS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContentBundleServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContentBundleServiceStubSettings.java
@@ -280,7 +280,7 @@ public class ContentBundleServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContentLabelServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContentLabelServiceStubSettings.java
@@ -279,7 +279,7 @@ public class ContentLabelServiceStubSettings extends StubSettings<ContentLabelSe
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContentServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ContentServiceStubSettings.java
@@ -268,7 +268,7 @@ public class ContentServiceStubSettings extends StubSettings<ContentServiceStubS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CreativeTemplateServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CreativeTemplateServiceStubSettings.java
@@ -290,7 +290,7 @@ public class CreativeTemplateServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CustomFieldServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CustomFieldServiceStubSettings.java
@@ -340,7 +340,7 @@ public class CustomFieldServiceStubSettings extends StubSettings<CustomFieldServ
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CustomTargetingKeyServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CustomTargetingKeyServiceStubSettings.java
@@ -373,7 +373,7 @@ public class CustomTargetingKeyServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CustomTargetingValueServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/CustomTargetingValueServiceStubSettings.java
@@ -300,7 +300,7 @@ public class CustomTargetingValueServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/DeviceCapabilityServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/DeviceCapabilityServiceStubSettings.java
@@ -295,7 +295,7 @@ public class DeviceCapabilityServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/DeviceCategoryServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/DeviceCategoryServiceStubSettings.java
@@ -287,7 +287,7 @@ public class DeviceCategoryServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/DeviceManufacturerServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/DeviceManufacturerServiceStubSettings.java
@@ -297,7 +297,7 @@ public class DeviceManufacturerServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/EntitySignalsMappingServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/EntitySignalsMappingServiceStubSettings.java
@@ -350,7 +350,7 @@ public class EntitySignalsMappingServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/GeoTargetServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/GeoTargetServiceStubSettings.java
@@ -271,7 +271,7 @@ public class GeoTargetServiceStubSettings extends StubSettings<GeoTargetServiceS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/LabelServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/LabelServiceStubSettings.java
@@ -328,7 +328,7 @@ public class LabelServiceStubSettings extends StubSettings<LabelServiceStubSetti
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/LineItemServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/LineItemServiceStubSettings.java
@@ -269,7 +269,7 @@ public class LineItemServiceStubSettings extends StubSettings<LineItemServiceStu
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/LinkedDeviceServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/LinkedDeviceServiceStubSettings.java
@@ -279,7 +279,7 @@ public class LinkedDeviceServiceStubSettings extends StubSettings<LinkedDeviceSe
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/McmEarningsServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/McmEarningsServiceStubSettings.java
@@ -269,7 +269,7 @@ public class McmEarningsServiceStubSettings extends StubSettings<McmEarningsServ
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/MobileCarrierServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/MobileCarrierServiceStubSettings.java
@@ -280,7 +280,7 @@ public class MobileCarrierServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/MobileDeviceServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/MobileDeviceServiceStubSettings.java
@@ -279,7 +279,7 @@ public class MobileDeviceServiceStubSettings extends StubSettings<MobileDeviceSe
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/MobileDeviceSubmodelServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/MobileDeviceSubmodelServiceStubSettings.java
@@ -300,7 +300,7 @@ public class MobileDeviceSubmodelServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/NetworkServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/NetworkServiceStubSettings.java
@@ -269,7 +269,7 @@ public class NetworkServiceStubSettings extends StubSettings<NetworkServiceStubS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/OperatingSystemServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/OperatingSystemServiceStubSettings.java
@@ -290,7 +290,7 @@ public class OperatingSystemServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/OperatingSystemVersionServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/OperatingSystemVersionServiceStubSettings.java
@@ -305,7 +305,7 @@ public class OperatingSystemVersionServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/OrderServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/OrderServiceStubSettings.java
@@ -269,7 +269,7 @@ public class OrderServiceStubSettings extends StubSettings<OrderServiceStubSetti
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/PlacementServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/PlacementServiceStubSettings.java
@@ -343,7 +343,7 @@ public class PlacementServiceStubSettings extends StubSettings<PlacementServiceS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/PrivateAuctionDealServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/PrivateAuctionDealServiceStubSettings.java
@@ -317,7 +317,7 @@ public class PrivateAuctionDealServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/PrivateAuctionServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/PrivateAuctionServiceStubSettings.java
@@ -301,7 +301,7 @@ public class PrivateAuctionServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ProgrammaticBuyerServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ProgrammaticBuyerServiceStubSettings.java
@@ -295,7 +295,7 @@ public class ProgrammaticBuyerServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ReportServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/ReportServiceStubSettings.java
@@ -419,7 +419,7 @@ public class ReportServiceStubSettings extends StubSettings<ReportServiceStubSet
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/RichMediaAdsCompanyServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/RichMediaAdsCompanyServiceStubSettings.java
@@ -300,7 +300,7 @@ public class RichMediaAdsCompanyServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/RoleServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/RoleServiceStubSettings.java
@@ -268,7 +268,7 @@ public class RoleServiceStubSettings extends StubSettings<RoleServiceStubSetting
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/SiteServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/SiteServiceStubSettings.java
@@ -330,7 +330,7 @@ public class SiteServiceStubSettings extends StubSettings<SiteServiceStubSetting
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/TaxonomyCategoryServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/TaxonomyCategoryServiceStubSettings.java
@@ -295,7 +295,7 @@ public class TaxonomyCategoryServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/TeamServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/TeamServiceStubSettings.java
@@ -328,7 +328,7 @@ public class TeamServiceStubSettings extends StubSettings<TeamServiceStubSetting
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/UserServiceStubSettings.java
+++ b/java-admanager/ad-manager/src/main/java/com/google/ads/admanager/v1/stub/UserServiceStubSettings.java
@@ -197,7 +197,7 @@ public class UserServiceStubSettings extends StubSettings<UserServiceStubSetting
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:ad-manager")
+        .setArtifactName("com.google.api-ad:ad-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-bigquery/.repo-metadata.json
+++ b/java-bigquery/.repo-metadata.json
@@ -2,7 +2,7 @@
   "api_shortname": "bigquery",
   "name_pretty": "Cloud BigQuery",
   "product_documentation": "https://cloud.google.com/bigquery",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquery/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquery/latest/overview",
   "api_description": "is a fully managed, NoOps, low cost data analytics service.\nData can be streamed into BigQuery at millions of rows per second to enable real-time analysis.\nWith BigQuery you can easily deploy Petabyte-scale Databases.",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559654",
   "release_level": "stable",

--- a/java-bigquery/README.md
+++ b/java-bigquery/README.md
@@ -330,7 +330,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/bigquery
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-bigquery/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-bigquery/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquery.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquery/2.42.2

--- a/java-bigquerystorage/.repo-metadata.json
+++ b/java-bigquerystorage/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "BigQuery Storage",
   "product_documentation": "https://cloud.google.com/bigquery/docs/reference/storage/",
   "api_description": "is an API for reading data stored in BigQuery. This API provides direct, high-throughput read access to existing BigQuery tables, supports parallel access with automatic liquid sharding, and allows fine-grained control over what data is returned.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/overview",
   "release_level": "stable",
   "transport": "grpc",
   "language": "java",

--- a/java-bigquerystorage/README.md
+++ b/java-bigquerystorage/README.md
@@ -239,7 +239,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/bigquery/docs/reference/storage/
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigquerystorage.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigquerystorage/3.30.0

--- a/java-bigtable/.repo-metadata.json
+++ b/java-bigtable/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud Bigtable",
   "product_documentation": "https://cloud.google.com/bigtable",
   "api_description": "API for reading and writing the contents of Bigtables associated with a cloud project.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/overview",
   "release_level": "stable",
   "transport": "grpc",
   "language": "java",
@@ -14,7 +14,6 @@
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
   "codeowner_team": "@googleapis/bigtable-team",
-  "excluded_poms": "google-cloud-bigtable-bom",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559777",
   "extra_versioned_modules": "google-cloud-bigtable-emulator,google-cloud-bigtable-emulator-core",
   "recommended_package": "com.google.cloud.bigtable"

--- a/java-bigtable/README.md
+++ b/java-bigtable/README.md
@@ -449,7 +449,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/bigtable
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-bigtable.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-bigtable/2.80.0

--- a/java-common-protos/.repo-metadata.json
+++ b/java-common-protos/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Common Protos",
   "product_documentation": "https://github.com/googleapis/api-common-protos",
   "api_description": "Protobuf classes for Google's common protos.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/proto-google-common-protos/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/proto-google-common-protos/latest/overview",
   "release_level": "stable",
   "transport": "grpc",
   "language": "java",
@@ -11,6 +11,5 @@
   "repo_short": "java-common-protos",
   "distribution_name": "com.google.api.grpc:proto-google-common-protos",
   "library_type": "OTHER",
-  "requires_billing": true,
-  "excluded_poms": "proto-google-common-protos-bom,proto-google-common-protos"
+  "requires_billing": true
 }

--- a/java-common-protos/README.md
+++ b/java-common-protos/README.md
@@ -158,7 +158,7 @@ Java 11 | [![Kokoro CI][kokoro-badge-image-5]][kokoro-badge-link-5]
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://github.com/googleapis/api-common-protos
-[javadocs]: https://cloud.google.com/java/docs/reference/proto-google-common-protos/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/proto-google-common-protos/latest/overview
 [kokoro-badge-image-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/sdk-platform-java/java7.svg
 [kokoro-badge-link-1]: http://storage.googleapis.com/cloud-devrel-public/java/badges/sdk-platform-java/java7.html
 [kokoro-badge-image-2]: http://storage.googleapis.com/cloud-devrel-public/java/badges/sdk-platform-java/java8.svg

--- a/java-compute/.repo-metadata.json
+++ b/java-compute/.repo-metadata.json
@@ -12,6 +12,5 @@
   "distribution_name": "com.google.cloud:google-cloud-compute",
   "api_id": "compute.googleapis.com",
   "library_type": "GAPIC_AUTO",
-  "requires_billing": true,
-  "excluded_poms": "grpc-google-cloud-compute-v1"
+  "requires_billing": true
 }

--- a/java-datamanager/.repo-metadata.json
+++ b/java-datamanager/.repo-metadata.json
@@ -9,7 +9,7 @@
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-datamanager",
-  "distribution_name": "com.google.api-ads:data-manager",
+  "distribution_name": "com.google.api-ad:data-manager",
   "api_id": "datamanager.googleapis.com",
   "library_type": "GAPIC_AUTO",
   "requires_billing": true,

--- a/java-datamanager/README.md
+++ b/java-datamanager/README.md
@@ -20,7 +20,7 @@ If you are using Maven, add this to your pom.xml file:
 
 ```xml
 <dependency>
-  <groupId>com.google.api-ads</groupId>
+  <groupId>com.google.api-ad</groupId>
   <artifactId>data-manager</artifactId>
   <version>0.15.0</version>
 </dependency>
@@ -29,13 +29,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.api-ads:data-manager:0.15.0'
+implementation 'com.google.api-ad:data-manager:0.15.0'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.api-ads" % "data-manager" % "0.15.0"
+libraryDependencies += "com.google.api-ad" % "data-manager" % "0.15.0"
 ```
 
 ## Authentication
@@ -157,8 +157,8 @@ Java is a registered trademark of Oracle and/or its affiliates.
 [product-docs]: https://developers.google.com/data-manager
 [javadocs]: https://cloud.google.com/java/docs/reference/data-manager/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-preview-yellow
-[maven-version-image]: https://img.shields.io/maven-central/v/com.google.api-ads/data-manager.svg
-[maven-version-link]: https://central.sonatype.com/artifact/com.google.api-ads/data-manager/0.15.0
+[maven-version-image]: https://img.shields.io/maven-central/v/com.google.api-ad/data-manager.svg
+[maven-version-link]: https://central.sonatype.com/artifact/com.google.api-ad/data-manager/0.15.0
 [authentication]: https://github.com/googleapis/google-cloud-java#authentication
 [auth-scopes]: https://developers.google.com/identity/protocols/oauth2/scopes
 [predefined-iam-roles]: https://cloud.google.com/iam/docs/understanding-roles#predefined_roles

--- a/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/IngestionServiceStubSettings.java
+++ b/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/IngestionServiceStubSettings.java
@@ -270,7 +270,7 @@ public class IngestionServiceStubSettings extends StubSettings<IngestionServiceS
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:data-manager")
+        .setArtifactName("com.google.api-ad:data-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/MarketingDataInsightsServiceStubSettings.java
+++ b/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/MarketingDataInsightsServiceStubSettings.java
@@ -233,7 +233,7 @@ public class MarketingDataInsightsServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:data-manager")
+        .setArtifactName("com.google.api-ad:data-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/PartnerLinkServiceStubSettings.java
+++ b/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/PartnerLinkServiceStubSettings.java
@@ -321,7 +321,7 @@ public class PartnerLinkServiceStubSettings extends StubSettings<PartnerLinkServ
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:data-manager")
+        .setArtifactName("com.google.api-ad:data-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/UserListDirectLicenseServiceStubSettings.java
+++ b/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/UserListDirectLicenseServiceStubSettings.java
@@ -357,7 +357,7 @@ public class UserListDirectLicenseServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:data-manager")
+        .setArtifactName("com.google.api-ad:data-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/UserListGlobalLicenseServiceStubSettings.java
+++ b/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/UserListGlobalLicenseServiceStubSettings.java
@@ -460,7 +460,7 @@ public class UserListGlobalLicenseServiceStubSettings
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:data-manager")
+        .setArtifactName("com.google.api-ad:data-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/UserListServiceStubSettings.java
+++ b/java-datamanager/data-manager/src/main/java/com/google/ads/datamanager/v1/stub/UserListServiceStubSettings.java
@@ -324,7 +324,7 @@ public class UserListServiceStubSettings extends StubSettings<UserListServiceStu
   @Override
   protected LibraryMetadata getLibraryMetadata() {
     return LibraryMetadata.newBuilder()
-        .setArtifactName("com.google.api-ads:data-manager")
+        .setArtifactName("com.google.api-ad:data-manager")
         .setRepository("googleapis/google-cloud-java")
         .setVersion(Version.VERSION)
         .build();

--- a/java-datastore/.repo-metadata.json
+++ b/java-datastore/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud Datastore",
   "product_documentation": "https://cloud.google.com/datastore",
   "api_description": "is a fully managed, schemaless database for\\nstoring non-relational data. Cloud Datastore automatically scales with\\nyour users and supports ACID transactions, high availability of reads and\\nwrites, strong consistency for reads and ancestor queries, and eventual\\nconsistency for all other queries.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/overview",
   "release_level": "stable",
   "transport": "grpc+rest",
   "language": "java",
@@ -13,7 +13,6 @@
   "api_id": "datastore.googleapis.com",
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
-  "excluded_poms": "grpc-google-cloud-datastore-v1",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559768",
   "extra_versioned_modules": "datastore-v1-proto-client",
   "recommended_package": "com.google.cloud.datastore"

--- a/java-datastore/README.md
+++ b/java-datastore/README.md
@@ -473,7 +473,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/datastore
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-datastore.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-datastore/3.2.0

--- a/java-firestore/.repo-metadata.json
+++ b/java-firestore/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud Firestore",
   "product_documentation": "https://cloud.google.com/firestore",
   "api_description": "is a fully-managed NoSQL document database for mobile, web, and server development from Firebase and Google Cloud Platform.  It's backed by a multi-region replicated database that ensures once data is committed, it's durable even in the face of unexpected disasters. Not only that, but despite being a distributed database, it's also strongly consistent and offers seamless integration with other Firebase and Google Cloud Platform products, including Google Cloud Functions.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-firestore/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-firestore/latest/overview",
   "release_level": "stable",
   "transport": "grpc",
   "language": "java",
@@ -14,7 +14,6 @@
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
   "codeowner_team": "@googleapis/firestore-team",
-  "excluded_poms": "google-cloud-firestore,google-cloud-firestore-bom",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/5337669",
   "recommended_package": "com.google.cloud.firestore",
   "library_path_overrides": {

--- a/java-firestore/README.md
+++ b/java-firestore/README.md
@@ -198,7 +198,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/firestore
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-firestore/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-firestore/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-firestore.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-firestore/3.44.0

--- a/java-iam-policy/.repo-metadata.json
+++ b/java-iam-policy/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud IAM Policy",
   "product_documentation": "n/a",
   "api_description": "n/a",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/overview",
   "release_level": "stable",
   "transport": "grpc+rest",
   "language": "java",
@@ -12,6 +12,5 @@
   "distribution_name": "com.google.cloud:google-iam-policy",
   "api_id": "iam.googleapis.com",
   "library_type": "GAPIC_AUTO",
-  "requires_billing": true,
-  "excluded_poms": "proto-google-iam-v1-bom,google-iam-policy,proto-google-iam-v1"
+  "requires_billing": true
 }

--- a/java-iam-policy/README.md
+++ b/java-iam-policy/README.md
@@ -172,7 +172,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: n/a
-[javadocs]: https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-iam-policy.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-iam-policy/1.91.0

--- a/java-iam/.repo-metadata.json
+++ b/java-iam/.repo-metadata.json
@@ -11,6 +11,5 @@
   "repo_short": "java-iam",
   "distribution_name": "com.google.api.grpc:proto-google-iam-v1",
   "library_type": "OTHER",
-  "requires_billing": true,
-  "excluded_poms": "proto-google-iam-v1-bom,google-iam-policy,proto-google-iam-v1"
+  "requires_billing": true
 }

--- a/java-logging-logback/.repo-metadata.json
+++ b/java-logging-logback/.repo-metadata.json
@@ -2,7 +2,7 @@
   "api_shortname": "logging-logback",
   "name_pretty": "Cloud Logging Logback Appender",
   "product_documentation": "https://cloud.google.com/logging/docs/setup/java#logback_appender_for",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-logging-logback/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-logging-logback/latest/overview",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559764",
   "release_level": "preview",
   "language": "java",

--- a/java-logging-logback/README.md
+++ b/java-logging-logback/README.md
@@ -311,7 +311,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/logging/docs/setup/java#logback_appender_for
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-logging-logback/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-logging-logback/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-preview-yellow
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging-logback.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging-logback/0.131.11-alpha

--- a/java-logging/.repo-metadata.json
+++ b/java-logging/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud Logging",
   "product_documentation": "https://cloud.google.com/logging/docs",
   "api_description": "allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud and Amazon Web Services. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premises systems, and hybrid cloud systems. BindPlane is included with your Google Cloud project at no additional cost.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-logging/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-logging/latest/overview",
   "release_level": "stable",
   "transport": "grpc",
   "language": "java",

--- a/java-logging/README.md
+++ b/java-logging/README.md
@@ -441,7 +441,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/logging/docs
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-logging/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-logging/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-logging.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-logging/3.35.0

--- a/java-pubsub/.repo-metadata.json
+++ b/java-pubsub/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud Pub/Sub",
   "product_documentation": "https://cloud.google.com/pubsub/docs/",
   "api_description": "is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a topic and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/overview",
   "release_level": "stable",
   "transport": "grpc+rest",
   "language": "java",

--- a/java-pubsub/README.md
+++ b/java-pubsub/README.md
@@ -398,7 +398,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/pubsub/docs/
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-pubsub.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-pubsub/1.152.0

--- a/java-showcase/.repo-metadata.json
+++ b/java-showcase/.repo-metadata.json
@@ -11,6 +11,5 @@
   "repo_short": "java-showcase",
   "distribution_name": "com.google.cloud:gapic-showcase",
   "library_type": "OTHER",
-  "requires_billing": true,
-  "excluded_poms": "gapic-showcase-bom"
+  "requires_billing": true
 }

--- a/java-spanner-jdbc/.repo-metadata.json
+++ b/java-spanner-jdbc/.repo-metadata.json
@@ -2,7 +2,7 @@
   "api_shortname": "spanner-jdbc",
   "name_pretty": "Google Cloud Spanner JDBC",
   "product_documentation": "https://cloud.google.com/spanner/docs/use-oss-jdbc",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-spanner-jdbc/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-spanner-jdbc/latest/overview",
   "release_level": "stable",
   "language": "java",
   "min_java_version": 8,

--- a/java-spanner/.repo-metadata.json
+++ b/java-spanner/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud Spanner",
   "product_documentation": "https://cloud.google.com/spanner/docs/",
   "api_description": "is a fully managed, mission-critical,  relational database service that offers transactional consistency at global scale, schemas, SQL (ANSI 2011 with extensions), and automatic, synchronous replication for high availability. Be sure to activate the Cloud Spanner API on the Developer's Console to use Cloud Spanner from your project.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-spanner/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-spanner/latest/overview",
   "release_level": "stable",
   "transport": "grpc",
   "language": "java",
@@ -14,7 +14,6 @@
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
   "codeowner_team": "@googleapis/spanner-team",
-  "excluded_poms": "google-cloud-spanner-bom,google-cloud-spanner",
   "issue_tracker": "https://issuetracker.google.com/issues?q=componentid:190851%2B%20status:open",
   "recommended_package": "com.google.cloud.spanner",
   "min_java_version": 8

--- a/java-spanner/README.md
+++ b/java-spanner/README.md
@@ -547,7 +547,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/spanner/docs/
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-spanner/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-spanner/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-spanner.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner/6.119.0

--- a/java-storage-nio/.repo-metadata.json
+++ b/java-storage-nio/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "NIO Filesystem Provider for Google Cloud Storage",
   "api_description": "provides a Google Cloud Storage extension for Java's NIO Filesystem.",
   "product_documentation": "https://cloud.google.com/storage/docs",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-nio/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-nio/latest/overview",
   "release_level": "preview",
   "language": "java",
   "repo": "googleapis/google-cloud-java",

--- a/java-storage/.repo-metadata.json
+++ b/java-storage/.repo-metadata.json
@@ -3,7 +3,7 @@
   "name_pretty": "Cloud Storage",
   "product_documentation": "https://cloud.google.com/storage",
   "api_description": "is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.",
-  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/history",
+  "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/overview",
   "release_level": "stable",
   "transport": "rest",
   "language": "java",
@@ -14,7 +14,6 @@
   "library_type": "GAPIC_COMBO",
   "requires_billing": true,
   "codeowner_team": "@googleapis/gcs-team",
-  "excluded_poms": "google-cloud-storage-bom,google-cloud-storage",
   "issue_tracker": "https://issuetracker.google.com/savedsearches/559782",
   "extra_versioned_modules": "gapic-google-cloud-storage-v2",
   "recommended_package": "com.google.cloud.storage"

--- a/java-storage/README.md
+++ b/java-storage/README.md
@@ -471,7 +471,7 @@ Apache 2.0 - See [LICENSE][license] for more information.
 Java is a registered trademark of Oracle and/or its affiliates.
 
 [product-docs]: https://cloud.google.com/storage
-[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/history
+[javadocs]: https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/overview
 [stability-image]: https://img.shields.io/badge/stability-stable-green
 [maven-version-image]: https://img.shields.io/maven-central/v/com.google.cloud/google-cloud-storage.svg
 [maven-version-link]: https://central.sonatype.com/artifact/com.google.cloud/google-cloud-storage/2.70.0

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -765,7 +765,7 @@ libraries:
     java:
       api_id_override: bigquerystorage.googleapis.com
       api_description_override: is an API for reading data stored in BigQuery. This API provides direct, high-throughput read access to existing BigQuery tables, supports parallel access with automatic liquid sharding, and allows fine-grained control over what data is returned.
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/overview
       codeowner_team: '@googleapis/bigquery-team'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559654
       released_version: 3.30.0
@@ -789,7 +789,7 @@ libraries:
     java:
       api_id_override: bigtable.googleapis.com
       api_description_override: API for reading and writing the contents of Bigtables associated with a cloud project.
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-bigtable/latest/overview
       codeowner_team: '@googleapis/bigtable-team'
       excluded_poms:
         - google-cloud-bigtable-bom
@@ -1110,7 +1110,7 @@ libraries:
       api_description_override: Protobuf classes for Google's common protos.
       api_shortname_override: common-protos
       artifact_id: proto-google-common-protos
-      client_documentation_override: https://cloud.google.com/java/docs/reference/proto-google-common-protos/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/proto-google-common-protos/latest/overview
       excluded_poms:
         - proto-google-common-protos-bom
         - proto-google-common-protos
@@ -1420,7 +1420,7 @@ libraries:
     java:
       api_id_override: datastore.googleapis.com
       api_description_override: is a fully managed, schemaless database for\nstoring non-relational data. Cloud Datastore automatically scales with\nyour users and supports ACID transactions, high availability of reads and\nwrites, strong consistency for reads and ancestor queries, and eventual\nconsistency for all other queries.
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/overview
       excluded_poms:
         - grpc-google-cloud-datastore-v1
       extra_versioned_modules: datastore-v1-proto-client
@@ -1790,7 +1790,7 @@ libraries:
     java:
       api_id_override: firestore.googleapis.com
       api_description_override: is a fully-managed NoSQL document database for mobile, web, and server development from Firebase and Google Cloud Platform.  It's backed by a multi-region replicated database that ensures once data is committed, it's durable even in the face of unexpected disasters. Not only that, but despite being a distributed database, it's also strongly consistent and offers seamless integration with other Firebase and Google Cloud Platform products, including Google Cloud Functions.
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-firestore/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-firestore/latest/overview
       codeowner_team: '@googleapis/firestore-team'
       excluded_poms:
         - google-cloud-firestore
@@ -2167,7 +2167,7 @@ libraries:
       api_description_override: n/a
       api_shortname_override: iam-policy
       artifact_id: google-iam-policy
-      client_documentation_override: https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/overview
       excluded_poms:
         - proto-google-iam-v1-bom
         - google-iam-policy
@@ -2355,7 +2355,7 @@ libraries:
     java:
       api_id_override: logging.googleapis.com
       api_description_override: allows you to store, search, analyze, monitor, and alert on log data and events from Google Cloud and Amazon Web Services. Using the BindPlane service, you can also collect this data from over 150 common application components, on-premises systems, and hybrid cloud systems. BindPlane is included with your Google Cloud project at no additional cost.
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-logging/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-logging/latest/overview
       codeowner_team: '@googleapis/cloud-sdk-java-team'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559764
       released_version: 3.35.0
@@ -3064,7 +3064,7 @@ libraries:
       api_id_override: pubsub.googleapis.com
       api_reference: https://cloud.google.com/pubsub/
       api_description_override: is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a topic and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/overview
       codeowner_team: '@googleapis/pubsub-team'
       issue_tracker_override: https://issuetracker.google.com/savedsearches/559741
       released_version: 1.152.0
@@ -3648,7 +3648,7 @@ libraries:
     java:
       api_id_override: spanner.googleapis.com
       api_description_override: is a fully managed, mission-critical,  relational database service that offers transactional consistency at global scale, schemas, SQL (ANSI 2011 with extensions), and automatic, synchronous replication for high availability. Be sure to activate the Cloud Spanner API on the Developer's Console to use Cloud Spanner from your project.
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-spanner/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-spanner/latest/overview
       codeowner_team: '@googleapis/spanner-team'
       excluded_poms:
         - google-cloud-spanner-bom
@@ -3721,7 +3721,7 @@ libraries:
     java:
       api_id_override: storage.googleapis.com
       api_description_override: 'is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.'
-      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/history
+      client_documentation_override: https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/overview
       codeowner_team: '@googleapis/gcs-team'
       excluded_poms:
         - google-cloud-storage-bom


### PR DESCRIPTION
Updates the shared README.md template to fix Authentication and Troubleshooting links globally, and to handle monorepo pathing for samples.

Updates .repo-metadata.json and regenerates README.md (or manually fixes them) for the following libraries to resolve broken Javadocs, Authentication, Troubleshooting, and Samples links:

java-bigtable
java-pubsub
java-bigquery
java-bigquerystorage
java-datastore
java-logging
java-logging-logback
java-storage
java-storage-nio
java-spanner
java-spanner-jdbc
java-firestore

Fixes: [googleapis/google-cloud-java#13530](https://github.com/googleapis/google-cloud-java/issues/13530) (for Firestore, but also applies this to the other handwritten libraries)