### PR TITLE
fix(java-cloud-bom): execute pre-install pass in GHA release notes generator

### DIFF
--- a/.github/workflows/java-cloud-bom-release-note-generation.yaml
+++ b/.github/workflows/java-cloud-bom-release-note-generation.yaml
@@ -40,6 +40,10 @@ jobs:
         java-version: 11
         cache: maven
     - run: java -version
+    - name: Pre-install Snapshot Dependencies
+      run: |
+        bash java-cloud-bom/tests/pre-install.sh
+      shell: bash
     - name: Pick Libraries BOM version
       id: pick-version
       shell: bash


### PR DESCRIPTION
This PR fixes a SNAPSHOT dependency resolution error inside the `java-cloud-bom-release-note-generation.yaml` GHA workflow. It adds a `pre-install.sh` execution pass to compile and install local snapshots (like `gapic-libraries-bom`) to the runner's Maven cache before executing the generator.