### PR TITLE
chore(java-cloud-bom): register libraries-bom in root release-please-config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,6 +23,10 @@
         "sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg",
         "java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/telemetry/Version.java"
       ]
+    },
+    "java-cloud-bom": {
+      "component": "libraries-bom",
+      "include-component-in-tag": true
     }
   }
 }


### PR DESCRIPTION
This PR registers the `java-cloud-bom` package inside the root `/release-please-config.json` configuration. This enables Release Please to push the `libraries-bom/v26.x.y` release tag upon merging the unified release PR.