### PR TITLE
fix(ci): build dependencies before convergence check

### DIFF
--- a/.kokoro/dashboard.sh
+++ b/.kokoro/dashboard.sh
@@ -25,6 +25,8 @@ if [[ "${JOB_TYPE}" == "dashboard-units-check" ]]; then
   echo -e "\n******************** BUILDING THE DASHBOARD ********************"
   mvn test --fail-at-end
 elif [[ "${JOB_TYPE}" == "dependency-convergence-check" ]]; then
+  echo -e "\n******************** BUILDING DEPENDENCIES ********************"
+  mvn install -pl java-cloud-bom/tests/dependency-convergence -am -Pquick-build -DskipTests
   cd java-cloud-bom/tests/dependency-convergence/
   echo -e "\n******************** RUNNING DEPENDENCY CONVERGENCE CHECK ********************"
   mvn validate --fail-at-end

--- a/.kokoro/dashboard.sh
+++ b/.kokoro/dashboard.sh
@@ -26,7 +26,7 @@ if [[ "${JOB_TYPE}" == "dashboard-units-check" ]]; then
   mvn test --fail-at-end
 elif [[ "${JOB_TYPE}" == "dependency-convergence-check" ]]; then
   echo -e "\n******************** BUILDING DEPENDENCIES ********************"
-  mvn install -pl java-cloud-bom/tests/dependency-convergence -am -Pquick-build -DskipTests
+  mvn install -pl java-cloud-bom/tests/dependency-convergence -am -Pquick-build -DskipTests -Denforcer.skip=true
   cd java-cloud-bom/tests/dependency-convergence/
   echo -e "\n******************** RUNNING DEPENDENCY CONVERGENCE CHECK ********************"
   mvn validate --fail-at-end


### PR DESCRIPTION
Build dependencies of the dependency-convergence-check project before running the validation.