### PR TITLE
fix(bigtable): honour session_load override when server-returned session_load is 0

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManager.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManager.java
@@ -395,8 +395,10 @@ public class ClientConfigurationManager implements AutoCloseable {
     // Inject overrides
     overrideConfig.ifPresent(builder::mergeFrom);
 
-    // When sessions are disabled make sure to clear out the config
-    if (cfg.getSessionConfiguration().getSessionLoad() == 0) {
+    // When sessions are disabled make sure to clear out the config. Read from the builder, not
+    // cfg, so that a nonzero session_load supplied via the override sys-prop is honoured even when
+    // the server-returned config has session_load=0.
+    if (builder.getSessionConfiguration().getSessionLoad() == 0) {
       builder.clearSessionConfiguration();
       return builder.build();
     }

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
@@ -196,6 +196,43 @@ class ClientConfigurationManagerTest {
         .isEqualToDefaultInstance();
   }
 
+  @Test
+  void testDisabledSessionsOverriddenBySysProp()
+      throws ExecutionException, InterruptedException, IOException {
+    // Server returns session_load=0 (sessions disabled from the server's perspective)…
+    ClientConfiguration.Builder disabledBuilder = manager.getDefaultConfig().toBuilder();
+    disabledBuilder.getSessionConfigurationBuilder().setSessionLoad(0);
+    service.config.set(disabledBuilder.build());
+
+    // …but a sys-prop override forces session_load>0 to opt this client into sessions.
+    manager.close();
+    String clientConfigOverrides =
+        TextFormat.printer()
+            .printToString(
+                ClientConfiguration.newBuilder()
+                    .setSessionConfiguration(
+                        SessionClientConfiguration.newBuilder().setSessionLoad(0.75f))
+                    .build());
+    Properties sysProps = new Properties();
+    sysProps.setProperty(ClientConfigurationManager.OVERRIDE_SYS_PROP_KEY, clientConfigOverrides);
+    manager =
+        new ClientConfigurationManager(
+            sysProps, FEATURE_FLAGS, CLIENT_INFO, channelProvider, noopDebugTracer, mockExecutor);
+
+    ClientConfiguration resolvedConfig = manager.start().get();
+
+    // The override must be honoured: session_load and the default SessionPoolConfiguration must
+    // survive normalization instead of being cleared as if sessions were disabled.
+    assertThat(resolvedConfig.getSessionConfiguration().getSessionLoad()).isEqualTo(0.75f);
+    assertThat(resolvedConfig.getSessionConfiguration().getSessionPoolConfiguration())
+        .isEqualTo(
+            manager
+                .getDefaultConfig()
+                .getSessionConfiguration()
+                .getSessionPoolConfiguration());
+    assertThat(manager.areSessionsRequired()).isTrue();
+  }
+
   @Deprecated
   @Test
   void testMigrateSessionPool() throws ExecutionException, InterruptedException {

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
@@ -226,10 +226,7 @@ class ClientConfigurationManagerTest {
     assertThat(resolvedConfig.getSessionConfiguration().getSessionLoad()).isEqualTo(0.75f);
     assertThat(resolvedConfig.getSessionConfiguration().getSessionPoolConfiguration())
         .isEqualTo(
-            manager
-                .getDefaultConfig()
-                .getSessionConfiguration()
-                .getSessionPoolConfiguration());
+            manager.getDefaultConfig().getSessionConfiguration().getSessionPoolConfiguration());
     assertThat(manager.areSessionsRequired()).isTrue();
   }
 


### PR DESCRIPTION
## Summary

- `ClientConfigurationManager.normalizeConfig()` overlays the sys-prop override into the builder, then guards a "clear session_configuration when disabled" branch on `session_load`. The guard was reading `cfg` (the original server response), not the merged builder, so any client that supplied a nonzero `session_load` via the `bigtable.internal.client-config-override` sys-prop still had its entire `session_configuration` wiped whenever the server returned `session_load=0`.
- In practice: such clients ran with no sessions pre-started, `DynamicPicker` logged `LOADBALANCINGSTRATEGY_NOT_SET`, and every RPC fell through to the old stack — silently invalidating any local session validation using the override.
- Fix: read `session_load` from the merged builder so the override is respected. Bug has been present since the initial commit of the session protocol stack (#2862).

## Test plan

- [x] New regression test `ClientConfigurationManagerTest#testDisabledSessionsOverriddenBySysProp` — server returns `session_load=0` + sys-prop override sets `session_load=0.75`; asserts the effective config keeps the override's `session_load` and the default `SessionPoolConfiguration`, and that `areSessionsRequired()` is true. Verified the test fails on the unfixed code (`expected 0.75 but was 0.0`) and passes with the fix.
- [x] Full `ClientConfigurationManagerTest` suite passes.