### PR TITLE
fix(spanner): update dynamic channel pool default configuration

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -144,7 +144,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
 
   // Dynamic Channel Pool (DCP) default values and bounds
   /** Default max concurrent RPCs per channel before triggering scale up. */
-  public static final int DEFAULT_DYNAMIC_POOL_MAX_RPC = 90;
+  public static final int DEFAULT_DYNAMIC_POOL_MAX_RPC = 25;
 
   /** Default min concurrent RPCs per channel for scale down check. */
   public static final int DEFAULT_DYNAMIC_POOL_MIN_RPC = 15;
@@ -153,13 +153,13 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
   public static final Duration DEFAULT_DYNAMIC_POOL_SCALE_DOWN_INTERVAL = Duration.ofMinutes(3);
 
   /** Default initial number of channels for dynamic pool. */
-  public static final int DEFAULT_DYNAMIC_POOL_INITIAL_SIZE = 1;
+  public static final int DEFAULT_DYNAMIC_POOL_INITIAL_SIZE = 4;
 
   /** Default max number of channels for dynamic pool. */
-  public static final int DEFAULT_DYNAMIC_POOL_MAX_CHANNELS = 256;
+  public static final int DEFAULT_DYNAMIC_POOL_MAX_CHANNELS = 10;
 
   /** Default min number of channels for dynamic pool. */
-  public static final int DEFAULT_DYNAMIC_POOL_MIN_CHANNELS = 1;
+  public static final int DEFAULT_DYNAMIC_POOL_MIN_CHANNELS = 2;
 
   /**
    * Default affinity key lifetime for dynamic channel pool. This is how long to keep an affinity

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerOptionsTest.java
@@ -1345,6 +1345,20 @@ public class SpannerOptionsTest {
   }
 
   @Test
+  public void testDynamicChannelPoolDefaultValues() {
+    // Pins the documented dynamic channel pool default values. If this test fails, the defaults
+    // changed: update these literals deliberately and call the change out in the PR description.
+    assertEquals(25, SpannerOptions.DEFAULT_DYNAMIC_POOL_MAX_RPC);
+    assertEquals(15, SpannerOptions.DEFAULT_DYNAMIC_POOL_MIN_RPC);
+    assertEquals(Duration.ofMinutes(3), SpannerOptions.DEFAULT_DYNAMIC_POOL_SCALE_DOWN_INTERVAL);
+    assertEquals(4, SpannerOptions.DEFAULT_DYNAMIC_POOL_INITIAL_SIZE);
+    assertEquals(10, SpannerOptions.DEFAULT_DYNAMIC_POOL_MAX_CHANNELS);
+    assertEquals(2, SpannerOptions.DEFAULT_DYNAMIC_POOL_MIN_CHANNELS);
+    assertEquals(Duration.ofMinutes(10), SpannerOptions.DEFAULT_DYNAMIC_POOL_AFFINITY_KEY_LIFETIME);
+    assertEquals(Duration.ofMinutes(1), SpannerOptions.DEFAULT_DYNAMIC_POOL_CLEANUP_INTERVAL);
+  }
+
+  @Test
   public void testCreateDefaultDynamicChannelPoolOptions() {
     // Test the static factory method for creating default options
     GcpChannelPoolOptions defaults = SpannerOptions.createDefaultDynamicChannelPoolOptions();


### PR DESCRIPTION
Set Spanner DCP defaults to maxRpcPerChannel=25, minRpcPerChannel=15, scaleDownInterval=3m, initSize=4, maxChannels=10, minChannels=2.



Internal Ref: go/dynamic-channel-pooling-non-sab