### PR TITLE
fix(oauth2_http): Avoid retrying on 403 Forbidden during GCE metadata ping

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -673,8 +673,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
       } catch (SocketTimeoutException expected) {
         // Ignore logging timeouts which is the expected failure mode in non GCE environments.
       } catch (IOException e) {
-        if (e instanceof HttpResponseException httpResponseException
-            && httpResponseException.getStatusCode() == 403) {
+        if (e instanceof HttpResponseException
+            && ((HttpResponseException) e).getStatusCode() == 403) {
           return false;
         }
         LOGGER.log(

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -673,6 +673,10 @@ public class ComputeEngineCredentials extends GoogleCredentials
       } catch (SocketTimeoutException expected) {
         // Ignore logging timeouts which is the expected failure mode in non GCE environments.
       } catch (IOException e) {
+        if (e instanceof HttpResponseException httpResponseException
+            && httpResponseException.getStatusCode() == 403) {
+          return false;
+        }
         LOGGER.log(
             Level.FINE,
             "Encountered an unexpected exception when checking"

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -1184,6 +1184,7 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     DefaultCredentialsProvider provider = new DefaultCredentialsProvider();
     boolean isOnGce = ComputeEngineCredentials.isOnGce(transportFactory, provider);
     assertFalse(isOnGce);
+    assertEquals(1, transportFactory.transport.getRequestCount());
   }
 
   static class MockMetadataServerTransportFactory implements HttpTransportFactory {

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -1177,6 +1177,15 @@ class ComputeEngineCredentialsTest extends BaseSerializationTest {
     assertEquals(0, transportFactory.transport.getRequestCount());
   }
 
+  @Test
+  void isOnGce_forbidden_doesNotRetry() {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    transportFactory.transport.setStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    DefaultCredentialsProvider provider = new DefaultCredentialsProvider();
+    boolean isOnGce = ComputeEngineCredentials.isOnGce(transportFactory, provider);
+    assertFalse(isOnGce);
+  }
+
   static class MockMetadataServerTransportFactory implements HttpTransportFactory {
 
     MockMetadataServerTransport transport =

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -71,6 +71,11 @@ public class MockMetadataServerTransport extends MockHttpTransport {
 
   private boolean emptyContent;
   private MockLowLevelHttpRequest request;
+  private int requestCount = 0;
+
+  public int getRequestCount() {
+    return requestCount;
+  }
 
   public MockMetadataServerTransport() {}
 
@@ -125,6 +130,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
 
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+    requestCount++;
     if (url.startsWith(ComputeEngineCredentials.getTokenServerEncodedUrl())) {
       this.request = getMockRequestForTokenEndpoint(url);
       return this.request;


### PR DESCRIPTION
Don't retry GCE Metadata 403 errors which are generally non-retriable errors and only adds startup noise/latency by retrying 3 times.

Fixes #13649