### PR TITLE
chore(java-cloud-bom): remove redundant filter job in release notes workflow

### DIFF
--- a/.github/workflows/java-cloud-bom-release-note-generation.yaml
+++ b/.github/workflows/java-cloud-bom-release-note-generation.yaml
@@ -13,21 +13,8 @@ name: java-cloud-bom release-notes
 env:
   BUILD_SUBDIR: java-cloud-bom
 jobs:
-  filter:
-    runs-on: ubuntu-latest
-    outputs:
-      library: ${{ steps.filter.outputs.library }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          library:
-            - 'java-cloud-bom/**'
   release-note-generation:
-    needs: filter
-    if: ${{ needs.filter.outputs.library == 'true' && (github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'libraries-bom/')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'libraries-bom/') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR removes the redundant `filter` job (which was checking for modified paths under `java-cloud-bom/`) from the release notes generation workflow. Since we now explicitly filter tag triggers by the prefix `libraries-bom/`, the path-filtering job is redundant.