### PR TITLE
chore(java-cloud-bom): prefix release tags with libraries-bom/

### DIFF
--- a/.github/workflows/java-cloud-bom-release-note-generation.yaml
+++ b/.github/workflows/java-cloud-bom-release-note-generation.yaml
@@ -48,13 +48,10 @@ jobs:
         if [ -n "${WORKFLOW_DISPATCH_INPUT}" ]; then
           echo "WORKFLOW_DISPATCH_INPUT: ${WORKFLOW_DISPATCH_INPUT}"
           echo "libraries-bom-version=${WORKFLOW_DISPATCH_INPUT}" >> $GITHUB_OUTPUT
-        elif [[ "${GITHUB_REF}" == *"refs/tags/v"* ]]; then
-          # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
-          # Example value of GITHUB_REF: refs/tags/v26.5.0
-          # With the single-component setup of Release Please, the Libraries BOM
-          # version is the version of this repository release.
+        elif [[ "${GITHUB_REF}" == *"refs/tags/"* ]]; then
+          # Example value of GITHUB_REF: refs/tags/libraries-bom/v26.5.0
           echo "GITHUB_REF: ${GITHUB_REF}"
-          VERSION=${GITHUB_REF#refs/*/v}
+          VERSION=${GITHUB_REF#*v}
           echo "libraries-bom-version=${VERSION}" >> $GITHUB_OUTPUT
         else
           echo "Couldn't find the Libraries BOM version. WORKFLOW_DISPATCH_INPUT \
@@ -85,7 +82,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
     - name: Update the release note with release_note.md
       run: |
-        TAG="v${LIBRARIES_BOM_VERSION}"
+        TAG="libraries-bom/v${LIBRARIES_BOM_VERSION}"
         echo "Updating ${TAG}"
         gh release edit "${TAG}" --notes-file release_note.md
       working-directory: java-cloud-bom/release-note-generation

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,10 @@
         "sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg",
         "java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/telemetry/Version.java"
       ]
+    },
+    "java-cloud-bom": {
+      "component": "libraries-bom",
+      "include-component-in-tag": true
     }
   }
 }


### PR DESCRIPTION
This PR updates the migrated java-cloud-bom component configuration to prefix release tags with libraries-bom/ natively. It also updates the release notes generation workflow to parse and edit release descriptions on the new prefixed tag format.
