### PR TITLE
chore(ci): Bom-Content-Test checks local Maven cache first

### DIFF
--- a/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -148,8 +148,8 @@ public class BomContentTest {
   }
 
   /**
-   * Checks if the artifact exists in the local Maven repository cache.
-   * This is used as a fallback/bypass for reachability checks during release PRs.
+   * Checks if the artifact exists in the local Maven repository cache. This is used as a
+   * fallback/bypass for reachability checks during release PRs.
    */
   private static boolean existsLocally(Artifact artifact) {
     String localRepository = System.getProperty("maven.repo.local");
@@ -157,11 +157,13 @@ public class BomContentTest {
       // Standard default location for Maven local repository.
       localRepository = System.getProperty("user.home") + "/.m2/repository";
     }
-    Path localPath = Paths.get(localRepository,
-        artifact.getGroupId().replace('.', '/'),
-        artifact.getArtifactId(),
-        artifact.getVersion(),
-        artifact.getArtifactId() + "-" + artifact.getVersion() + ".pom");
+    Path localPath =
+        Paths.get(
+            localRepository,
+            artifact.getGroupId().replace('.', '/'),
+            artifact.getArtifactId(),
+            artifact.getVersion(),
+            artifact.getArtifactId() + "-" + artifact.getVersion() + ".pom");
     return Files.exists(localPath);
   }
 

--- a/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -155,7 +155,6 @@ public class BomContentTest {
     String localRepository = System.getProperty("maven.repo.local");
     if (localRepository == null) {
       // Standard default location for Maven local repository.
-      // GHA runners also use this path by default (cached by actions/setup-java).
       localRepository = System.getProperty("user.home") + "/.m2/repository";
     }
     Path localPath = Paths.get(localRepository,

--- a/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -154,8 +154,12 @@ public class BomContentTest {
   private static boolean existsLocally(Artifact artifact) {
     String localRepository = System.getProperty("maven.repo.local");
     if (localRepository == null) {
+      String userHome = System.getProperty("user.home");
+      if (userHome == null) {
+        return false;
+      }
       // Standard default location for Maven local repository.
-      localRepository = System.getProperty("user.home") + "/.m2/repository";
+      localRepository = userHome + "/.m2/repository";
     }
     Path localPath =
         Paths.get(

--- a/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -76,6 +77,9 @@ public class BomContentTest {
       if (artifact.getVersion().contains("SNAPSHOT")) {
         continue;
       }
+      if (existsLocally(artifact)) {
+        continue;
+      }
       assertReachable(buildMavenCentralUrl(artifact));
     }
 
@@ -102,6 +106,9 @@ public class BomContentTest {
     StringBuilder errors = new StringBuilder();
     for (Artifact artifact : artifacts) {
       if (artifact.getVersion().contains("SNAPSHOT")) {
+        continue;
+      }
+      if (existsLocally(artifact)) {
         continue;
       }
       try {
@@ -132,6 +139,19 @@ public class BomContentTest {
         + "-"
         + artifact.getVersion()
         + ".pom";
+  }
+
+  private static boolean existsLocally(Artifact artifact) {
+    String localRepository = System.getProperty("maven.repo.local");
+    if (localRepository == null) {
+      localRepository = System.getProperty("user.home") + "/.m2/repository";
+    }
+    Path localPath = Paths.get(localRepository,
+        artifact.getGroupId().replace('.', '/'),
+        artifact.getArtifactId(),
+        artifact.getVersion(),
+        artifact.getArtifactId() + "-" + artifact.getVersion() + ".pom");
+    return Files.exists(localPath);
   }
 
   /** Asserts that the BOM only provides JARs which contains unique class names to the classpath. */

--- a/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
+++ b/java-cloud-bom/tests/src/test/java/com/google/cloud/BomContentTest.java
@@ -77,6 +77,9 @@ public class BomContentTest {
       if (artifact.getVersion().contains("SNAPSHOT")) {
         continue;
       }
+      // If the artifact is built locally (e.g. during a release PR), it will be in the local
+      // .m2 cache. We can skip checking Maven Central for these local artifacts since they
+      // are not yet published.
       if (existsLocally(artifact)) {
         continue;
       }
@@ -108,6 +111,9 @@ public class BomContentTest {
       if (artifact.getVersion().contains("SNAPSHOT")) {
         continue;
       }
+      // If the artifact is built locally (e.g. during a release PR), it will be in the local
+      // .m2 cache. We can skip checking Maven Central for these local artifacts since they
+      // are not yet published.
       if (existsLocally(artifact)) {
         continue;
       }
@@ -141,9 +147,15 @@ public class BomContentTest {
         + ".pom";
   }
 
+  /**
+   * Checks if the artifact exists in the local Maven repository cache.
+   * This is used as a fallback/bypass for reachability checks during release PRs.
+   */
   private static boolean existsLocally(Artifact artifact) {
     String localRepository = System.getProperty("maven.repo.local");
     if (localRepository == null) {
+      // Standard default location for Maven local repository.
+      // GHA runners also use this path by default (cached by actions/setup-java).
       localRepository = System.getProperty("user.home") + "/.m2/repository";
     }
     Path localPath = Paths.get(localRepository,


### PR DESCRIPTION
Modify `BomContentTest` to check if an artifact exists in the local Maven repository (`.m2`) before checking its reachability on Maven Central.

During release PRs, new versions of libraries are built and installed locally (via `pre-install.sh` and `validate-bom` canary project) but are not yet published to Maven Central. This change allows the reachability check to pass
for these new versions if they are found in the local cache, while still verifying that other dependencies (which should be on Central) are reachable.

This works with standard GHA runner setups (which use `~/.m2/repository` by default, cached by `actions/setup-java@v4` with `cache: 'maven'`) and also respects custom local repository locations if `maven.repo.local` is set. This removes the need for conditional flags in GHA workflows.