### PR TITLE
fix: Add logging-logback to gapic-libraries-bom

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -889,7 +889,7 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-logging-logback</artifactId>
+        <artifactId>google-cloud-logging-logback</artifactId><!-- {x-version-update:google-cloud-logging-logback:current} -->
         <version>0.143.0-alpha-SNAPSHOT</version>
       </dependency>
       <dependency>

--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -889,6 +889,11 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-logging-logback</artifactId>
+        <version>0.143.0-alpha-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-lustre-bom</artifactId>
         <version>0.34.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-lustre:current} -->
         <type>pom</type>

--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -889,8 +889,8 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-logging-logback</artifactId><!-- {x-version-update:google-cloud-logging-logback:current} -->
-        <version>0.143.0-alpha-SNAPSHOT</version>
+        <artifactId>google-cloud-logging-logback</artifactId>
+        <version>0.143.0-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging-logback:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
google-cloud-logging-logback was removed from the java-cloud-bom but not added to other boms managed by libraries-bom. This caused breaking changes to customers' build. Add it back to gapic-libraries-bom so it is managed by libraries-bom again.

fixes: https://github.com/googleapis/java-cloud-bom/issues/7498