### PR TITLE
refactor(ci): remove unused split-repository logic from release notes generator

### DIFF
--- a/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
+++ b/java-cloud-bom/release-note-generation/src/main/java/com/google/cloud/ReleaseNoteGeneration.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
 import com.google.cloud.tools.opensource.dependencies.Artifacts;
 import com.google.cloud.tools.opensource.dependencies.Bom;
 import com.google.cloud.tools.opensource.dependencies.MavenRepositoryException;
@@ -27,13 +25,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.base.Verify;
-import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
-import com.google.common.collect.Streams;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,8 +37,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -60,8 +54,6 @@ public class ReleaseNoteGeneration {
   private static final String cloudLibraryArtifactPrefix = "com.google.cloud:google-cloud-";
   private static final String RELEASE_NOTE_FILE_NAME = "release_note.md";
   private static final String GOOGLEAPIS_ORG = "googleapis";
-
-  private static final ImmutableSet<String> splitRepositoryLibraryNames = ImmutableSet.of();
 
   private static boolean clientLibraryFilter(String coordinates) {
     if (coordinates.contains("google-cloud-core")) {
@@ -332,11 +324,7 @@ public class ReleaseNoteGeneration {
     }
 
     report.append("# Notable Changes\n\n");
-    reportClientLibrariesNotableChangeLogs(
-        minorVersionBumpVersionlessCoordinates,
-        versionlessCoordinatesToVersionOld,
-        versionlessCoordinatesToVersionNew,
-        googleCloudJavaVersion);
+    reportClientLibrariesNotableChangeLogs(googleCloudJavaVersion);
 
     report.append("# Version Upgrades\n\n");
     if (!majorVersionBumpVersionlessCoordinates.isEmpty()) {
@@ -429,25 +417,15 @@ public class ReleaseNoteGeneration {
         libraryName = artifactId.replace("google-", "");
       }
 
-      List<String> links = new ArrayList<>();
+      String releaseUrl = releaseUrlForMonorepo(libraryName, googleCloudJavaVersion);
+      ImmutableList.Builder<String> links = ImmutableList.builder();
       for (String versionForReleaseNotes : versionsForReleaseNotes) {
-        String[] versionAndQualifier = versionForReleaseNotes.split("-");
-        String version = versionAndQualifier[0];
-        String releaseUrl =
-            splitRepositoryLibraryNames.contains(libraryName)
-                ? releaseUrlForSplitRepo(libraryName, version)
-                : releaseUrlForMonorepo(libraryName, googleCloudJavaVersion);
         links.add(String.format("[v%s](%s)", versionForReleaseNotes, releaseUrl));
       }
-      line.append(Joiner.on(", ").join(links)).append(")");
+      line.append(Joiner.on(", ").join(links.build())).append(")");
 
       report.append(line).append("\n");
     }
-  }
-
-  private static String releaseUrlForSplitRepo(String libraryName, String version) {
-    return String.format(
-        "https://github.com/googleapis/java-%s/releases/tag/v%s", libraryName, version);
   }
 
   private String releaseUrlForMonorepo(String libraryName, String version) {
@@ -531,59 +509,8 @@ public class ReleaseNoteGeneration {
    * in between the two versions, not including the old version.
    */
   @VisibleForTesting
-  void reportClientLibrariesNotableChangeLogs(
-      Iterable<String> artifactsInBothBoms,
-      Map<String, String> versionlessCoordinatesToVersionOld,
-      Map<String, String> versionlessCoordinatesToVersionNew,
-      String googleCloudJavaVersion)
+  void reportClientLibrariesNotableChangeLogs(String googleCloudJavaVersion)
       throws IOException, InterruptedException {
-
-    ImmutableList<String> sortedVersionlessCoordinates =
-        Streams.stream(artifactsInBothBoms).sorted().collect(toImmutableList());
-
-    for (String versionlessCoordinates : sortedVersionlessCoordinates) {
-      List<String> coordinates = Splitter.on(":").splitToList(versionlessCoordinates);
-      String artifactId = coordinates.get(1);
-      String previousVersion = versionlessCoordinatesToVersionOld.get(versionlessCoordinates);
-      String currentVersion = versionlessCoordinatesToVersionNew.get(versionlessCoordinates);
-      Optional<String> matchingSplitRepoName =
-          splitRepositoryLibraryNames.stream()
-              .map(libraryName -> artifactId.endsWith(libraryName) ? "java-" + libraryName : null)
-              .filter(Objects::nonNull)
-              .findFirst();
-      matchingSplitRepoName.ifPresent(
-          splitRepoName -> {
-            try {
-              ImmutableList<String> versionsForReleaseNotes =
-                  clientLibraryReleaseNoteVersions(
-                      versionlessCoordinates, previousVersion, currentVersion);
-              String changelog =
-                  fetchClientLibraryNotableChangeLog(splitRepoName, versionsForReleaseNotes);
-              if (!changelog.isEmpty()) {
-                // Only print library name when there are notable changes
-                report
-                    .append("## ")
-                    .append(artifactId)
-                    .append(" ")
-                    .append(currentVersion)
-                    .append(" (prev: ")
-                    .append(previousVersion)
-                    .append(")");
-                report.append(changelog).append("\n");
-              }
-            } catch (MavenRepositoryException | IOException | InterruptedException ex) {
-              throw new VerifyException(
-                  "Couldn't write notable changelog for "
-                      + versionlessCoordinates
-                      + "'s versions between "
-                      + previousVersion
-                      + " and "
-                      + currentVersion,
-                  ex);
-            }
-          });
-    }
-
     report.append("## Other libraries\n\n");
     String changelog =
         fetchClientLibraryNotableChangeLog(


### PR DESCRIPTION
Removes split-repository release notes parsing and URL linking logic from the BOM release notes compiler tool (`ReleaseNoteGeneration.java`).

Since all major Java client libraries (bigtable, firestore, pubsub, pubsublite) have been migrated into the monorepo, their release tags are hosted on `googleapis/google-cloud-java` and their old split repositories are no longer used for new releases. This change cleans up all associated dead code.

Verifications:
* Completed local compilation, tests, and formatting successfully (`ReleaseNoteGenerationTest` passed).