### PR TITLE
chore: Update to use google-cloud-java tag for gapic-libraries-bom

### DIFF
--- a/java-cloud-bom/google-cloud-bom/pom.xml
+++ b/java-cloud-bom/google-cloud-bom/pom.xml
@@ -172,7 +172,7 @@
         <!-- Artifacts from google-cloud-java monorepo -->
         <groupId>com.google.cloud</groupId>
         <artifactId>gapic-libraries-bom</artifactId>
-        <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:gapic-libraries:current} -->
+        <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
From error in: https://github.com/googleapis/google-cloud-java/actions/runs/28532515130/job/84585745890?pr=13624