### PR TITLE
chore(ci): include libraries-bom in reactor for dependency-convergence-check

### DIFF
--- a/.kokoro/dashboard.sh
+++ b/.kokoro/dashboard.sh
@@ -26,7 +26,7 @@ if [[ "${JOB_TYPE}" == "dashboard-units-check" ]]; then
   mvn test --fail-at-end
 elif [[ "${JOB_TYPE}" == "dependency-convergence-check" ]]; then
   echo -e "\n******************** BUILDING DEPENDENCIES ********************"
-  mvn install -pl java-cloud-bom/tests/dependency-convergence -am -Pquick-build -DskipTests -Denforcer.skip=true
+  mvn install -pl java-cloud-bom/libraries-bom,java-cloud-bom/tests/dependency-convergence -am -Pquick-build -DskipTests -Denforcer.skip=true
   cd java-cloud-bom/tests/dependency-convergence/
   echo -e "\n******************** RUNNING DEPENDENCY CONVERGENCE CHECK ********************"
   mvn validate --fail-at-end


### PR DESCRIPTION
To fix GHA shared-dependencies-convergence failure on release PRs, ensure libraries-bom is built and installed to the local repository before running dependency convergence validation.