### PR TITLE
fix(ci): fix java-cloud-bom release-notes workflow errors

### DIFF
--- a/.github/workflows/java-cloud-bom-release-note-generation.yaml
+++ b/.github/workflows/java-cloud-bom-release-note-generation.yaml
@@ -61,7 +61,7 @@ jobs:
         mvn -B -ntp compile
 
         GOOGLE_CLOUD_JAVA_VERSION=$(grep -A1 'gapic-libraries-bom' \
-            ../google-cloud-bom/pom.xml |perl -nle 'print $1 if m/<version>(.+)</')
+            ../google-cloud-bom/pom.xml |perl -nle 'print $1 if m/<version>([^<]+)</')
 
         # This generates release_note.md file
         mvn -B -ntp exec:java \

--- a/.github/workflows/java-cloud-bom-release-note-generation.yaml
+++ b/.github/workflows/java-cloud-bom-release-note-generation.yaml
@@ -58,13 +58,13 @@ jobs:
       shell: bash
       run: |
         set -x
-        mvn -B -ntp compile -f java-cloud-bom/release-note-generation/pom.xml
+        mvn -B -ntp compile
 
         GOOGLE_CLOUD_JAVA_VERSION=$(grep -A1 'gapic-libraries-bom' \
             ../google-cloud-bom/pom.xml |perl -nle 'print $1 if m/<version>(.+)</')
 
         # This generates release_note.md file
-        mvn -B -ntp exec:java -f java-cloud-bom/release-note-generation/pom.xml \
+        mvn -B -ntp exec:java \
             -Dlibraries-bom.version="${LIBRARIES_BOM_VERSION}" \
             -Dgoogle-cloud-java.version="${GOOGLE_CLOUD_JAVA_VERSION}"
       working-directory: java-cloud-bom/release-note-generation

--- a/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -63,7 +63,7 @@ public class ReleaseNoteGeneration {
   private static final String GOOGLEAPIS_ORG = "googleapis";
 
   private static final ImmutableSet<String> splitRepositoryLibraryNames =
-      ImmutableSet.of("bigtable", "firestore", "pubsub", "pubsublite");
+      ImmutableSet.of();
 
   private static boolean clientLibraryFilter(String coordinates) {
     if (coordinates.contains("google-cloud-core")) {
@@ -521,7 +521,6 @@ public class ReleaseNoteGeneration {
               .findFirst();
       matchingSplitRepoName.ifPresent(
           splitRepoName -> {
-            System.out.println("DEBUG: Processing " + versionlessCoordinates + " (" + previousVersion + " -> " + currentVersion + ")");
             try {
               ImmutableList<String> versionsForReleaseNotes =
                   clientLibraryReleaseNoteVersions(

--- a/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -62,8 +62,7 @@ public class ReleaseNoteGeneration {
   private static final String RELEASE_NOTE_FILE_NAME = "release_note.md";
   private static final String GOOGLEAPIS_ORG = "googleapis";
 
-  private static final ImmutableSet<String> splitRepositoryLibraryNames =
-      ImmutableSet.of();
+  private static final ImmutableSet<String> splitRepositoryLibraryNames = ImmutableSet.of();
 
   private static boolean clientLibraryFilter(String coordinates) {
     if (coordinates.contains("google-cloud-core")) {

--- a/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -521,6 +521,7 @@ public class ReleaseNoteGeneration {
               .findFirst();
       matchingSplitRepoName.ifPresent(
           splitRepoName -> {
+            System.out.println("DEBUG: Processing " + versionlessCoordinates + " (" + previousVersion + " -> " + currentVersion + ")");
             try {
               ImmutableList<String> versionsForReleaseNotes =
                   clientLibraryReleaseNoteVersions(


### PR DESCRIPTION
Resolves java-cloud-bom release-notes GHA workflow failures by:
1. Correcting the working directory and POM paths inside the workflow file.
2. Adjusting the regex pattern in the version parser to prevent greedy comment-matching.
3. Updating `ReleaseNoteGeneration.java` to skip split-repository release page queries for migrated client libraries (bigtable, firestore, pubsub, and pubsublite).

Verifications:
* Manual GHA verification run: https://github.com/googleapis/google-cloud-java/actions/runs/28888992080 (Success)
* Updated release page: https://github.com/googleapis/google-cloud-java/releases/tag/libraries-bom/v26.85.0

b/532119638