### PR TITLE
chore: declare jspecify in jar parent and ignore if unused

### DIFF
--- a/google-cloud-jar-parent/pom.xml
+++ b/google-cloud-jar-parent/pom.xml
@@ -148,6 +148,13 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+  </dependencies>
+
   <profiles>
     <profile>
       <id>java9</id>

--- a/java-bigquery/pom.xml
+++ b/java-bigquery/pom.xml
@@ -135,6 +135,7 @@
             <!-- maven-dependency-plugin cannot detect the runtime usage of junit-platform-suite-engine for executing JUnit 5+ test suites. -->
             <ignoredUnusedDeclaredDependency>org.junit.platform:junit-platform-suite-engine</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/java-bigquerystorage/pom.xml
+++ b/java-bigquerystorage/pom.xml
@@ -173,6 +173,7 @@
               <ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
               <!-- maven-dependency-plugin cannot detect the runtime usage of junit-vintage-engine for executing JUnit 4.x tests. -->
               <ignoredUnusedDeclaredDependency>org.junit.vintage:junit-vintage-engine</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>

--- a/java-datastore/pom.xml
+++ b/java-datastore/pom.xml
@@ -214,6 +214,7 @@
               <ignoredUnusedDeclaredDependency>com.google.http-client:google-http-client-jackson2</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>com.google.oauth-client:google-oauth-client</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>

--- a/java-logging/pom.xml
+++ b/java-logging/pom.xml
@@ -89,6 +89,7 @@
             <ignoredUnusedDeclaredDependencies>
               <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.objenesis:objenesis</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>

--- a/java-pubsub/google-cloud-pubsub/pom.xml
+++ b/java-pubsub/google-cloud-pubsub/pom.xml
@@ -203,6 +203,7 @@
               <ignoredUnusedDeclaredDependency>io.opencensus:opencensus-impl</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.assertj:assertj-core</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>

--- a/java-pubsub/pom.xml
+++ b/java-pubsub/pom.xml
@@ -127,6 +127,7 @@
             <ignoredUnusedDeclaredDependencies>
               <ignoredUnusedDeclaredDependency>org.objenesis:objenesis</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>

--- a/java-shared-config/java-shared-config/pom.xml
+++ b/java-shared-config/java-shared-config/pom.xml
@@ -145,6 +145,7 @@
           <configuration>
             <ignoredUnusedDeclaredDependencies>
               <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
             <!-- TODO: Try to remove these exclusions by updating handwritten libs -->
             <ignoredNonTestScopedDependencies>

--- a/java-spanner-jdbc/pom.xml
+++ b/java-spanner-jdbc/pom.xml
@@ -373,6 +373,7 @@
               <ignoredDependency>com.google.api.grpc:grpc-google-cloud-spanner-admin-database-v1</ignoredDependency>
               <ignoredDependency>io.opentelemetry:*</ignoredDependency>
               <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
             <ignoredNonTestScopedDependencies>
               <ignoredDependency>io.opentelemetry:*</ignoredDependency>

--- a/java-storage-nio/google-cloud-nio/pom.xml
+++ b/java-storage-nio/google-cloud-nio/pom.xml
@@ -189,6 +189,7 @@
 		  <!-- This dependency is used for its native image configuration in the test scope -->
           <ignoredUnusedDeclaredDependency>com.google.api:gax:jar</ignoredUnusedDeclaredDependency>
           <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
+          <ignoredUnusedDeclaredDependency>org.jspecify:jspecify</ignoredUnusedDeclaredDependency>
 		</ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
Declare org.jspecify:jspecify as a dependency in google-cloud-jar-parent so that all client libraries inherit it, resolving "used undeclared dependency" issues caused by the new JSpecify changes.

Also add org.jspecify:jspecify to ignoredUnusedDeclaredDependencies in java-shared-config to prevent "unused declared dependency" warnings/failures in modules that do not use it yet (e.g. gRPC modules)