### PR TITLE
ci(librarian): close existing PR and delete branch in update workflow

### DIFF
--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -34,23 +34,29 @@ jobs:
         path: google-cloud-java
         fetch-depth: 0
         persist-credentials: false
-    - name: Check for Open PR
+    - name: Close Existing PR and Branch
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
       run: |
         set -x
         current_branch="update-librarian-googleapis-main"
         
         if [ "${{ github.event_name }}" = "pull_request" ]; then
-          echo "PR Test: Skipping open PR check."
+          echo "PR Test: Skipping cleanup."
         else
           # Try to find an open pull request associated with the branch
           pr_num=$(gh pr list -s open -H "${current_branch}" -q . --json number | jq ".[] | .number")
           
           if [ -n "${pr_num}" ]; then
-            echo "Error: An open Pull Request already exists for this update: PR #${pr_num}."
-            echo "Please merge or close the existing PR before running this workflow again."
-            exit 1 # Fails this step and the workflow
+            echo "Closing existing PR #${pr_num}..."
+            gh pr close "${pr_num}" --delete-branch || gh pr close "${pr_num}"
+          fi
+          
+          # Delete the remote branch if it still exists (e.g. if no PR was open)
+          echo "Checking if remote branch ${current_branch} exists..."
+          if gh api "repos/${{ github.repository }}/git/refs/heads/${current_branch}" --silent 2>/dev/null; then
+            echo "Deleting remote branch ${current_branch}..."
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${current_branch}" || true
           fi
         fi
     - name: Set up Go

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -139,7 +139,7 @@ jobs:
         PR_BODY: |
           Updated googleapis commitish in librarian.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}
 
-          💡 **Note:** Please merge or close this PR so that the daily update workflow can continue to run successfully the next day. Alternatively, you can manually trigger the workflow once this PR is merged or closed.
+          💡 **Note:** If this PR is still open when the daily update workflow runs next, it will be closed and replaced with a new PR containing the latest updates.
       run: |
         set -x
         

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -56,7 +56,10 @@ jobs:
           echo "Checking if remote branch ${current_branch} exists..."
           if gh api "repos/${{ github.repository }}/git/refs/heads/${current_branch}" --silent 2>/dev/null; then
             echo "Deleting remote branch ${current_branch}..."
-            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${current_branch}" || true
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${current_branch}" || {
+              echo "Error: Failed to delete remote branch ${current_branch}."
+              exit 1
+            }
           fi
         fi
     - name: Set up Go


### PR DESCRIPTION
Close the existing pull request and delete its branch (instead of failing) to allow the daily update workflow to run continuously without manual intervention. 

Fixes https://github.com/googleapis/librarian/issues/6687