### PR TITLE
fix(ci): ignore SNAPSHOT suffix in flatten-plugin check

### DIFF
--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -146,11 +146,17 @@ flatten-plugin)
     ../.kokoro/build.sh
     echo "After running ../.kokoro/build.sh"
     pushd ${LIBRARY_NAME}
-    mvn dependency:list -f .flattened-pom.xml -DincludeScope=runtime -Dsort=true \
+    mvn -B -ntp dependency:list -f .flattened-pom.xml -DincludeScope=runtime -Dsort=true \
         | grep '\[INFO]    .*:.*:.*:.*:.*' |awk '{print $2}' > .actual-flattened-dependencies-list.txt
-    echo "Diff from the expected file (${EXPECTED_DEPENDENCIES_LIST}):"
-    diff "${scriptDir}/${EXPECTED_DEPENDENCIES_LIST}" .actual-flattened-dependencies-list.txt
+    
+    # Strip -SNAPSHOT for comparison to support release PRs where dependencies are bumped to release versions
+    sed 's/-SNAPSHOT//g' "${scriptDir}/${EXPECTED_DEPENDENCIES_LIST}" > .expected-stripped.txt
+    sed 's/-SNAPSHOT//g' .actual-flattened-dependencies-list.txt > .actual-stripped.txt
+    
+    echo "Diff from the expected file (${EXPECTED_DEPENDENCIES_LIST}) (ignoring -SNAPSHOT):"
+    diff .expected-stripped.txt .actual-stripped.txt
     RETURN_CODE=$?
+    rm .expected-stripped.txt .actual-stripped.txt
     if [ "${RETURN_CODE}" == 0 ]; then
       echo "No diff."
     else

--- a/.kokoro/client-library-check.sh
+++ b/.kokoro/client-library-check.sh
@@ -150,13 +150,9 @@ flatten-plugin)
         | grep '\[INFO]    .*:.*:.*:.*:.*' |awk '{print $2}' > .actual-flattened-dependencies-list.txt
     
     # Strip -SNAPSHOT for comparison to support release PRs where dependencies are bumped to release versions
-    sed 's/-SNAPSHOT//g' "${scriptDir}/${EXPECTED_DEPENDENCIES_LIST}" > .expected-stripped.txt
-    sed 's/-SNAPSHOT//g' .actual-flattened-dependencies-list.txt > .actual-stripped.txt
-    
     echo "Diff from the expected file (${EXPECTED_DEPENDENCIES_LIST}) (ignoring -SNAPSHOT):"
-    diff .expected-stripped.txt .actual-stripped.txt
+    diff <(sed 's/-SNAPSHOT//g' "${scriptDir}/${EXPECTED_DEPENDENCIES_LIST}") <(sed 's/-SNAPSHOT//g' .actual-flattened-dependencies-list.txt)
     RETURN_CODE=$?
-    rm .expected-stripped.txt .actual-stripped.txt
     if [ "${RETURN_CODE}" == 0 ]; then
       echo "No diff."
     else


### PR DESCRIPTION
Ignore the `-SNAPSHOT` suffix when comparing the actual flattened dependencies with the expected dependencies. This prevents false positives during release PRs when dependencies are temporarily bumped to release versions.