### PR TITLE
Revert "chore(java-cloud-bom): register libraries-bom in root release-please-config (#13610)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,10 +23,6 @@
         "sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg",
         "java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/telemetry/Version.java"
       ]
-    },
-    "java-cloud-bom": {
-      "component": "libraries-bom",
-      "include-component-in-tag": true
     }
   }
 }


### PR DESCRIPTION
This reverts commit e54452f524057e62223743cfe66192f6b45d03f9. We want to keep only one versions.txt file at the root, so we cannot register java-cloud-bom as a separate package since it would require its own versions.txt for Yoshi strategies.