### PR TITLE
feat: automate libraries-bom tag and release creation on release publish

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -22,8 +22,10 @@ jobs:
         git config --local user.name "GitHub Action"
     - name: Create additional tags
       shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       run: |
-        ARTIFACT_IDS=('google-cloud-shared-dependencies' 'api-common' 'gax' 'google-cloud-bigtable')
+        ARTIFACT_IDS=('google-cloud-shared-dependencies' 'api-common' 'gax' 'google-cloud-bigtable' 'libraries-bom')
         for ARTIFACT_ID in "${ARTIFACT_IDS[@]}"; do
           VERSION=$(grep "^${ARTIFACT_ID}:" versions.txt | cut -d':' -f2 | tr -d '[:space:]')
           TAG_NAME="${ARTIFACT_ID}/v$VERSION"
@@ -33,4 +35,8 @@ jobs:
           fi
           git tag $TAG_NAME
           git push origin $TAG_NAME
+          if [ "${ARTIFACT_ID}" = "libraries-bom" ]; then
+            echo "Creating GitHub Release for ${TAG_NAME}"
+            gh release create "${TAG_NAME}" --title "GCP Libraries BOM ${VERSION}" --notes "Release notes will be generated shortly."
+          fi
         done

--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -37,6 +37,6 @@ jobs:
           git push origin $TAG_NAME
           if [ "${ARTIFACT_ID}" = "libraries-bom" ]; then
             echo "Creating GitHub Release for ${TAG_NAME}"
-            gh release create "${TAG_NAME}" --title "GCP Libraries BOM ${VERSION}" --notes "Release notes will be generated shortly."
+            gh release create "${TAG_NAME}" --title "GCP Libraries BOM ${VERSION}" --notes "libraries-bom release."
           fi
         done


### PR DESCRIPTION
Adds libraries-bom to create_additional_release_tag.yaml so that when a root monorepo release is published, the corresponding libraries-bom/vX.Y.Z tag and its GitHub Release page are created automatically. This will subsequently trigger the java-cloud-bom-release-note-generation workflow to compile and populate the BOM release notes.