### PR TITLE
chore: update librarian to v0.23.1-0.20260701125507-b8e50a51a11c

### DIFF
--- a/java-accessapproval/.repo-metadata.json
+++ b/java-accessapproval/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "enables controlling access to your organization's data by Google personnel.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-accessapproval/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-accessapproval",

--- a/java-accesscontextmanager/.repo-metadata.json
+++ b/java-accesscontextmanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "n/a",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-identity-accesscontextmanager/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-accesscontextmanager",

--- a/java-admanager/.repo-metadata.json
+++ b/java-admanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Ad Manager API enables an app to integrate with Google Ad Manager. You can read Ad Manager data and run reports using the API.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/ad-manager/latest/overview",
   "release_level": "preview",
-  "transport": "http",
+  "transport": "rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-admanager",

--- a/java-advisorynotifications/.repo-metadata.json
+++ b/java-advisorynotifications/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "An API for accessing Advisory Notifications in Google Cloud.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-advisorynotifications/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-advisorynotifications",

--- a/java-agentregistry/.repo-metadata.json
+++ b/java-agentregistry/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Agent Registry is a centralized, unified catalog that lets you store,\ndiscover, and govern Model Context Protocol (MCP) servers, tools, and AI\nagents within Google Cloud.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-agentregistry/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-agentregistry",

--- a/java-alloydb/.repo-metadata.json
+++ b/java-alloydb/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "AlloyDB is a fully managed, PostgreSQL-compatible database service with industry-leading performance, availability, and scale.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-alloydb/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-alloydb",

--- a/java-analytics-admin/.repo-metadata.json
+++ b/java-analytics-admin/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to manage Google Analytics accounts and properties.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-analytics-admin/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-analytics-admin",

--- a/java-analytics-data/.repo-metadata.json
+++ b/java-analytics-data/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides programmatic methods to access report data in Google Analytics App+Web properties.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-analytics-data/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-analytics-data",

--- a/java-analyticshub/.repo-metadata.json
+++ b/java-analyticshub/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "TBD",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-analyticshub/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-analyticshub",

--- a/java-api-gateway/.repo-metadata.json
+++ b/java-api-gateway/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "enables you to provide secure access to your backend services through a well-defined REST API that is consistent across all of your services, regardless of the service implementation. Clients consume your REST APIS to implement standalone apps for a mobile device or tablet, through apps running in a browser, or through any other type of app that can make a request to an HTTP endpoint.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-api-gateway/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-api-gateway",

--- a/java-apigee-connect/.repo-metadata.json
+++ b/java-apigee-connect/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows the Apigee hybrid management plane to connect securely to the MART service in the runtime plane without requiring you to expose the MART endpoint on the internet.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-apigee-connect/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-apigee-connect",

--- a/java-apigee-registry/.repo-metadata.json
+++ b/java-apigee-registry/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows teams to upload and share machine-readable descriptions of APIs that are in use and in development.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-apigee-registry/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-apigee-registry",

--- a/java-apihub/.repo-metadata.json
+++ b/java-apihub/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "API hub lets you consolidate and organize information about all of the APIs     of interest to your organization. API hub lets you capture critical information about APIs that allows developers to discover and evaluate     them easily and leverage the work of other teams wherever possible. API     platform teams can use API hub to have visibility into and manage their portfolio of APIs.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-apihub/latest/overview",
   "release_level": "preview",
-  "transport": "http",
+  "transport": "rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-apihub",

--- a/java-apikeys/.repo-metadata.json
+++ b/java-apikeys/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "API Keys lets you create and manage your API keys for your projects.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-apikeys",

--- a/java-appengine-admin/.repo-metadata.json
+++ b/java-appengine-admin/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "you to manage your App Engine applications.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-appengine-admin/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-appengine-admin",

--- a/java-apphub/.repo-metadata.json
+++ b/java-apphub/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "App Hub simplifies the process of building, running, and managing applications on Google Cloud.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-apphub/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-apphub",

--- a/java-appoptimize/.repo-metadata.json
+++ b/java-appoptimize/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The App Optimize API provides developers and platform teams with tools to monitor, analyze, and improve the performance and cost-efficiency of their cloud applications.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-appoptimize/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-appoptimize",

--- a/java-area120-tables/.repo-metadata.json
+++ b/java-area120-tables/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides programmatic methods to the Area 120 Tables API.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-area120-tables/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-area120-tables",

--- a/java-artifact-registry/.repo-metadata.json
+++ b/java-artifact-registry/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides a single place for your organization to manage container images and language packages (such as Maven and npm). It is fully integrated with Google Cloud's tooling and runtimes and comes with support for native artifact protocols. This makes it simple to integrate it with your CI/CD tooling to set up automated pipelines.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-artifact-registry/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-artifact-registry",

--- a/java-asset/.repo-metadata.json
+++ b/java-asset/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides inventory services based on a time series database. This database keeps a five week history of Google Cloud asset metadata. The Cloud Asset Inventory export service allows you to export all asset metadata at a certain timestamp or export event change history during a timeframe.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-asset/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-asset",

--- a/java-assured-workloads/.repo-metadata.json
+++ b/java-assured-workloads/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to secure your government workloads and accelerate your path to running compliant workloads on Google Cloud with Assured Workloads for Government.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-assured-workloads/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-assured-workloads",

--- a/java-auditmanager/.repo-metadata.json
+++ b/java-auditmanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Lists information about the supported locations for this service.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-auditmanager/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-auditmanager",

--- a/java-automl/.repo-metadata.json
+++ b/java-automl/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "makes the power of machine learning available to you even if you have limited knowledge of machine learning. You can use AutoML to build on Google's machine learning capabilities to create your own custom machine learning models that are tailored to your business needs, and then integrate those models into your applications and web sites.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-automl/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-automl",

--- a/java-backstory/.repo-metadata.json
+++ b/java-backstory/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Common Universal Data Model (UDM) and Entity protos used by Chronicle.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-backstory/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-backstory",

--- a/java-backupdr/.repo-metadata.json
+++ b/java-backupdr/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Backup and DR Service is a powerful, centralized, cloud-first backup and disaster recovery solution for cloud-based and hybrid workloads. ",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-backupdr/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-backupdr",

--- a/java-bare-metal-solution/.repo-metadata.json
+++ b/java-bare-metal-solution/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Bring your Oracle workloads to Google Cloud with Bare Metal Solution and jumpstart your cloud journey with minimal risk.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bare-metal-solution/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bare-metal-solution",

--- a/java-batch/.repo-metadata.json
+++ b/java-batch/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "n/a",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-batch/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-batch",

--- a/java-biglake/.repo-metadata.json
+++ b/java-biglake/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The BigLake API provides access to BigLake Metastore, a serverless, fully managed, and highly available metastore for open-source data that can be used for querying Apache Iceberg tables in BigQuery.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-biglake/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-biglake",

--- a/java-bigquery-data-exchange/.repo-metadata.json
+++ b/java-bigquery-data-exchange/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a data exchange that allows you to efficiently and securely exchange data assets across organizations to address challenges of data reliability and cost.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquery-data-exchange/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bigquery-data-exchange",

--- a/java-bigqueryconnection/.repo-metadata.json
+++ b/java-bigqueryconnection/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows users to manage BigQuery connections to external data sources.",
   "client_documentation": "https://cloud.google.com/bigquery/docs/reference/reservations/rpc/google.cloud.bigquery.reservation.v1beta1",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bigqueryconnection",

--- a/java-bigquerydatapolicy/.repo-metadata.json
+++ b/java-bigquerydatapolicy/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Allows users to manage BigQuery data policies.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquerydatapolicy/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bigquerydatapolicy",

--- a/java-bigquerydatatransfer/.repo-metadata.json
+++ b/java-bigquerydatatransfer/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "transfers data from partner SaaS applications to Google BigQuery on a scheduled, managed basis.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquerydatatransfer/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bigquerydatatransfer",

--- a/java-bigquerymigration/.repo-metadata.json
+++ b/java-bigquerymigration/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "BigQuery Migration API",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigquerymigration/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bigquerymigration",

--- a/java-bigqueryreservation/.repo-metadata.json
+++ b/java-bigqueryreservation/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows users to manage their flat-rate BigQuery reservations.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-bigqueryreservation/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-bigqueryreservation",

--- a/java-billing/.repo-metadata.json
+++ b/java-billing/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows developers to manage their billing accounts or browse the catalog of SKUs and pricing.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-billing/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-billing",

--- a/java-billingbudgets/.repo-metadata.json
+++ b/java-billingbudgets/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to avoid surprises on your bill by creating budgets to monitor all your Google Cloud charges in one place.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-billingbudgets/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-billingbudgets",

--- a/java-binary-authorization/.repo-metadata.json
+++ b/java-binary-authorization/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": " is a service on Google Cloud that provides centralized software supply-chain security for applications that run on Google Kubernetes Engine (GKE) and Anthos clusters on VMware",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-binary-authorization/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-binary-authorization",

--- a/java-capacityplanner/.repo-metadata.json
+++ b/java-capacityplanner/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Provides programmatic access to Capacity Planner features.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-capacityplanner/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-capacityplanner",

--- a/java-certificate-manager/.repo-metadata.json
+++ b/java-certificate-manager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "lets you acquire and manage TLS (SSL) certificates for use with Cloud Load Balancing.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-certificate-manager/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-certificate-manager",

--- a/java-ces/.repo-metadata.json
+++ b/java-ces/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Customer Experience Agent Studio (CX Agent Studio) is a minimal code conversational agent builder.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-ces/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-ces",

--- a/java-channel/.repo-metadata.json
+++ b/java-channel/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "With Channel Services, Google Cloud partners and resellers have a single unified resale platform, with a unified resale catalog, customer management, order management, billing management, policy and authorization management, and cost management.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-channel/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-channel",

--- a/java-chat/.repo-metadata.json
+++ b/java-chat/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Google Chat API lets you build Chat apps to integrate your services with Google Chat and manage Chat resources such as spaces, members, and messages.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-chat/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-chat",

--- a/java-chronicle/.repo-metadata.json
+++ b/java-chronicle/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Google Cloud Security Operations API, popularly known as the Chronicle API, serves endpoints that enable security analysts to analyze and mitigate a security threat throughout its lifecycle",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-chronicle/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-chronicle",

--- a/java-cloudapiregistry/.repo-metadata.json
+++ b/java-cloudapiregistry/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Cloud API Registry lets you discover, govern, use, and monitor Model Context Protocol (MCP) servers and tools provided by Google, or by your organization through Apigee API hub.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-cloudapiregistry/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-cloudapiregistry",

--- a/java-cloudbuild/.repo-metadata.json
+++ b/java-cloudbuild/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "lets you build software quickly across all languages. Get complete control over defining custom workflows for building, testing, and deploying across multiple environments such as VMs, serverless, Kubernetes, or Firebase.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-build/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-cloudbuild",

--- a/java-cloudcommerceconsumerprocurement/.repo-metadata.json
+++ b/java-cloudcommerceconsumerprocurement/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Find top solutions integrated with Google Cloud to accelerate your digital transformation. Scale and simplify procurement for your organization with online discovery, flexible purchasing, and fulfillment of enterprise-grade cloud solutions.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-cloudcommerceconsumerprocurement/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-cloudcommerceconsumerprocurement",

--- a/java-cloudcontrolspartner/.repo-metadata.json
+++ b/java-cloudcontrolspartner/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Provides insights about your customers and their Assured Workloads based on your Sovereign Controls by Partners offering.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-cloudcontrolspartner/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-cloudcontrolspartner",

--- a/java-cloudquotas/.repo-metadata.json
+++ b/java-cloudquotas/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Cloud Quotas API provides GCP service consumers with management and\n    observability for resource usage, quotas, and restrictions of the services\n    they consume.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-cloudquotas/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-cloudquotas",

--- a/java-cloudsecuritycompliance/.repo-metadata.json
+++ b/java-cloudsecuritycompliance/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Compliance Manager uses software-defined controls that let you assess support for multiple compliance programs and security requirements within a Google Cloud organization",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-cloudsecuritycompliance/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-cloudsecuritycompliance",

--- a/java-cloudsupport/.repo-metadata.json
+++ b/java-cloudsupport/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Manages Google Cloud technical support cases for Customer Care support offerings.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-cloudsupport/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-cloudsupport",

--- a/java-compute/.repo-metadata.json
+++ b/java-compute/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "delivers virtual machines running in Google's innovative data centers and worldwide fiber network. Compute Engine's tooling and workflow support enable scaling from single instances to global, load-balanced cloud computing. Compute Engine's VMs boot quickly, come with persistent disk storage, deliver consistent performance and are available in many configurations. ",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-compute/latest/overview",
   "release_level": "stable",
-  "transport": "http",
+  "transport": "rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-compute",

--- a/java-confidentialcomputing/.repo-metadata.json
+++ b/java-confidentialcomputing/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Protect data in-use with Confidential VMs, Confidential GKE, Confidential Dataproc, and Confidential Space.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-confidentialcomputing/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-confidentialcomputing",

--- a/java-configdelivery/.repo-metadata.json
+++ b/java-configdelivery/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "ConfigDelivery service manages the deployment of kubernetes configuration to a fleet of kubernetes clusters.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-configdelivery/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-configdelivery",

--- a/java-connectgateway/.repo-metadata.json
+++ b/java-connectgateway/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Connect Gateway service allows connectivity from external parties to     connected Kubernetes clusters.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-connectgateway/latest/overview",
   "release_level": "preview",
-  "transport": "http",
+  "transport": "rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-connectgateway",

--- a/java-contact-center-insights/.repo-metadata.json
+++ b/java-contact-center-insights/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": " helps users detect and visualize patterns in their contact center data.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-contact-center-insights/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-contact-center-insights",

--- a/java-container/.repo-metadata.json
+++ b/java-container/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is an enterprise-grade platform for containerized applications, including stateful and stateless, AI and ML, Linux and Windows, complex and simple web apps, API, and backend services. Leverage industry-first features like four-way auto-scaling and no-stress management. Optimize GPU and TPU provisioning, use integrated developer tools, and get multi-cluster support from SREs.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-container/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-container",

--- a/java-containeranalysis/.repo-metadata.json
+++ b/java-containeranalysis/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a service that provides vulnerability scanning and metadata storage for software artifacts. The service performs vulnerability scans on built software artifacts, such as the images in Container Registry, then stores the resulting metadata and makes it available for consumption through an API. The metadata may come from several sources, including vulnerability scanning, other Cloud services, and third-party providers.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-containeranalysis/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-containeranalysis",

--- a/java-contentwarehouse/.repo-metadata.json
+++ b/java-contentwarehouse/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Document AI Warehouse is an integrated cloud-native GCP platform to store, search, organize, govern and analyze documents and their structured metadata.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-contentwarehouse/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-contentwarehouse",

--- a/java-data-fusion/.repo-metadata.json
+++ b/java-data-fusion/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a fully managed, cloud-native, enterprise data integration service for quickly building and managing data pipelines.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-data-fusion/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-data-fusion",

--- a/java-databasecenter/.repo-metadata.json
+++ b/java-databasecenter/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Database Center provides an organization-wide, cross-product fleet health platform to eliminate the overhead, complexity, and risk associated with aggregating and summarizing health signals through custom dashboards. Through Database Center's fleet health dashboard and API, database platform teams that are responsible for reliability, compliance, security, cost, and administration of database fleets will now have a single pane of glass that pinpoints issues relevant to each team.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-databasecenter/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-databasecenter",

--- a/java-datacatalog/.repo-metadata.json
+++ b/java-datacatalog/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a fully managed and highly scalable data discovery and metadata management service.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-datacatalog/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-datacatalog",

--- a/java-dataflow/.repo-metadata.json
+++ b/java-dataflow/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a managed service for executing a wide variety of data processing patterns.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dataflow/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dataflow",

--- a/java-dataform/.repo-metadata.json
+++ b/java-dataform/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Help analytics teams manage data inside BigQuery using SQL.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dataform/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dataform",

--- a/java-datalineage/.repo-metadata.json
+++ b/java-datalineage/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Lineage is used to track data flows between assets over time.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-datalineage/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-datalineage",

--- a/java-datamanager/.repo-metadata.json
+++ b/java-datamanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "A unified ingestion API for data partners, agencies and advertisers to connect first-party data across Google advertising products.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/data-manager/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-datamanager",

--- a/java-dataplex/.repo-metadata.json
+++ b/java-dataplex/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides intelligent data fabric that enables organizations to centrally manage, monitor, and govern their data across data lakes, data warehouses, and data marts with consistent controls, providing access to trusted data and powering analytics at scale.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dataplex/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dataplex",

--- a/java-dataproc-metastore/.repo-metadata.json
+++ b/java-dataproc-metastore/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a fully managed, highly available, autoscaled, autohealing, OSS-native metastore service that greatly simplifies technical metadata management. Dataproc Metastore service is based on Apache Hive metastore and serves as a critical component towards enterprise data lakes.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dataproc-metastore/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dataproc-metastore",

--- a/java-dataproc/.repo-metadata.json
+++ b/java-dataproc/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a faster, easier, more cost-effective way to run Apache Spark and Apache Hadoop.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dataproc/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dataproc",

--- a/java-datastore/.repo-metadata.json
+++ b/java-datastore/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a fully managed, schemaless database for\\nstoring non-relational data. Cloud Datastore automatically scales with\\nyour users and supports ACID transactions, high availability of reads and\\nwrites, strong consistency for reads and ancestor queries, and eventual\\nconsistency for all other queries.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/history",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-datastore",

--- a/java-datastream/.repo-metadata.json
+++ b/java-datastream/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a serverless and easy-to-use change data capture (CDC) and replication service. It allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-datastream/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-datastream",

--- a/java-deploy/.repo-metadata.json
+++ b/java-deploy/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a service that automates delivery of your applications to a series of target environments in a defined sequence",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-deploy/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-deploy",

--- a/java-developerconnect/.repo-metadata.json
+++ b/java-developerconnect/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Connect third-party source code management to Google",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-developerconnect/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-developerconnect",

--- a/java-developerknowledge/.repo-metadata.json
+++ b/java-developerknowledge/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Developer Knowledge API provides access to Google's developer knowledge",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-developer-knowledge/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-developerknowledge",

--- a/java-devicestreaming/.repo-metadata.json
+++ b/java-devicestreaming/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Cloud API for device streaming usage.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-devicestreaming/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-devicestreaming",

--- a/java-dialogflow-cx/.repo-metadata.json
+++ b/java-dialogflow-cx/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides a new way of designing agents, taking a state machine approach to agent design. This gives you clear and explicit control over a conversation, a better end-user experience, and a better development workflow.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dialogflow-cx/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dialogflow-cx",

--- a/java-dialogflow/.repo-metadata.json
+++ b/java-dialogflow/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is an end-to-end, build-once deploy-everywhere development suite for creating conversational interfaces for websites, mobile applications, popular messaging platforms, and IoT devices. You can use it to build interfaces (such as chatbots and conversational IVR) that enable natural and rich interactions between your users and your business. Dialogflow Enterprise Edition users have access to Google Cloud Support and a service level agreement (SLA) for production deployments.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dialogflow/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dialogflow",

--- a/java-discoveryengine/.repo-metadata.json
+++ b/java-discoveryengine/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "A Cloud API that offers search and recommendation discoverability for documents from different industry verticals (e.g. media, retail, etc.).",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-discoveryengine/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-discoveryengine",

--- a/java-distributedcloudedge/.repo-metadata.json
+++ b/java-distributedcloudedge/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Google Distributed Cloud Edge allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-distributedcloudedge/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-distributedcloudedge",

--- a/java-dlp/.repo-metadata.json
+++ b/java-dlp/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides programmatic access to a powerful detection engine for personally identifiable information and other privacy-sensitive data in unstructured data streams, like text blocks and images.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-dlp/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-dlp",

--- a/java-document-ai/.repo-metadata.json
+++ b/java-document-ai/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows developers to unlock insights from your documents with machine learning.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-document-ai/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-document-ai",

--- a/java-domains/.repo-metadata.json
+++ b/java-domains/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to register and manage domains by using Cloud Domains.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-domains/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-domains",

--- a/java-edgenetwork/.repo-metadata.json
+++ b/java-edgenetwork/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Network management API for Distributed Cloud Edge.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-edgenetwork/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-edgenetwork",

--- a/java-enterpriseknowledgegraph/.repo-metadata.json
+++ b/java-enterpriseknowledgegraph/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Enterprise Knowledge Graph organizes siloed information into organizational knowledge, which involves consolidating, standardizing, and reconciling data in an efficient and useful way.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-enterpriseknowledgegraph/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-enterpriseknowledgegraph",

--- a/java-errorreporting/.repo-metadata.json
+++ b/java-errorreporting/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "counts, analyzes, and aggregates the crashes in your running cloud services. A centralized error management interface displays the results with sorting and filtering capabilities. A dedicated view shows the error details: time chart, occurrences, affected user count, first- and last-seen dates and a cleaned exception stack trace. Opt in to receive email and mobile alerts on new errors.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-errorreporting/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-errorreporting",

--- a/java-essential-contacts/.repo-metadata.json
+++ b/java-essential-contacts/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "helps you customize who receives notifications by providing your own list of contacts in many Google Cloud services.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-essential-contacts/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-essential-contacts",

--- a/java-eventarc-publishing/.repo-metadata.json
+++ b/java-eventarc-publishing/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-eventarc-publishing/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-eventarc-publishing",

--- a/java-eventarc/.repo-metadata.json
+++ b/java-eventarc/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "lets you asynchronously deliver events from Google services, SaaS, and your own apps using loosely coupled services that react to state changes. Eventarc requires no infrastructure management, you can optimize productivity and costs while building a modern, event-driven solution.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-eventarc/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-eventarc",

--- a/java-filestore/.repo-metadata.json
+++ b/java-filestore/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "instances are fully managed NFS file servers on Google Cloud for use with applications running on Compute Engine virtual machines (VMs) instances or Google Kubernetes Engine clusters.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-filestore/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-filestore",

--- a/java-financialservices/.repo-metadata.json
+++ b/java-financialservices/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Google Cloud's Anti Money Laundering AI (AML AI) product is an API that scores AML risk. Use it to identify more risk, more defensibly, with fewer false positives and reduced time per review.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-financialservices/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-financialservices",

--- a/java-functions/.repo-metadata.json
+++ b/java-functions/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a scalable pay as you go Functions-as-a-Service (FaaS) to run your code with zero server management.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-functions/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-functions",

--- a/java-gdchardwaremanagement/.repo-metadata.json
+++ b/java-gdchardwaremanagement/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Google Distributed Cloud connected allows you to run Kubernetes clusters on dedicated hardware provided and maintained by Google that is separate from the Google Cloud data center.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-gdchardwaremanagement/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-gdchardwaremanagement",

--- a/java-geminidataanalytics/.repo-metadata.json
+++ b/java-geminidataanalytics/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Use Conversational Analytics API to build an artificial intelligence (AI)-powered chat interface, or data agent, that answers questions about structured data using natural language.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-geminidataanalytics/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-geminidataanalytics",

--- a/java-gke-backup/.repo-metadata.json
+++ b/java-gke-backup/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a service for backing up and restoring workloads in GKE.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-gke-backup/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-gke-backup",

--- a/java-gke-connect-gateway/.repo-metadata.json
+++ b/java-gke-connect-gateway/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "builds on the power of fleets to let Anthos users connect to and run commands against registered Anthos clusters in a simple, consistent, and secured way, whether the clusters are on Google Cloud, other public clouds, or on premises, and makes it easier to automate DevOps processes across all your clusters.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-gke-connect-gateway/latest/overview",
   "release_level": "stable",
-  "transport": "http",
+  "transport": "rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-gke-connect-gateway",

--- a/java-gke-multi-cloud/.repo-metadata.json
+++ b/java-gke-multi-cloud/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "enables you to provision and manage GKE clusters running on AWS and Azure infrastructure through a centralized Google Cloud backed control plane.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-gke-multi-cloud/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-gke-multi-cloud",

--- a/java-gkehub/.repo-metadata.json
+++ b/java-gkehub/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides a unified way to work with Kubernetes clusters as part of Anthos, extending GKE to work in multiple environments. You have consistent, unified, and secure infrastructure, cluster, and container management, whether you're using Anthos on Google Cloud (with traditional GKE), hybrid cloud, or multiple public clouds.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-gkehub/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-gkehub",

--- a/java-gkerecommender/.repo-metadata.json
+++ b/java-gkerecommender/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "lets you analyze the performance and cost-efficiency of your inference workloads, and make data-driven decisions about resource allocation and model deployment strategies.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-gkerecommender/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-gkerecommender",

--- a/java-gsuite-addons/.repo-metadata.json
+++ b/java-gsuite-addons/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "are customized applications that integrate with Google Workspace productivity applications.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-gsuite-addons/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-gsuite-addons",

--- a/java-health/.repo-metadata.json
+++ b/java-health/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Google Health API lets you view and manage health and fitness metrics and measurement data.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-health/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-health",

--- a/java-hypercomputecluster/.repo-metadata.json
+++ b/java-hypercomputecluster/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "simplifies cluster management across compute, network, and storage",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-hypercomputecluster/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-hypercomputecluster",

--- a/java-iam-policy/.repo-metadata.json
+++ b/java-iam-policy/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "n/a",
   "client_documentation": "https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/history",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-iam-policy",

--- a/java-iam/.repo-metadata.json
+++ b/java-iam/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Manages access control for Google Cloud Platform resources",
   "client_documentation": "https://cloud.google.com/java/docs/reference/proto-google-iam-v1/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-iam",

--- a/java-iamcredentials/.repo-metadata.json
+++ b/java-iamcredentials/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "creates short-lived, limited-privilege credentials for IAM service accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-iamcredentials/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-iamcredentials",

--- a/java-iap/.repo-metadata.json
+++ b/java-iap/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Controls access to cloud applications running on Google Cloud Platform.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-iap/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-iap",

--- a/java-ids/.repo-metadata.json
+++ b/java-ids/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": " monitors your networks, and it alerts you when it detects malicious activity. Cloud IDS is powered by Palo Alto Networks.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-ids/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-ids",

--- a/java-infra-manager/.repo-metadata.json
+++ b/java-infra-manager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Creates and manages Google Cloud Platform resources and infrastructure.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-infra-manager/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-infra-manager",

--- a/java-iot/.repo-metadata.json
+++ b/java-iot/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a complete set of tools to connect, process, store, and analyze data both at the edge and in the cloud. The platform consists of scalable, fully-managed cloud services; an integrated software stack for edge/on-premises computing with machine learning capabilities for all your IoT needs.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-iot/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-iot",

--- a/java-java-shopping-merchant-issue-resolution/.repo-metadata.json
+++ b/java-java-shopping-merchant-issue-resolution/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programatically manage your Merchant Issues",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-issue-resolution/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-java-shopping-merchant-issue-resolution",

--- a/java-java-shopping-merchant-order-tracking/.repo-metadata.json
+++ b/java-java-shopping-merchant-order-tracking/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center Accounts",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-order-tracking/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-java-shopping-merchant-order-tracking",

--- a/java-kms/.repo-metadata.json
+++ b/java-kms/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "a cloud-hosted key management service that lets you manage cryptographic keys for your cloud services the same way you do on-premises. You can generate, use, rotate, and destroy AES256, RSA 2048, RSA 3072, RSA 4096, EC P256, and EC P384 cryptographic keys. Cloud KMS is integrated with Cloud IAM and Cloud Audit Logging so that you can manage permissions on individual keys and monitor how these are used. Use Cloud KMS to protect secrets and other sensitive data that you need to store in Google Cloud Platform.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-kms/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-kms",

--- a/java-kmsinventory/.repo-metadata.json
+++ b/java-kmsinventory/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "KMS Inventory API.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-kmsinventory/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-kmsinventory",

--- a/java-language/.repo-metadata.json
+++ b/java-language/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides natural language understanding technologies to developers, including sentiment analysis, entity analysis, entity sentiment analysis, content classification, and syntax analysis. This API is part of the larger Cloud Machine Learning API family.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-language/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-language",

--- a/java-licensemanager/.repo-metadata.json
+++ b/java-licensemanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "License Manager is a tool to manage and track third-party licenses on Google Cloud.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-licensemanager/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-licensemanager",

--- a/java-life-sciences/.repo-metadata.json
+++ b/java-life-sciences/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a suite of services and tools for managing, processing, and transforming life sciences data.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-life-sciences/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-life-sciences",

--- a/java-locationfinder/.repo-metadata.json
+++ b/java-locationfinder/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Cloud Location Finder is a public API that offers a repository of all Google Cloud and Google Distributed Cloud locations, as well as cloud locations for other cloud providers.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-locationfinder/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-locationfinder",

--- a/java-lustre/.repo-metadata.json
+++ b/java-lustre/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Google Cloud Managed Lustre delivers a high-performance, fully managed parallel file system optimized for AI and HPC applications.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-lustre/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-lustre",

--- a/java-maintenance/.repo-metadata.json
+++ b/java-maintenance/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Maintenance API provides a centralized view of planned disruptive maintenance events across supported Google Cloud products.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-maintenance/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maintenance",

--- a/java-managedkafka/.repo-metadata.json
+++ b/java-managedkafka/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Manage Apache Kafka clusters and resources.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-managedkafka/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-managedkafka",

--- a/java-maps-addressvalidation/.repo-metadata.json
+++ b/java-maps-addressvalidation/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Address Validation API allows developers to verify the accuracy of addresses. Given an address, it returns information about the correctness of the components of the parsed address, a geocode, and a verdict on the deliverability of the parsed address.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-addressvalidation/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-addressvalidation",

--- a/java-maps-area-insights/.repo-metadata.json
+++ b/java-maps-area-insights/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Places Insights API.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-area-insights/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-area-insights",

--- a/java-maps-fleetengine-delivery/.repo-metadata.json
+++ b/java-maps-fleetengine-delivery/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Enables Fleet Engine for access to the On Demand Rides and Deliveries and Last Mile Fleet Solution APIs.  Customer's use of Google Maps Content in the Cloud Logging Services is subject to the Google Maps Platform Terms of Service located at https://cloud.google.com/maps-platform/terms.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-fleetengine-delivery/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-fleetengine-delivery",

--- a/java-maps-geocode/.repo-metadata.json
+++ b/java-maps-geocode/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Geocoding API is a service that accepts a place as an address, latitude and longitude coordinates, or Place ID.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-geocode/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-geocode",

--- a/java-maps-mapmanagement/.repo-metadata.json
+++ b/java-maps-mapmanagement/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Map Management API is a RESTful service that accepts HTTP requests for map styling data through a variety of methods. It returns formatted configuration data about map styling resources so that you can programmatically manage your Cloud-based map styles.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-mapmanagement/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-mapmanagement",

--- a/java-maps-mapsplatformdatasets/.repo-metadata.json
+++ b/java-maps-mapsplatformdatasets/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Maps Platform Datasets API enables developers to ingest geospatially-tied datasets\n    that they can use to enrich their experience of Maps Platform solutions (e.g. styling, routing).",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-mapsplatformdatasets/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-mapsplatformdatasets",

--- a/java-maps-places/.repo-metadata.json
+++ b/java-maps-places/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Places API allows developers to access a variety of search and retrieval endpoints for a Place.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-places/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-places",

--- a/java-maps-routeoptimization/.repo-metadata.json
+++ b/java-maps-routeoptimization/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Route Optimization API assigns tasks and routes to a vehicle fleet, optimizing against the objectives and constraints that you supply for your transportation goals.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-routeoptimization/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-routeoptimization",

--- a/java-maps-routing/.repo-metadata.json
+++ b/java-maps-routing/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Routes API is the next generation, performance optimized version of the existing Directions API and Distance Matrix API. It helps you find the ideal route from A to Z, calculates ETAs and distances for matrices of origin and destination locations, and also offers new features.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-routing/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-routing",

--- a/java-maps-solar/.repo-metadata.json
+++ b/java-maps-solar/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Solar API allows users to read details about the solar potential of over 60 million buildings. This includes measurements of the building's roof (e.g., size and tilt/azimuth), energy production for a range of sizes of solar installations, and financial costs and benefits.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-maps-solar/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-maps-solar",

--- a/java-marketingplatformadminapi/.repo-metadata.json
+++ b/java-marketingplatformadminapi/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Google Marketing Platform Admin API allows for programmatic access to the Google Marketing Platform configuration data. You can use the Google Marketing Platform Admin API to manage links between your Google Marketing Platform organization and Google Analytics accounts, and to set the service level of your GA4 properties.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/admin/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-marketingplatformadminapi",

--- a/java-meet/.repo-metadata.json
+++ b/java-meet/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Google Meet REST API lets you create and manage meetings for Google Meet and offers entry points to your users directly from your app",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-meet/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-meet",

--- a/java-memcache/.repo-metadata.json
+++ b/java-memcache/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a fully-managed in-memory data store service for Memcache.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-memcache/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-memcache",

--- a/java-migrationcenter/.repo-metadata.json
+++ b/java-migrationcenter/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Google Cloud Migration Center is a unified platform that helps you accelerate your end-to-end cloud journey from your current on-premises or cloud environments to Google Cloud",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-migrationcenter/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-migrationcenter",

--- a/java-modelarmor/.repo-metadata.json
+++ b/java-modelarmor/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Model Armor helps you protect against risks like prompt injection, harmful content, and data leakage in generative AI applications by letting you define policies that filter user prompts and model responses.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-modelarmor/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-modelarmor",

--- a/java-monitoring-dashboards/.repo-metadata.json
+++ b/java-monitoring-dashboards/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "are one way for you to view and analyze metric data. The Cloud Console provides predefined dashboards that require no setup or configuration. You can also define custom dashboards. With custom dashboards, you have complete control over the charts that are displayed and their configuration.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-monitoring-dashboard/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-monitoring-dashboards",

--- a/java-netapp/.repo-metadata.json
+++ b/java-netapp/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Google Cloud NetApp Volumes is a fully-managed, cloud-based data storage service that provides advanced data management capabilities and highly scalable performance with global availability.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-netapp/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-netapp",

--- a/java-network-management/.repo-metadata.json
+++ b/java-network-management/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides a collection of network performance monitoring and diagnostic capabilities.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-network-management/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-network-management",

--- a/java-networkservices/.repo-metadata.json
+++ b/java-networkservices/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Google Cloud offers a broad portfolio of networking services built on top of planet-scale infrastructure that leverages automation, advanced AI, and programmability, enabling enterprises to connect, scale, secure, modernize and optimize their infrastructure.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-networkservices/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-networkservices",

--- a/java-notebooks/.repo-metadata.json
+++ b/java-notebooks/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a managed service that offers an integrated and secure JupyterLab environment for data scientists and machine learning developers to experiment, develop, and deploy models into production. Users can create instances running JupyterLab that come pre-installed with the latest data science and machine learning frameworks in a single click.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-notebooks/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-notebooks",

--- a/java-optimization/.repo-metadata.json
+++ b/java-optimization/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a managed routing service that takes your list of orders, vehicles, constraints, and objectives and returns the most efficient plan for your entire fleet in near real-time.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-optimization/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-optimization",

--- a/java-oracledatabase/.repo-metadata.json
+++ b/java-oracledatabase/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Oracle Database@Google Cloud API provides a set of APIs to manage   Oracle database services, such as Exadata and Autonomous Databases.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-oracledatabase/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-oracledatabase",

--- a/java-orchestration-airflow/.repo-metadata.json
+++ b/java-orchestration-airflow/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a managed Apache Airflow service that helps you create, schedule, monitor and manage workflows. Cloud Composer automation helps you create Airflow environments quickly and use Airflow-native tools, such as the powerful Airflow web interface and command line tools, so you can focus on your workflows and not your infrastructure.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-orchestration-airflow/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-orchestration-airflow",

--- a/java-orgpolicy/.repo-metadata.json
+++ b/java-orgpolicy/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "n/a",
   "client_documentation": "https://cloud.google.com/java/docs/reference/proto-google-cloud-orgpolicy-v1/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-orgpolicy",

--- a/java-os-config/.repo-metadata.json
+++ b/java-os-config/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "provides OS management tools that can be used for patch management, patch compliance, and configuration management on VM instances.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-os-config/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-os-config",

--- a/java-os-login/.repo-metadata.json
+++ b/java-os-login/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "manages OS login configuration for Directory API users.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-os-login/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-os-login",

--- a/java-parallelstore/.repo-metadata.json
+++ b/java-parallelstore/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Parallelstore is based on Intel DAOS and delivers up to 6.3x greater read throughput performance compared to competitive Lustre scratch offerings. ",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-parallelstore/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-parallelstore",

--- a/java-parametermanager/.repo-metadata.json
+++ b/java-parametermanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "(Public Preview) Parameter Manager is a single source of truth to store,     access and manage the lifecycle of your workload parameters. Parameter     Manager aims to make management of sensitive application parameters     effortless for customers without diminishing focus on security.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-parametermanager/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-parametermanager",

--- a/java-phishingprotection/.repo-metadata.json
+++ b/java-phishingprotection/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "helps prevent users from accessing phishing sites by identifying various signals associated with malicious content, including the use of your brand assets, classifying malicious content that uses your brand and reporting the unsafe URLs to Google Safe Browsing. Once a site is propagated to Safe Browsing, users will see warnings across more than 4 billion devices.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-phishingprotection/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-phishingprotection",

--- a/java-policy-troubleshooter/.repo-metadata.json
+++ b/java-policy-troubleshooter/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "makes it easier to understand why a user has access to a resource or doesn't have permission to call an API. Given an email, resource, and permission, Policy Troubleshooter examines all Identity and Access Management (IAM) policies that apply to the resource. It then reveals whether the member's roles include the permission on that resource and, if so, which policies bind the member to those roles.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-policy-troubleshooter/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-policy-troubleshooter",

--- a/java-policysimulator/.repo-metadata.json
+++ b/java-policysimulator/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Policy Simulator is a collection of endpoints for creating, running, and viewing a Replay.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-policysimulator/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-policysimulator",

--- a/java-private-catalog/.repo-metadata.json
+++ b/java-private-catalog/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows developers and cloud admins to make their solutions discoverable to their internal enterprise users. Cloud admins can manage their solutions and ensure their users are always launching the latest versions.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-private-catalog/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-private-catalog",

--- a/java-privilegedaccessmanager/.repo-metadata.json
+++ b/java-privilegedaccessmanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Privileged Access Manager (PAM) helps you on your journey towards least privilege and helps mitigate risks tied to privileged access misuse orabuse. PAM allows you to shift from always-on standing privileges towards on-demand access with just-in-time, time-bound, and approval-based access elevations. PAM allows IAM administrators to create entitlements that can grant just-in-time, temporary access to any resource scope. Requesters can explore eligible entitlements and request the access needed for their task. Approvers are notified when approvals await their decision. Streamlined workflows facilitated by using PAM can support various use cases, including emergency access for incident responders, time-boxed access for developers for critical deployment or maintenance, temporary access for operators for data ingestion and audits, JIT access to service accounts for automated tasks, and more.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-privilegedaccessmanager/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-privilegedaccessmanager",

--- a/java-profiler/.repo-metadata.json
+++ b/java-profiler/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a statistical, low-overhead profiler that continuously gathers CPU usage and memory-allocation information from your production applications. It attributes that information to the application's source code, helping you identify the parts of the application consuming the most resources, and otherwise illuminating the performance characteristics of the code.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-profiler/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-profiler",

--- a/java-publicca/.repo-metadata.json
+++ b/java-publicca/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Public Certificate Authority API may be used to create and manage ACME external account binding keys associated with Google Trust Services' publicly trusted certificate authority.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-publicca/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-publicca",

--- a/java-pubsub/.repo-metadata.json
+++ b/java-pubsub/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is designed to provide reliable, many-to-many, asynchronous messaging between applications. Publisher applications can send messages to a topic and other applications can subscribe to that topic to receive the messages. By decoupling senders and receivers, Google Cloud Pub/Sub allows developers to communicate between independently written applications.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/history",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-pubsub",

--- a/java-rapidmigrationassessment/.repo-metadata.json
+++ b/java-rapidmigrationassessment/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Rapid Migration Assessment API",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-rapidmigrationassessment/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-rapidmigrationassessment",

--- a/java-recommendations-ai/.repo-metadata.json
+++ b/java-recommendations-ai/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "delivers highly personalized product recommendations at scale.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-recommendations-ai/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-recommendations-ai",

--- a/java-recommender/.repo-metadata.json
+++ b/java-recommender/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "delivers highly personalized product recommendations at scale.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-recommender/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-recommender",

--- a/java-redis-cluster/.repo-metadata.json
+++ b/java-redis-cluster/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Creates and manages Redis instances on the Google Cloud Platform.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-redis-cluster/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-redis-cluster",

--- a/java-redis/.repo-metadata.json
+++ b/java-redis/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a fully managed Redis service for the Google Cloud. Applications running on Google Cloud can achieve extreme performance by leveraging the highly scalable, available, secure Redis service without the burden of managing complex Redis deployments.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-redis/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-redis",

--- a/java-resourcemanager/.repo-metadata.json
+++ b/java-resourcemanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "enables you to programmatically manage resources by project, folder, and organization.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-resourcemanager/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-resourcemanager",

--- a/java-retail/.repo-metadata.json
+++ b/java-retail/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Retail solutions API.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-retail/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-retail",

--- a/java-run/.repo-metadata.json
+++ b/java-run/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a managed compute platform that enables you to run containers that are invocable via requests or events.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-run/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-run",

--- a/java-saasservicemgmt/.repo-metadata.json
+++ b/java-saasservicemgmt/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Model, deploy, and operate your SaaS at scale.\t",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-saasservicemgmt/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-saasservicemgmt",

--- a/java-scheduler/.repo-metadata.json
+++ b/java-scheduler/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "lets you set up scheduled units of work to be executed at defined times or regular intervals. These work units are commonly known as cron jobs. Typical use cases might include sending out a report email on a daily basis, updating some cached data every 10 minutes, or updating some summary information once an hour.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-scheduler/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-scheduler",

--- a/java-secretmanager/.repo-metadata.json
+++ b/java-secretmanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to encrypt, store, manage, and audit infrastructure and application-level secrets.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-secretmanager/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-secretmanager",

--- a/java-securesourcemanager/.repo-metadata.json
+++ b/java-securesourcemanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Regionally deployed, single-tenant managed source code repository hosted on\n    Google Cloud.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-securesourcemanager/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-securesourcemanager",

--- a/java-security-private-ca/.repo-metadata.json
+++ b/java-security-private-ca/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "simplifies the deployment and management of private CAs without managing infrastructure.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-security-private-ca/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-security-private-ca",

--- a/java-securitycenter/.repo-metadata.json
+++ b/java-securitycenter/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "makes it easier for you to prevent, detect, and respond to threats. Identify security misconfigurations in virtual machines, networks, applications, and storage buckets from a centralized dashboard. Take action on them before they can potentially result in business damage or loss. Built-in capabilities can quickly surface suspicious activity in your Stackdriver security logs or indicate compromised virtual machines. Respond to threats by following actionable recommendations or exporting logs to your SIEM for further investigation.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-securitycenter/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-securitycenter",

--- a/java-securitycentermanagement/.repo-metadata.json
+++ b/java-securitycentermanagement/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Security Center Management API",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-securitycentermanagement/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-securitycentermanagement",

--- a/java-securityposture/.repo-metadata.json
+++ b/java-securityposture/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Security Posture is a comprehensive framework of policy sets that empowers organizations to define, assess early, deploy, and monitor their security measures in a unified way and helps simplify governance and reduces administrative toil.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-securityposture/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-securityposture",

--- a/java-service-control/.repo-metadata.json
+++ b/java-service-control/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": " is a foundational platform for creating, managing, securing, and consuming APIs and services across organizations. It is used by Google APIs, Cloud APIs, Cloud Endpoints, and API Gateway.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-service-control/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-service-control",

--- a/java-service-management/.repo-metadata.json
+++ b/java-service-management/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a foundational platform for creating, managing, securing, and consuming APIs and services across organizations. It is used by Google APIs, Cloud APIs, Cloud Endpoints, and API Gateway. Service Infrastructure provides a wide range of features to service consumers and service producers, including authentication, authorization, auditing, rate limiting, analytics, billing, logging, and monitoring.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-service-management/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-service-management",

--- a/java-service-usage/.repo-metadata.json
+++ b/java-service-usage/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is an infrastructure service of Google Cloud that lets you list and manage other APIs and services in your Cloud projects.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-service-usage/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-service-usage",

--- a/java-servicedirectory/.repo-metadata.json
+++ b/java-servicedirectory/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows the registration and lookup of service endpoints.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-servicedirectory/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-servicedirectory",

--- a/java-servicehealth/.repo-metadata.json
+++ b/java-servicehealth/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Personalized Service Health helps you gain visibility into disruptive events impacting Google Cloud products.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-servicehealth/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-servicehealth",

--- a/java-shell/.repo-metadata.json
+++ b/java-shell/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is an interactive shell environment for Google Cloud that makes it easy for you to learn and experiment with Google Cloud and manage your projects and resources from your web browser.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-shell/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shell",

--- a/java-shopping-css/.repo-metadata.json
+++ b/java-shopping-css/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The CSS API is used to manage your CSS and control your CSS Products portfolio",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-css/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-css",

--- a/java-shopping-merchant-accounts/.repo-metadata.json
+++ b/java-shopping-merchant-accounts/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-accounts/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-accounts",

--- a/java-shopping-merchant-conversions/.repo-metadata.json
+++ b/java-shopping-merchant-conversions/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-conversions/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-conversions",

--- a/java-shopping-merchant-datasources/.repo-metadata.json
+++ b/java-shopping-merchant-datasources/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-datasources/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-datasources",

--- a/java-shopping-merchant-inventories/.repo-metadata.json
+++ b/java-shopping-merchant-inventories/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-inventories/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-inventories",

--- a/java-shopping-merchant-lfp/.repo-metadata.json
+++ b/java-shopping-merchant-lfp/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-lfp/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-lfp",

--- a/java-shopping-merchant-notifications/.repo-metadata.json
+++ b/java-shopping-merchant-notifications/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-notifications/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-notifications",

--- a/java-shopping-merchant-product-studio/.repo-metadata.json
+++ b/java-shopping-merchant-product-studio/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your products.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-productstudio/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-product-studio",

--- a/java-shopping-merchant-products/.repo-metadata.json
+++ b/java-shopping-merchant-products/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-products/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-products",

--- a/java-shopping-merchant-promotions/.repo-metadata.json
+++ b/java-shopping-merchant-promotions/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-promotions/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-promotions",

--- a/java-shopping-merchant-quota/.repo-metadata.json
+++ b/java-shopping-merchant-quota/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-quota/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-quota",

--- a/java-shopping-merchant-reports/.repo-metadata.json
+++ b/java-shopping-merchant-reports/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-reports/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-reports",

--- a/java-shopping-merchant-reviews/.repo-metadata.json
+++ b/java-shopping-merchant-reviews/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Programmatically manage your Merchant Center Accounts.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-shopping-merchant-reviews/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-shopping-merchant-reviews",

--- a/java-showcase/.repo-metadata.json
+++ b/java-showcase/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Showcase module",
   "client_documentation": "https://cloud.google.com/java/docs/reference/gapic-showcase/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-showcase",

--- a/java-spanneradapter/.repo-metadata.json
+++ b/java-spanneradapter/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Cloud Spanner Adapter service allows native drivers of supported     database dialects to interact directly with Cloud Spanner by wrapping the underlying     wire protocol used by the driver in a gRPC stream.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-spanneradapter/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-spanneradapter",

--- a/java-speech/.repo-metadata.json
+++ b/java-speech/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "enables easy integration of Google speech recognition technologies into developer applications. Send audio and receive a text transcription from the Speech-to-Text API service.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-speech/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-speech",

--- a/java-storage-transfer/.repo-metadata.json
+++ b/java-storage-transfer/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Secure, low-cost services for transferring data from cloud or on-premises sources.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-storage-transfer/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-storage-transfer",

--- a/java-storage/.repo-metadata.json
+++ b/java-storage/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a durable and highly available object storage service. Google Cloud Storage is almost infinitely scalable and guarantees consistency: when a write succeeds, the latest copy of the object will be returned to any GET, globally.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-storage/latest/history",
   "release_level": "stable",
-  "transport": "http",
+  "transport": "rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-storage",

--- a/java-storagebatchoperations/.repo-metadata.json
+++ b/java-storagebatchoperations/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Storage batch operations is a Cloud Storage management feature that performs operations on billions of Cloud Storage objects in a serverless manner.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-storagebatchoperations/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-storagebatchoperations",

--- a/java-storageinsights/.repo-metadata.json
+++ b/java-storageinsights/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Provides insights capability on Google Cloud Storage",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-storageinsights/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-storageinsights",

--- a/java-talent/.repo-metadata.json
+++ b/java-talent/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to transform your job search and candidate matching capabilities with Cloud Talent Solution, designed to support enterprise talent acquisition technology and evolve with your growing needs. This AI solution includes features such as Job Search and Profile Search (Beta) to provide candidates and employers with an enhanced talent acquisition experience. Learn more about Cloud Talent Solution from the product overview page.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-talent/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-talent",

--- a/java-tasks/.repo-metadata.json
+++ b/java-tasks/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "a fully managed service that allows you to manage the execution, dispatch and delivery of a large number of distributed tasks. You can asynchronously perform work outside of a user request. Your tasks can be executed on App Engine or any arbitrary HTTP endpoint.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-tasks/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-tasks",

--- a/java-telcoautomation/.repo-metadata.json
+++ b/java-telcoautomation/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "APIs to automate 5G deployment and management of cloud infrastructure and network functions.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-telcoautomation/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-telcoautomation",

--- a/java-texttospeech/.repo-metadata.json
+++ b/java-texttospeech/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "enables easy integration of Google text recognition technologies into developer applications. Send text and receive synthesized audio output from the Cloud Text-to-Speech API service.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-texttospeech/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-texttospeech",

--- a/java-tpu/.repo-metadata.json
+++ b/java-tpu/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "are Google's custom-developed application-specific integrated circuits (ASICs) used to accelerate machine learning workloads.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-tpu/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-tpu",

--- a/java-trace/.repo-metadata.json
+++ b/java-trace/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console. You can track how requests propagate through your application and receive detailed near real-time performance insights.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-trace/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-trace",

--- a/java-translate/.repo-metadata.json
+++ b/java-translate/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "can dynamically translate text between thousands of language pairs. Translation lets websites and programs programmatically integrate with the translation service.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-translate/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-translate",

--- a/java-valkey/.repo-metadata.json
+++ b/java-valkey/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Memorystore for Valkey is a fully managed Valkey Cluster service for Google Cloud.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-memorystore/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-valkey",

--- a/java-vectorsearch/.repo-metadata.json
+++ b/java-vectorsearch/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Vector Search API provides a fully-managed, highly performant, and scalable vector database designed to power next-generation search, recommendation, and generative AI applications. It allows you to store, index, and query your data and its corresponding vector embeddings through a simple, intuitive interface. With Vector Search, you can define custom schemas for your data, insert objects with associated metadata, automatically generate embeddings from your data, and perform fast approximate nearest neighbor (ANN) searches to find semantically similar items at scale.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-vectorsearch/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-vectorsearch",

--- a/java-video-intelligence/.repo-metadata.json
+++ b/java-video-intelligence/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows developers to use Google video analysis technology as part of their applications.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-video-intelligence/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-video-intelligence",

--- a/java-video-live-stream/.repo-metadata.json
+++ b/java-video-live-stream/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "transcodes mezzanine live signals into direct-to-consumer streaming formats, including Dynamic Adaptive Streaming over HTTP (DASH/MPEG-DASH), and HTTP Live Streaming (HLS), for multiple device platforms.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-live-stream/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-video-live-stream",

--- a/java-video-transcoder/.repo-metadata.json
+++ b/java-video-transcoder/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to transcode videos into a variety of formats. The Transcoder API benefits broadcasters, production companies, businesses, and individuals looking to transform their video content for use across a variety of user devices.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-video-transcoder/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-video-transcoder",

--- a/java-vision/.repo-metadata.json
+++ b/java-vision/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows developers to easily integrate vision detection features within applications, including image labeling, face and landmark detection, optical character recognition (OCR), and tagging of explicit content.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-vision/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-vision",

--- a/java-visionai/.repo-metadata.json
+++ b/java-visionai/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Vertex AI Vision is an AI-powered platform to ingest, analyze and store video data.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-visionai/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-visionai",

--- a/java-vmmigration/.repo-metadata.json
+++ b/java-vmmigration/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "helps customers migrating VMs to GCP at no additional cost, as well as an extensive ecosystem of partners to help with discovery and assessment, planning, migration, special use cases, and more.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-vmmigration/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-vmmigration",

--- a/java-vmwareengine/.repo-metadata.json
+++ b/java-vmwareengine/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Easily lift and shift your VMware-based applications to Google Cloud without changes to your apps, tools, or processes.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-vmwareengine/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-vmwareengine",

--- a/java-vpcaccess/.repo-metadata.json
+++ b/java-vpcaccess/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "enables you to connect from a serverless environment on Google Cloud directly to your VPC network. This connection makes it possible for your serverless environment to access resources in your VPC network via internal IP addresses.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-vpcaccess/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-vpcaccess",

--- a/java-webrisk/.repo-metadata.json
+++ b/java-webrisk/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "is a Google Cloud service that lets client applications check URLs against Google's constantly updated lists of unsafe web resources. Unsafe web resources include social engineering sites - such as phishing and deceptive sites - and sites that host malware or unwanted software. With the Web Risk API, you can quickly identify known bad sites, warn users before they click infected links, and prevent users from posting links to known infected pages from your site. The Web Risk API includes data on more than a million unsafe URLs and stays up to date by examining billions of URLs each day.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-webrisk/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-webrisk",

--- a/java-websecurityscanner/.repo-metadata.json
+++ b/java-websecurityscanner/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "identifies security vulnerabilities in your App Engine, Compute Engine, and Google Kubernetes Engine web applications. It crawls your application, following all links within the scope of your starting URLs, and attempts to exercise as many user inputs and event handlers as possible.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-websecurityscanner/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-websecurityscanner",

--- a/java-workflow-executions/.repo-metadata.json
+++ b/java-workflow-executions/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to ochestrate and automate Google Cloud and HTTP-based API services with serverless workflows.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-workflow-executions/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-workflow-executions",

--- a/java-workflows/.repo-metadata.json
+++ b/java-workflows/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "allows you to ochestrate and automate Google Cloud and HTTP-based API services with serverless workflows.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-workflows/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-workflows",

--- a/java-workloadmanager/.repo-metadata.json
+++ b/java-workloadmanager/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Workload Manager is a service that provides tooling for enterprise workloads to automate the deployment and validation of your workloads against best practices and recommendations.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-workloadmanager/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-workloadmanager",

--- a/java-workspaceevents/.repo-metadata.json
+++ b/java-workspaceevents/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "The Google Workspace Events API lets you subscribe to events and manage change notifications across Google Workspace applications.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-workspaceevents/latest/overview",
   "release_level": "preview",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-workspaceevents",

--- a/java-workstations/.repo-metadata.json
+++ b/java-workstations/.repo-metadata.json
@@ -5,7 +5,7 @@
   "api_description": "Fully managed development environments built to meet the needs of security-sensitive enterprises. It enhances the security of development environments while accelerating developer onboarding and productivity.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/google-cloud-workstations/latest/overview",
   "release_level": "stable",
-  "transport": "both",
+  "transport": "grpc+rest",
   "language": "java",
   "repo": "googleapis/google-cloud-java",
   "repo_short": "java-workstations",

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.22.0
+version: v0.23.1-0.20260701125507-b8e50a51a11c
 repo: googleapis/google-cloud-java
 sources:
   googleapis:

--- a/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/README.md
+++ b/sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/README.md
@@ -157,9 +157,9 @@ To get help, follow the instructions in the [shared Troubleshooting document][tr
 
 {% if metadata['repo']['transport'] == 'grpc' -%}
 {{metadata['repo']['name_pretty']}} uses gRPC for the transport layer.
-{% elif metadata['repo']['transport'] == 'http' -%}
+{% elif metadata['repo']['transport'] in ['http', 'rest'] -%}
 {{metadata['repo']['name_pretty']}} uses HTTP/JSON for the transport layer.
-{% elif metadata['repo']['transport'] == 'both' -%}
+{% elif metadata['repo']['transport'] in ['both', 'grpc+rest'] -%}
 {{metadata['repo']['name_pretty']}} uses both gRPC and HTTP/JSON for the transport layer.
 {% endif %}
 {% endif -%}


### PR DESCRIPTION
Update librarian version that includes:
- https://github.com/googleapis/librarian/pull/6601.
- https://github.com/googleapis/librarian/pull/6582 (for this change, added a fix in README template [7522f3b](https://github.com/googleapis/google-cloud-java/pull/13619/commits/7522f3b361574faefa18d3f0a874481b141b2a1c))

Created with command below plus a manual fix in [7522f3b](https://github.com/googleapis/google-cloud-java/pull/13619/commits/7522f3b361574faefa18d3f0a874481b141b2a1c)
```
# update librarian version used in librarian.yaml
PSEUDO=$(GOPROXY=direct go list -m -f '{{.Version}}' github.com/googleapis/librarian@main)
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
go run github.com/googleapis/librarian/cmd/librarian@${V} config set version $PSEUDO

# regenerate all
go run github.com/googleapis/librarian/cmd/librarian@${V} generate -all
```

Fixes https://github.com/googleapis/google-cloud-java/issues/13609