### PR TITLE
fix(storage): handle map clears without current state

### DIFF
--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/BlobInfo.java
@@ -814,13 +814,16 @@ public class BlobInfo implements Serializable {
     private OffsetDateTime softDeleteTime;
     private OffsetDateTime hardDeleteTime;
     private ObjectContexts contexts;
+    private final boolean hasOriginalState;
     private final ImmutableSet.Builder<NamedField> modifiedFields = ImmutableSet.builder();
 
     BuilderImpl(BlobId blobId) {
       this.blobId = blobId;
+      this.hasOriginalState = false;
     }
 
     BuilderImpl(BlobInfo blobInfo) {
+      this.hasOriginalState = true;
       blobId = blobInfo.blobId;
       generatedId = blobInfo.generatedId;
       cacheControl = blobInfo.cacheControl;
@@ -1080,8 +1083,13 @@ public class BlobInfo implements Serializable {
     public Builder setMetadata(@Nullable Map<@NonNull String, @Nullable String> metadata) {
       Map<String, String> left = this.metadata;
       Map<String, String> right = metadata;
-      if (!Objects.equals(left, right)) {
-        diffMaps(BlobField.METADATA, left, right, modifiedFields::add);
+      boolean clearWithoutBase = !hasOriginalState && (right == null || right.isEmpty());
+      if (!Objects.equals(left, right) || clearWithoutBase) {
+        if (clearWithoutBase) {
+          modifiedFields.add(BlobField.METADATA);
+        } else {
+          diffMaps(BlobField.METADATA, left, right, modifiedFields::add);
+        }
         if (right != null) {
           this.metadata = new HashMap<>(right);
         } else {
@@ -1275,18 +1283,18 @@ public class BlobInfo implements Serializable {
           this.contexts == null ? null : this.contexts.getCustom();
       Map<String, ObjectCustomContextPayload> right =
           contexts == null ? null : contexts.getCustom();
-      if (!Objects.equals(left, right)) {
-        if (right != null) {
+      boolean clearWithoutBase = !hasOriginalState && (right == null || right.isEmpty());
+      if (!Objects.equals(left, right) || clearWithoutBase) {
+        if (clearWithoutBase || right == null) {
+          modifiedFields.add(BlobField.OBJECT_CONTEXTS);
+        } else {
           diffMaps(
               NamedField.nested(BlobField.OBJECT_CONTEXTS, NamedField.literal("custom")),
               left,
               right,
               modifiedFields::add);
-          this.contexts = contexts;
-        } else {
-          modifiedFields.add(BlobField.OBJECT_CONTEXTS);
-          this.contexts = null;
         }
+        this.contexts = contexts;
       }
       return this;
     }

--- a/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
+++ b/java-storage/google-cloud-storage/src/main/java/com/google/cloud/storage/BucketInfo.java
@@ -2757,13 +2757,16 @@ public class BucketInfo implements Serializable {
     private CustomerManagedEncryptionEnforcementConfig customerManagedEncryptionEnforcementConfig;
     private CustomerSuppliedEncryptionEnforcementConfig customerSuppliedEncryptionEnforcementConfig;
     private Boolean isUnreachable;
+    private final boolean hasOriginalState;
     private final ImmutableSet.Builder<NamedField> modifiedFields = ImmutableSet.builder();
 
     BuilderImpl(String name) {
       this.name = name;
+      this.hasOriginalState = false;
     }
 
     BuilderImpl(BucketInfo bucketInfo) {
+      this.hasOriginalState = true;
       generatedId = bucketInfo.generatedId;
       project = bucketInfo.project;
       name = bucketInfo.name;
@@ -3061,8 +3064,13 @@ public class BucketInfo implements Serializable {
     public Builder setLabels(@Nullable Map<@NonNull String, @Nullable String> labels) {
       Map<String, String> left = this.labels;
       Map<String, String> right = labels;
-      if (!Objects.equals(left, right)) {
-        diffMaps(BucketField.LABELS, left, right, modifiedFields::add);
+      boolean clearWithoutBase = !hasOriginalState && (right == null || right.isEmpty());
+      if (!Objects.equals(left, right) || clearWithoutBase) {
+        if (clearWithoutBase) {
+          modifiedFields.add(BucketField.LABELS);
+        } else {
+          diffMaps(BucketField.LABELS, left, right, modifiedFields::add);
+        }
         if (right != null) {
           this.labels = new HashMap<>(right);
         } else {

--- a/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNestedUpdateMaskTest.java
+++ b/java-storage/google-cloud-storage/src/test/java/com/google/cloud/storage/it/ITNestedUpdateMaskTest.java
@@ -131,11 +131,34 @@ public final class ITNestedUpdateMaskTest {
   }
 
   @Test
+  public void testBucketLabels_updateBaseOnNewInfoInsteadOfResolvedInfo() throws Exception {
+    BucketInfo bucket = newBucketInfo(param.initial);
+    try (TemporaryBucket tempB =
+        TemporaryBucket.newBuilder().setBucketInfo(bucket).setStorage(storage).build()) {
+      BucketInfo gen1 = tempB.getBucket();
+      BucketInfo modified = BucketInfo.newBuilder(gen1.getName()).setLabels(param.update).build();
+      Bucket gen2 = storage.update(modified);
+      assertThat(gen2.getLabels()).isEqualTo(param.expected);
+    }
+  }
+
+  @Test
   public void testBlobMetadata() {
     BlobInfo blob = newBlobInfo(param.initial);
     Blob gen1 = storage.create(blob, BlobTargetOption.doesNotExist());
     BlobInfo modified = gen1.toBuilder().setMetadata(param.update).build();
     Blob gen2 = storage.update(modified, BlobTargetOption.metagenerationMatch());
+    assertThat(gen2.getMetadata()).isEqualTo(param.expected);
+  }
+
+  @Test
+  public void testBlobMetadata_updateBaseOnNewInfoInsteadOfResolvedInfo() {
+    BlobInfo blob = newBlobInfo(param.initial);
+    Blob gen1 = storage.create(blob, BlobTargetOption.doesNotExist());
+    BlobInfo modified =
+        BlobInfo.newBuilder(bucket, gen1.getName()).setMetadata(param.update).build();
+    Blob gen2 =
+        storage.update(modified, BlobTargetOption.metagenerationMatch(gen1.getMetageneration()));
     assertThat(gen2.getMetadata()).isEqualTo(param.expected);
   }
 
@@ -159,6 +182,26 @@ public final class ITNestedUpdateMaskTest {
   }
 
   @Test
+  public void testBlobContexts_updateBaseOnNewInfoInsteadOfResolvedInfo() {
+    ObjectContexts initial = contextsFromMap(param.initial);
+    ObjectContexts update = contextsFromMap(param.update);
+    ObjectContexts expected = contextsFromMap(param.expected);
+
+    String blobName = generator.randomObjectName();
+    BlobInfo.Builder builder = BlobInfo.newBuilder(bucket, blobName);
+    if (initial != null) {
+      builder.setContexts(initial);
+    }
+    BlobInfo info = builder.build();
+    Blob gen1 = storage.create(info, BlobTargetOption.doesNotExist());
+
+    BlobInfo modified = BlobInfo.newBuilder(bucket, gen1.getName()).setContexts(update).build();
+    Blob gen2 =
+        storage.update(modified, BlobTargetOption.metagenerationMatch(gen1.getMetageneration()));
+    assertContextsWithEqualValues(gen2.getContexts(), expected);
+  }
+
+  @Test
   public void testBlob_metadataAndContext() {
     ObjectContexts initial = contextsFromMap(param.initial);
     ObjectContexts update = contextsFromMap(param.update);
@@ -178,6 +221,35 @@ public final class ITNestedUpdateMaskTest {
 
     BlobInfo modified = gen1.toBuilder().setContexts(update).setMetadata(param.update).build();
     Blob gen2 = storage.update(modified, BlobTargetOption.metagenerationMatch());
+    assertContextsWithEqualValues(gen2.getContexts(), expected);
+    assertThat(gen2.getMetadata()).isEqualTo(param.expected);
+  }
+
+  @Test
+  public void testBlob_metadataAndContext_updateBaseOnNewInfoInsteadOfResolvedInfo() {
+    ObjectContexts initial = contextsFromMap(param.initial);
+    ObjectContexts update = contextsFromMap(param.update);
+    ObjectContexts expected = contextsFromMap(param.expected);
+
+    String blobName = generator.randomObjectName();
+    BlobInfo.Builder builder = BlobInfo.newBuilder(bucket, blobName);
+    if (initial != null) {
+      builder.setContexts(initial);
+    }
+    if (param.initial != null) {
+      builder.setMetadata(param.initial);
+    }
+
+    BlobInfo info = builder.build();
+    Blob gen1 = storage.create(info, BlobTargetOption.doesNotExist());
+
+    BlobInfo modified =
+        BlobInfo.newBuilder(bucket, gen1.getName())
+            .setContexts(update)
+            .setMetadata(param.update)
+            .build();
+    Blob gen2 =
+        storage.update(modified, BlobTargetOption.metagenerationMatch(gen1.getMetageneration()));
     assertContextsWithEqualValues(gen2.getContexts(), expected);
     assertThat(gen2.getMetadata()).isEqualTo(param.expected);
   }


### PR DESCRIPTION
Fixes #12632

## Summary

- Treat empty or null blob metadata, object contexts, and bucket labels on fresh builders as root-level clears.
- Preserve fine-grained map diffs when a builder has original state or receives non-empty updates.
- Add production integration coverage for updates built without fetching the current resource first.

## Root cause

Fresh builders start with null map fields. Updating them to an empty or null value produced no nested differences, so the update mask remained empty and the client performed a read instead of clearing the remote field.

## Validation

- `mvn -pl google-cloud-storage -DskipTests fmt:format` (Java 21)
- `mvn -pl google-cloud-storage -am -Dtest=ITUpdateMaskTest,BlobInfoTest,BucketInfoTest -Dsurefire.failIfNoSpecifiedTests=false test` (82 tests)
- `git diff --check`
