### PR TITLE
chore: update librarian version and generated code change

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>google-cloud-pom-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 

--- a/java-agentregistry/google-cloud-agentregistry-bom/pom.xml
+++ b/java-agentregistry/google-cloud-agentregistry-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pom-parent</artifactId>
-    <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 

--- a/java-cloud-bom/tests/validate-bom/pom.xml
+++ b/java-cloud-bom/tests/validate-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pom-parent</artifactId>
-    <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.88.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../../../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.23.1-0.20260701125507-b8e50a51a11c
+version: v0.24.1-0.20260701202128-6037497ba994
 repo: googleapis/google-cloud-java
 sources:
   googleapis:


### PR DESCRIPTION
This is last step in setting up `google-cloud-pom-parent` version separately from `google-cloud-java`, so that in partial releases they can be updated separately.

Updated release please marker in 2 more pom.xmls in [5670129](https://github.com/googleapis/google-cloud-java/pull/13635/commits/567012901d0a238acd3d46d954713249106c38c2). One is new from recent merged in libraries bom, the other is new library added after the [bulk change pr](https://github.com/googleapis/google-cloud-java/pull/13483).

Fixes https://github.com/googleapis/librarian/issues/6411