### PR TITLE
feat(spanner): add settings for gRCP keep-alive

### DIFF
--- a/java-spanner/google-cloud-spanner/pom.xml
+++ b/java-spanner/google-cloud-spanner/pom.xml
@@ -15,6 +15,7 @@
   </parent>
   <properties>
     <site.installationModule>google-cloud-spanner</site.installationModule>
+    <awaitility.version>4.3.0</awaitility.version>
     <opencensus.version>0.31.1</opencensus.version>
     <google.cloud.monitoring.version>3.85.0</google.cloud.monitoring.version>
     <spanner.testenv.config.class>com.google.cloud.spanner.GceTestEnvConfig</spanner.testenv.config.class>
@@ -432,6 +433,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -268,6 +268,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   private final InstanceAdminStubSettings instanceAdminStubSettings;
   private final DatabaseAdminStubSettings databaseAdminStubSettings;
   private final Duration partitionedDmlTimeout;
+  private final Duration grpcKeepAliveTime;
+  private final Duration grpcKeepAliveTimeout;
   private final boolean grpcGcpExtensionEnabled;
   private final GcpManagedChannelOptions grpcGcpOptions;
   private final boolean dynamicChannelPoolEnabled;
@@ -939,6 +941,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       throw SpannerExceptionFactory.newSpannerException(e);
     }
     partitionedDmlTimeout = builder.partitionedDmlTimeout;
+    grpcKeepAliveTime = builder.grpcKeepAliveTime;
+    grpcKeepAliveTimeout = builder.grpcKeepAliveTimeout;
     grpcGcpExtensionEnabled = builder.grpcGcpExtensionEnabled;
     grpcGcpOptions = builder.grpcGcpOptions;
 
@@ -1317,6 +1321,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     private Map<DatabaseId, QueryOptions> defaultQueryOptions = new HashMap<>();
     private boolean enableGrpcGcpOtelMetrics =
         SpannerOptions.environment.isEnableGrpcGcpOtelMetrics();
+    private Duration grpcKeepAliveTime = Duration.ofSeconds(120);
+    private Duration grpcKeepAliveTimeout = Duration.ofSeconds(20);
     private CallCredentialsProvider callCredentialsProvider;
     private CloseableExecutorProvider asyncExecutorProvider;
     private String compressorName;
@@ -1430,6 +1436,8 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
       this.enableGrpcGcpOtelMetrics = options.enableGrpcGcpOtelMetrics;
       this.defaultQueryOptions = options.defaultQueryOptions;
       this.callCredentialsProvider = options.callCredentialsProvider;
+      this.grpcKeepAliveTime = options.grpcKeepAliveTime;
+      this.grpcKeepAliveTimeout = options.grpcKeepAliveTimeout;
       this.asyncExecutorProvider = options.asyncExecutorProvider;
       this.compressorName = options.compressorName;
       this.channelProvider = options.channelProvider;
@@ -1689,6 +1697,32 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
      */
     public Builder setPartitionedDmlTimeoutDuration(Duration timeout) {
       this.partitionedDmlTimeout = timeout;
+      return this;
+    }
+
+    /**
+     * Sets the keep-alive time for gRPC connections. The default is 120 seconds. Note that the
+     * client-side keepalive time is clamped to a minimum of 10 seconds by gRPC.
+     */
+    public Builder setGrpcKeepAliveTime(Duration grpcKeepAliveTime) {
+      Preconditions.checkNotNull(grpcKeepAliveTime, "grpcKeepAliveTime cannot be null");
+      Preconditions.checkArgument(
+          !grpcKeepAliveTime.isNegative() && !grpcKeepAliveTime.isZero(),
+          "grpcKeepAliveTime must be positive");
+      this.grpcKeepAliveTime = grpcKeepAliveTime;
+      return this;
+    }
+
+    /**
+     * Sets the keep-alive timeout for gRPC connections. The default is 20 seconds. Note that the
+     * client-side keepalive timeout is clamped to a minimum of 20 milliseconds by gRPC.
+     */
+    public Builder setGrpcKeepAliveTimeout(Duration grpcKeepAliveTimeout) {
+      Preconditions.checkNotNull(grpcKeepAliveTimeout, "grpcKeepAliveTimeout cannot be null");
+      Preconditions.checkArgument(
+          !grpcKeepAliveTimeout.isNegative() && !grpcKeepAliveTimeout.isZero(),
+          "grpcKeepAliveTimeout must be positive");
+      this.grpcKeepAliveTimeout = grpcKeepAliveTimeout;
       return this;
     }
 
@@ -2491,6 +2525,14 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
   public Duration getPartitionedDmlTimeoutDuration() {
     return partitionedDmlTimeout;
+  }
+
+  public Duration getGrpcKeepAliveTime() {
+    return grpcKeepAliveTime;
+  }
+
+  public Duration getGrpcKeepAliveTimeout() {
+    return grpcKeepAliveTimeout;
   }
 
   public boolean isGrpcGcpExtensionEnabled() {

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionOptions.java
@@ -42,6 +42,8 @@ import static com.google.cloud.spanner.connection.ConnectionProperties.ENABLE_GR
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENCODED_CREDENTIALS;
 import static com.google.cloud.spanner.connection.ConnectionProperties.ENDPOINT;
 import static com.google.cloud.spanner.connection.ConnectionProperties.GRPC_INTERCEPTOR_PROVIDER;
+import static com.google.cloud.spanner.connection.ConnectionProperties.GRPC_KEEPALIVE_TIME;
+import static com.google.cloud.spanner.connection.ConnectionProperties.GRPC_KEEPALIVE_TIMEOUT;
 import static com.google.cloud.spanner.connection.ConnectionProperties.IS_EXPERIMENTAL_HOST;
 import static com.google.cloud.spanner.connection.ConnectionProperties.LENIENT;
 import static com.google.cloud.spanner.connection.ConnectionProperties.MAX_COMMIT_DELAY;
@@ -278,6 +280,12 @@ public class ConnectionOptions {
    * OAuth token to use for authentication. Cannot be used in combination with a credentials file.
    */
   public static final String OAUTH_TOKEN_PROPERTY_NAME = "oauthToken";
+
+  /** Name of the 'grpcKeepAliveTime' connection property. */
+  public static final String GRPC_KEEPALIVE_TIME_PROPERTY_NAME = "grpcKeepAliveTime";
+
+  /** Name of the 'grpcKeepAliveTimeout' connection property. */
+  public static final String GRPC_KEEPALIVE_TIMEOUT_PROPERTY_NAME = "grpcKeepAliveTimeout";
 
   /** Name of the 'minSessions' connection property. */
   public static final String MIN_SESSIONS_PROPERTY_NAME = "minSessions";
@@ -1081,6 +1089,16 @@ public class ConnectionOptions {
   /** The number of channels to use for the connection. */
   public Integer getNumChannels() {
     return getInitialConnectionPropertyValue(NUM_CHANNELS);
+  }
+
+  /** The gRPC keepalive time for this connection. */
+  public Duration getGrpcKeepAliveTime() {
+    return getInitialConnectionPropertyValue(GRPC_KEEPALIVE_TIME);
+  }
+
+  /** The gRPC keepalive timeout for this connection. */
+  public Duration getGrpcKeepAliveTimeout() {
+    return getInitialConnectionPropertyValue(GRPC_KEEPALIVE_TIMEOUT);
   }
 
   /** Whether dynamic channel pooling is enabled for this connection. */

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/ConnectionProperties.java
@@ -97,6 +97,8 @@ import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_GRPC_
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENABLE_GRPC_INTERCEPTOR_PROVIDER_SYSTEM_PROPERTY;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENCODED_CREDENTIALS_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.ENDPOINT_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.GRPC_KEEPALIVE_TIMEOUT_PROPERTY_NAME;
+import static com.google.cloud.spanner.connection.ConnectionOptions.GRPC_KEEPALIVE_TIME_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.IS_EXPERIMENTAL_HOST_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.KEEP_TRANSACTION_ALIVE_PROPERTY_NAME;
 import static com.google.cloud.spanner.connection.ConnectionOptions.LENIENT_PROPERTY_NAME;
@@ -252,6 +254,24 @@ public class ConnectionProperties {
           DEFAULT_USE_PLAIN_TEXT,
           BOOLEANS,
           BooleanConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Duration> GRPC_KEEPALIVE_TIME =
+      create(
+          GRPC_KEEPALIVE_TIME_PROPERTY_NAME,
+          "The keepalive time for gRPC connections (e.g. '120s', '20s'). "
+              + "Setting a lower keep-alive time (minimum 10s enforced by the gRPC library) "
+              + "helps detect disconnected connections faster.",
+          null,
+          DurationConverter.INSTANCE,
+          Context.STARTUP);
+  static final ConnectionProperty<Duration> GRPC_KEEPALIVE_TIMEOUT =
+      create(
+          GRPC_KEEPALIVE_TIMEOUT_PROPERTY_NAME,
+          "The keepalive timeout for gRPC connections (e.g. '20s', '5s'). "
+              + "This determines how long the client waits for a keep-alive ping response before terminating "
+              + "the connection. A lower timeout helps speed up recovery during network failures.",
+          null,
+          DurationConverter.INSTANCE,
           Context.STARTUP);
 
   /**

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/SpannerPool.java
@@ -32,6 +32,7 @@ import com.google.common.base.Ticker;
 import io.grpc.ManagedChannelBuilder;
 import io.opentelemetry.api.OpenTelemetry;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -151,6 +152,8 @@ public class SpannerPool {
   static class SpannerPoolKey {
     private final String host;
     private final String projectId;
+    private final Duration grpcKeepAliveTime;
+    private final Duration grpcKeepAliveTimeout;
     private final CredentialsKey credentialsKey;
     private final SessionPoolOptions sessionPoolOptions;
     private final Integer numChannels;
@@ -222,6 +225,8 @@ public class SpannerPool {
       this.enableDirectAccess = options.isEnableDirectAccess();
       this.universeDomain = options.getUniverseDomain();
       this.grpcInterceptorProvider = options.getGrpcInterceptorProviderName();
+      this.grpcKeepAliveTime = options.getGrpcKeepAliveTime();
+      this.grpcKeepAliveTimeout = options.getGrpcKeepAliveTimeout();
     }
 
     @Override
@@ -259,7 +264,9 @@ public class SpannerPool {
           && Objects.equals(this.instanceType, other.instanceType)
           && Objects.equals(this.enableDirectAccess, other.enableDirectAccess)
           && Objects.equals(this.universeDomain, other.universeDomain)
-          && Objects.equals(this.grpcInterceptorProvider, other.grpcInterceptorProvider);
+          && Objects.equals(this.grpcInterceptorProvider, other.grpcInterceptorProvider)
+          && Objects.equals(this.grpcKeepAliveTime, other.grpcKeepAliveTime)
+          && Objects.equals(this.grpcKeepAliveTimeout, other.grpcKeepAliveTimeout);
     }
 
     @Override
@@ -292,7 +299,9 @@ public class SpannerPool {
           this.instanceType,
           this.enableDirectAccess,
           this.universeDomain,
-          this.grpcInterceptorProvider);
+          this.grpcInterceptorProvider,
+          this.grpcKeepAliveTime,
+          this.grpcKeepAliveTimeout);
     }
   }
 
@@ -509,6 +518,12 @@ public class SpannerPool {
     }
     if (options.getChannelProvider() != null) {
       builder.setChannelProvider(options.getChannelProvider());
+    }
+    if (key.grpcKeepAliveTime != null) {
+      builder.setGrpcKeepAliveTime(key.grpcKeepAliveTime);
+    }
+    if (key.grpcKeepAliveTimeout != null) {
+      builder.setGrpcKeepAliveTimeout(key.grpcKeepAliveTimeout);
     }
     if (!options.isRouteToLeader()) {
       builder.disableLeaderAwareRouting();

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/GapicSpannerRpc.java
@@ -251,7 +251,6 @@ public class GapicSpannerRpc implements SpannerRpc {
       "com.google.cloud.spanner.watchdogPeriodSeconds";
   private static final int DEFAULT_TIMEOUT_SECONDS = 30 * 60;
   private static final int DEFAULT_PERIOD_SECONDS = 10;
-  private static final int GRPC_KEEPALIVE_SECONDS = 2 * 60;
   private static final String USER_AGENT_KEY = "user-agent";
   private static final String CLIENT_LIBRARY_LANGUAGE = "spanner-java";
   public static final String DEFAULT_USER_AGENT =
@@ -740,9 +739,10 @@ public class GapicSpannerRpc implements SpannerRpc {
             .setMaxInboundMetadataSize(MAX_METADATA_SIZE)
             .setPoolSize(options.getNumChannels())
 
-            // Set a keepalive time of 120 seconds to help long running
+            // Set a keepalive time to help long running
             // commit GRPC calls succeed
-            .setKeepAliveTimeDuration(Duration.ofSeconds(GRPC_KEEPALIVE_SECONDS))
+            .setKeepAliveTimeDuration(options.getGrpcKeepAliveTime())
+            .setKeepAliveTimeoutDuration(options.getGrpcKeepAliveTimeout())
 
             // Then check if SpannerOptions provides an InterceptorProvider. Create a default
             // SpannerInterceptorProvider if none is provided

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -1452,4 +1452,69 @@ public class SpannerOptionsTest {
     SpannerOptions options = builder.build();
     assertTrue(options.getCredentials() instanceof SpannerOmniCredentials);
   }
+
+  @Test
+  public void testGrpcKeepAliveTime() {
+    SpannerOptions defaultOptions =
+        SpannerOptions.newBuilder()
+            .setProjectId("test-project")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    assertEquals(Duration.ofSeconds(120), defaultOptions.getGrpcKeepAliveTime());
+
+    SpannerOptions customOptions =
+        SpannerOptions.newBuilder()
+            .setProjectId("test-project")
+            .setCredentials(NoCredentials.getInstance())
+            .setGrpcKeepAliveTime(Duration.ofSeconds(20))
+            .build();
+    assertEquals(Duration.ofSeconds(20), customOptions.getGrpcKeepAliveTime());
+
+    SpannerOptions optionsFromBuilder = customOptions.toBuilder().build();
+    assertEquals(Duration.ofSeconds(20), optionsFromBuilder.getGrpcKeepAliveTime());
+
+    assertThrows(
+        NullPointerException.class, () -> SpannerOptions.newBuilder().setGrpcKeepAliveTime(null));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SpannerOptions.newBuilder().setGrpcKeepAliveTime(Duration.ZERO));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SpannerOptions.newBuilder().setGrpcKeepAliveTime(Duration.ofSeconds(-10)));
+  }
+
+  @Test
+  public void testGrpcKeepAliveTimeout() {
+    SpannerOptions defaultOptions =
+        SpannerOptions.newBuilder()
+            .setProjectId("test-project")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    assertEquals(Duration.ofSeconds(20), defaultOptions.getGrpcKeepAliveTimeout());
+
+    SpannerOptions customOptions =
+        SpannerOptions.newBuilder()
+            .setProjectId("test-project")
+            .setCredentials(NoCredentials.getInstance())
+            .setGrpcKeepAliveTimeout(Duration.ofSeconds(5))
+            .build();
+    assertEquals(Duration.ofSeconds(5), customOptions.getGrpcKeepAliveTimeout());
+
+    SpannerOptions optionsFromBuilder = customOptions.toBuilder().build();
+    assertEquals(Duration.ofSeconds(5), optionsFromBuilder.getGrpcKeepAliveTimeout());
+
+    assertThrows(
+        NullPointerException.class,
+        () -> SpannerOptions.newBuilder().setGrpcKeepAliveTimeout(null));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SpannerOptions.newBuilder().setGrpcKeepAliveTimeout(Duration.ZERO));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SpannerOptions.newBuilder().setGrpcKeepAliveTimeout(Duration.ofSeconds(-10)));
+  }
 }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/AbstractMockServerTest.java
@@ -191,6 +191,8 @@ public abstract class AbstractMockServerTest {
             .addService(mockDatabaseAdmin)
             .addService(mockOperations)
             .intercept(interceptor)
+            .permitKeepAliveTime(10, TimeUnit.MILLISECONDS)
+            .permitKeepAliveWithoutCalls(true)
             .build()
             .start();
     mockSpanner.putStatementResult(

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionOptionsTest.java
@@ -1597,4 +1597,44 @@ public class ConnectionOptionsTest {
     assertEquals(Integer.valueOf(15), options.getDcpMaxChannels());
     assertEquals(Integer.valueOf(5), options.getDcpInitialChannels());
   }
+
+  @Test
+  public void testGrpcKeepAliveTimeOption() {
+    ConnectionOptions options =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database"
+                    + "?grpcKeepAliveTime='20s'")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    assertEquals(Duration.ofSeconds(20), options.getGrpcKeepAliveTime());
+
+    ConnectionOptions defaultOptions =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    assertNull(defaultOptions.getGrpcKeepAliveTime());
+  }
+
+  @Test
+  public void testGrpcKeepAliveTimeoutOption() {
+    ConnectionOptions options =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database"
+                    + "?grpcKeepAliveTimeout='15s'")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    assertEquals(Duration.ofSeconds(15), options.getGrpcKeepAliveTimeout());
+
+    ConnectionOptions defaultOptions =
+        ConnectionOptions.newBuilder()
+            .setUri(
+                "cloudspanner:/projects/test-project-123/instances/test-instance/databases/test-database")
+            .setCredentials(NoCredentials.getInstance())
+            .build();
+    assertNull(defaultOptions.getGrpcKeepAliveTimeout());
+  }
 }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spanner.connection;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -24,11 +25,13 @@ import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.SlowTest;
 import com.google.cloud.spanner.Statement;
+import com.google.spanner.v1.ExecuteSqlRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -79,11 +82,18 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
               .build();
 
       try (Connection connection = createITConnection(options)) {
-        // 3. Make mock Spanner server delay the execution of SELECT 1
+        // 3. Warm up the connection so session creation and dialect detection are done, then
+        // make the mock Spanner server delay the execution of any following queries.
+        try (ResultSet rs = connection.executeQuery(Statement.of("SELECT 1"))) {
+          while (rs.next()) {
+            // consume
+          }
+        }
         mockSpanner.setExecuteStreamingSqlExecutionTime(
             SimulatedExecutionTime.ofMinimumAndRandomTime(35000, 0));
 
         // 4. Run the query in a separate thread
+        mockSpanner.clearRequests();
         ExecutorService executor = Executors.newSingleThreadExecutor();
         Future<Void> future =
             executor.submit(
@@ -96,20 +106,23 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
                   return null;
                 });
 
-        // 5. Let the query run for 1 second, then trigger network blackhole
-        Thread.sleep(1000L);
+        // 5. Wait until the query is actually in flight on the server, then trigger the
+        // network blackhole.
+        await()
+            .atMost(Duration.ofSeconds(10))
+            .until(() -> mockSpanner.countRequestsOfType(ExecuteSqlRequest.class) > 0);
         proxy.blackhole();
         long startTime = System.currentTimeMillis();
 
-        // 6. Restore proxy and clear execution delay at t=16s.
-        // This is after the keepalive fires and times out (10s keepalive + 5s timeout).
-        Thread.sleep(15000L);
+        // 6. Wait until the client detects the dead connection through the keepalive
+        // (10s keepalive + 5s timeout) and drops it, then restore the proxy and clear the
+        // execution delay so the retry succeeds immediately.
+        await().atMost(Duration.ofSeconds(60)).until(proxy::isClientDisconnected);
         proxy.restore();
         mockSpanner.removeAllExecutionTimes();
 
-        // 7. Wait for the query to recover and complete.
-        // Keepalive (10s keepalive + 5s timeout) should fire at t=16s, causing client to
-        // retry the query over the restored proxy, succeeding immediately.
+        // 7. Wait for the query to recover and complete. The client has already dropped the
+        // dead connection, so the retry runs over the restored proxy and succeeds immediately.
         try {
           future.get(10, TimeUnit.SECONDS);
           long elapsed = System.currentTimeMillis() - startTime;
@@ -132,6 +145,7 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
     private final int localPort;
     private final int targetPort;
     private final AtomicBoolean blackholed = new AtomicBoolean(false);
+    private final AtomicBoolean clientDisconnected = new AtomicBoolean(false);
     private final List<Socket> clientSockets = Collections.synchronizedList(new ArrayList<>());
     private final List<Socket> serverSockets = Collections.synchronizedList(new ArrayList<>());
     private final List<Thread> forwardingThreads = Collections.synchronizedList(new ArrayList<>());
@@ -148,6 +162,14 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
 
     int getPort() {
       return localPort;
+    }
+
+    /**
+     * Returns true when the client has dropped a black-holed connection (which happens when the
+     * client-side keepalive times out and the client closes the transport).
+     */
+    boolean isClientDisconnected() {
+      return clientDisconnected.get();
     }
 
     void blackhole() {
@@ -177,9 +199,9 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
             serverSockets.add(serverSocket);
 
             Thread forwardClientToServer =
-                new Thread(() -> forward(clientSocket, serverSocket), "SimpleProxy-C2S");
+                new Thread(() -> forward(clientSocket, serverSocket, true), "SimpleProxy-C2S");
             Thread forwardServerToClient =
-                new Thread(() -> forward(serverSocket, clientSocket), "SimpleProxy-S2C");
+                new Thread(() -> forward(serverSocket, clientSocket, false), "SimpleProxy-S2C");
             forwardClientToServer.setDaemon(true);
             forwardServerToClient.setDaemon(true);
             forwardingThreads.add(forwardClientToServer);
@@ -195,7 +217,16 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
       }
     }
 
-    private void forward(Socket input, Socket output) {
+    /**
+     * Forwards data from one socket to the other until the connection breaks or the blackhole is
+     * triggered. Once this direction has seen the blackhole it is poisoned and never forwards
+     * again: the client-to-server direction keeps reading and discarding, so the client closing the
+     * connection after its keepalive timeout is detected and signals {@link #clientDisconnected},
+     * while the server-to-client direction parks to keep the client socket open without delivering
+     * any data.
+     */
+    private void forward(Socket input, Socket output, boolean fromClient) {
+      boolean poisoned = false;
       try (InputStream in = input.getInputStream();
           OutputStream out = output.getOutputStream()) {
         byte[] buffer = new byte[4096];
@@ -204,18 +235,32 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
           try {
             read = in.read(buffer);
           } catch (IOException e) {
-            if (blackholed.get()) {
-              blockIndefinitely();
+            if (poisoned || blackholed.get()) {
+              if (fromClient) {
+                clientDisconnected.set(true);
+              } else {
+                blockIndefinitely();
+              }
             }
             throw e;
           }
           if (read == -1) {
-            if (blackholed.get()) {
-              blockIndefinitely();
+            if (poisoned || blackholed.get()) {
+              if (fromClient) {
+                clientDisconnected.set(true);
+              } else {
+                blockIndefinitely();
+              }
             }
             break;
           }
-          if (blackholed.get()) {
+          if (poisoned || blackholed.get()) {
+            poisoned = true;
+            if (fromClient) {
+              // Silently drop the data, but keep reading so the connection close by the client
+              // (after the keepalive timeout) is detected.
+              continue;
+            }
             blockIndefinitely();
             break;
           }
@@ -224,6 +269,12 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
             out.flush();
           } catch (IOException e) {
             if (blackholed.get()) {
+              poisoned = true;
+              if (fromClient) {
+                // The server side is gone; keep draining the client so its disconnect is
+                // detected.
+                continue;
+              }
               blockIndefinitely();
             }
             throw e;

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
@@ -101,9 +101,9 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
         proxy.blackhole();
         long startTime = System.currentTimeMillis();
 
-        // 6. Restore proxy and clear execution delay at t=8s.
-        // This is before the keepalive fires and times out.
-        Thread.sleep(7000L);
+        // 6. Restore proxy and clear execution delay at t=16s.
+        // This is after the keepalive fires and times out (10s keepalive + 5s timeout).
+        Thread.sleep(15000L);
         proxy.restore();
         mockSpanner.removeAllExecutionTimes();
 
@@ -111,7 +111,7 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
         // Keepalive (10s keepalive + 5s timeout) should fire at t=16s, causing client to
         // retry the query over the restored proxy, succeeding immediately.
         try {
-          future.get(25, TimeUnit.SECONDS);
+          future.get(10, TimeUnit.SECONDS);
           long elapsed = System.currentTimeMillis() - startTime;
           System.out.println("Query succeeded after blackhole recovery in " + elapsed + " ms");
           assertTrue(
@@ -134,6 +134,7 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
     private final AtomicBoolean blackholed = new AtomicBoolean(false);
     private final List<Socket> clientSockets = Collections.synchronizedList(new ArrayList<>());
     private final List<Socket> serverSockets = Collections.synchronizedList(new ArrayList<>());
+    private final List<Thread> forwardingThreads = Collections.synchronizedList(new ArrayList<>());
     private final Thread acceptThread;
 
     SimpleProxy(int targetPort) throws IOException {
@@ -141,6 +142,7 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
       this.localPort = serverSocket.getLocalPort();
       this.targetPort = targetPort;
       this.acceptThread = new Thread(this::acceptConnections, "SimpleProxy-accept");
+      this.acceptThread.setDaemon(true);
       this.acceptThread.start();
     }
 
@@ -178,6 +180,10 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
                 new Thread(() -> forward(clientSocket, serverSocket), "SimpleProxy-C2S");
             Thread forwardServerToClient =
                 new Thread(() -> forward(serverSocket, clientSocket), "SimpleProxy-S2C");
+            forwardClientToServer.setDaemon(true);
+            forwardServerToClient.setDaemon(true);
+            forwardingThreads.add(forwardClientToServer);
+            forwardingThreads.add(forwardServerToClient);
             forwardClientToServer.start();
             forwardServerToClient.start();
           } catch (IOException e) {
@@ -213,8 +219,15 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
             blockIndefinitely();
             break;
           }
-          out.write(buffer, 0, read);
-          out.flush();
+          try {
+            out.write(buffer, 0, read);
+            out.flush();
+          } catch (IOException e) {
+            if (blackholed.get()) {
+              blockIndefinitely();
+            }
+            throw e;
+          }
         }
       } catch (Exception e) {
         // ignore
@@ -235,17 +248,41 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
 
     @Override
     public void close() throws Exception {
-      serverSocket.close();
-      acceptThread.join(1000L);
       synchronized (clientSockets) {
         for (Socket s : clientSockets) {
-          s.close();
+          try {
+            s.close();
+          } catch (IOException e) {
+            // ignore
+          }
         }
+        clientSockets.clear();
       }
       synchronized (serverSockets) {
         for (Socket s : serverSockets) {
-          s.close();
+          try {
+            s.close();
+          } catch (IOException e) {
+            // ignore
+          }
         }
+        serverSockets.clear();
+      }
+      synchronized (forwardingThreads) {
+        for (Thread t : forwardingThreads) {
+          t.interrupt();
+        }
+        forwardingThreads.clear();
+      }
+      try {
+        serverSocket.close();
+      } catch (IOException e) {
+        // ignore
+      }
+      try {
+        acceptThread.join(1000L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     }
   }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spanner.connection;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.spanner.MockSpannerServiceImpl.SimulatedExecutionTime;
+import com.google.cloud.spanner.ResultSet;
+import com.google.cloud.spanner.SlowTest;
+import com.google.cloud.spanner.Statement;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+@Category(SlowTest.class)
+public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
+
+  @Before
+  public void before() {
+    SpannerPool.closeSpannerPool();
+  }
+
+  @After
+  public void after() {
+    SpannerPool.closeSpannerPool();
+    mockSpanner.removeAllExecutionTimes();
+  }
+
+  @Test
+  public void testKeepAliveDetectsDisconnect() throws Exception {
+    // 1. Start proxy targeting the mock Spanner server
+    try (SimpleProxy proxy = new SimpleProxy(getPort())) {
+      // 2. Configure connection options using the proxy.
+      // We set grpcKeepAliveTime to 10s, which is the absolute minimum client-side keepalive
+      // time enforced by the gRPC library. Any value below 10s is clamped to 10s.
+      // We set grpcKeepAliveTimeout to 5s.
+      ConnectionOptions options =
+          ConnectionOptions.newBuilder()
+              .setUri(
+                  String.format(
+                      "cloudspanner://localhost:%d/projects/proj/instances/inst/databases/db"
+                          + "?usePlainText=true;autocommit=true;retryAbortsInternally=true"
+                          + ";numChannels=1;grpcKeepAliveTime='10s';grpcKeepAliveTimeout='5s'",
+                      proxy.getPort()))
+              .setCredentials(NoCredentials.getInstance())
+              .build();
+
+      try (Connection connection = createITConnection(options)) {
+        // 3. Make mock Spanner server delay the execution of SELECT 1
+        mockSpanner.setExecuteStreamingSqlExecutionTime(
+            SimulatedExecutionTime.ofMinimumAndRandomTime(35000, 0));
+
+        // 4. Run the query in a separate thread
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Void> future =
+            executor.submit(
+                () -> {
+                  try (ResultSet rs = connection.executeQuery(Statement.of("SELECT 1"))) {
+                    while (rs.next()) {
+                      // consume
+                    }
+                  }
+                  return null;
+                });
+
+        // 5. Let the query run for 1 second, then trigger network blackhole
+        Thread.sleep(1000L);
+        proxy.blackhole();
+        long startTime = System.currentTimeMillis();
+
+        // 6. Restore proxy and clear execution delay at t=8s.
+        // This is before the keepalive fires and times out.
+        Thread.sleep(7000L);
+        proxy.restore();
+        mockSpanner.removeAllExecutionTimes();
+
+        // 7. Wait for the query to recover and complete.
+        // Keepalive (10s keepalive + 5s timeout) should fire at t=16s, causing client to
+        // retry the query over the restored proxy, succeeding immediately.
+        try {
+          future.get(25, TimeUnit.SECONDS);
+          long elapsed = System.currentTimeMillis() - startTime;
+          System.out.println("Query succeeded after blackhole recovery in " + elapsed + " ms");
+          assertTrue(
+              "Expected query to complete within 20 seconds, but took " + elapsed + "ms",
+              elapsed < 20000L);
+        } catch (Exception e) {
+          e.printStackTrace();
+          fail("Expected query to succeed after restoring connection, but got: " + e);
+        } finally {
+          executor.shutdown();
+        }
+      }
+    }
+  }
+
+  static class SimpleProxy implements AutoCloseable {
+    private final ServerSocket serverSocket;
+    private final int localPort;
+    private final int targetPort;
+    private final AtomicBoolean blackholed = new AtomicBoolean(false);
+    private final List<Socket> clientSockets = Collections.synchronizedList(new ArrayList<>());
+    private final List<Socket> serverSockets = Collections.synchronizedList(new ArrayList<>());
+    private final Thread acceptThread;
+
+    SimpleProxy(int targetPort) throws IOException {
+      this.serverSocket = new ServerSocket(0);
+      this.localPort = serverSocket.getLocalPort();
+      this.targetPort = targetPort;
+      this.acceptThread = new Thread(this::acceptConnections, "SimpleProxy-accept");
+      this.acceptThread.start();
+    }
+
+    int getPort() {
+      return localPort;
+    }
+
+    void blackhole() {
+      blackholed.set(true);
+      synchronized (serverSockets) {
+        for (Socket s : serverSockets) {
+          try {
+            s.close();
+          } catch (IOException e) {
+          }
+        }
+        serverSockets.clear();
+      }
+    }
+
+    private void acceptConnections() {
+      try {
+        while (!serverSocket.isClosed()) {
+          Socket clientSocket = serverSocket.accept();
+          if (blackholed.get()) {
+            clientSocket.close();
+            continue;
+          }
+          clientSockets.add(clientSocket);
+          try {
+            Socket serverSocket = new Socket("localhost", targetPort);
+            serverSockets.add(serverSocket);
+
+            Thread forwardClientToServer =
+                new Thread(() -> forward(clientSocket, serverSocket), "SimpleProxy-C2S");
+            Thread forwardServerToClient =
+                new Thread(() -> forward(serverSocket, clientSocket), "SimpleProxy-S2C");
+            forwardClientToServer.start();
+            forwardServerToClient.start();
+          } catch (IOException e) {
+            clientSocket.close();
+          }
+        }
+      } catch (IOException e) {
+        // expected on close
+      }
+    }
+
+    private void forward(Socket input, Socket output) {
+      try (InputStream in = input.getInputStream();
+          OutputStream out = output.getOutputStream()) {
+        byte[] buffer = new byte[4096];
+        int read;
+        while (true) {
+          try {
+            read = in.read(buffer);
+          } catch (IOException e) {
+            if (blackholed.get()) {
+              blockIndefinitely();
+            }
+            throw e;
+          }
+          if (read == -1) {
+            if (blackholed.get()) {
+              blockIndefinitely();
+            }
+            break;
+          }
+          if (blackholed.get()) {
+            blockIndefinitely();
+            break;
+          }
+          out.write(buffer, 0, read);
+          out.flush();
+        }
+      } catch (Exception e) {
+        // ignore
+      }
+    }
+
+    private void blockIndefinitely() {
+      try {
+        Thread.sleep(Long.MAX_VALUE);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    void restore() {
+      blackholed.set(false);
+    }
+
+    @Override
+    public void close() throws Exception {
+      serverSocket.close();
+      acceptThread.join(1000L);
+      synchronized (clientSockets) {
+        for (Socket s : clientSockets) {
+          s.close();
+        }
+      }
+      synchronized (serverSockets) {
+        for (Socket s : serverSockets) {
+          s.close();
+        }
+      }
+    }
+  }
+}

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/GrpcKeepAliveMockServerTest.java
@@ -117,7 +117,10 @@ public class GrpcKeepAliveMockServerTest extends AbstractMockServerTest {
         // 6. Wait until the client detects the dead connection through the keepalive
         // (10s keepalive + 5s timeout) and drops it, then restore the proxy and clear the
         // execution delay so the retry succeeds immediately.
-        await().atMost(Duration.ofSeconds(60)).until(proxy::isClientDisconnected);
+        // The disconnect is expected after ~15 seconds; the 20 second bound verifies that the
+        // lower keep-alive settings actually make the client recover this quickly (the default
+        // 120 second keep-alive time would need more than 2 minutes).
+        await().atMost(Duration.ofSeconds(20)).until(proxy::isClientDisconnected);
         proxy.restore();
         mockSpanner.removeAllExecutionTimes();
 


### PR DESCRIPTION
Adds options for setting a gRPC keep-alive and keep-alive-timeout for the Spanner client.