### PR TITLE
chore(ci): exclude java-vertexai from existing versions check

### DIFF
--- a/generation/check_existing_release_versions.sh
+++ b/generation/check_existing_release_versions.sh
@@ -44,7 +44,7 @@ function find_existing_version_pom() {
 return_code=0
 
 for pom_file in $(find . -maxdepth 3 -name pom.xml|sort --dictionary-order); do
-  if [[ "${pom_file}" == *java-samples* || "${pom_file}" == *showcase* || "${pom_file}" == *coverage-report* || "${pom_file}" == *sdk-platform-java/pom.xml ]]; then
+  if [[ "${pom_file}" == *java-samples* || "${pom_file}" == *showcase* || "${pom_file}" == *coverage-report* || "${pom_file}" == *sdk-platform-java/pom.xml || "${pom_file}" == *java-vertexai* ]]; then
       continue
   fi
   find_existing_version_pom "${pom_file}"

--- a/generation/check_existing_release_versions.sh
+++ b/generation/check_existing_release_versions.sh
@@ -44,6 +44,9 @@ function find_existing_version_pom() {
 return_code=0
 
 for pom_file in $(find . -maxdepth 3 -name pom.xml|sort --dictionary-order); do
+  # Exclude java-vertexai because it has been archived and replaced with a dummy POM.
+  # We do not plan to release any new versions for it, so we don't want to check if its
+  # version (which already exists) is a duplicate.
   if [[ "${pom_file}" == *java-samples* || "${pom_file}" == *showcase* || "${pom_file}" == *coverage-report* || "${pom_file}" == *sdk-platform-java/pom.xml || "${pom_file}" == *java-vertexai* ]]; then
       continue
   fi


### PR DESCRIPTION
The java-vertexai library has been archived/deprecated and replaced with a dummy POM. We do not plan to release any new versions for it, so it should be excluded from the existing versions check in CI.

TAG=agy
CONV=f8eb6315-206b-49b6-ac81-b3d05af93c38