### PR TITLE
chore: release java-cloud-bom as 26.85.1

### DIFF
--- a/java-cloud-bom/google-cloud-bom/pom.xml
+++ b/java-cloud-bom/google-cloud-bom/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-bom</artifactId>
   <packaging>pom</packaging>
-  <version>0.267.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
+  <version>0.266.1</version><!-- {x-version-update:google-cloud-bom:current} -->
   <name>Google Cloud Java BOM</name>
   <url>https://github.com/googleapis/google-cloud-java</url>
   <description>
@@ -172,7 +172,7 @@
         <!-- Artifacts from google-cloud-java monorepo -->
         <groupId>com.google.cloud</groupId>
         <artifactId>gapic-libraries-bom</artifactId>
-        <version>1.89.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
+        <version>1.88.1</version><!-- {x-version-update:google-cloud-java:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/java-cloud-bom/libraries-bom/pom.xml
+++ b/java-cloud-bom/libraries-bom/pom.xml
@@ -4,7 +4,7 @@
   <!-- adding comment for testing-->
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>26.86.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom:current} -->
+  <version>26.85.1</version><!-- {x-version-update:libraries-bom:current} -->
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.267.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
+        <version>0.266.1</version><!-- {x-version-update:google-cloud-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/java-cloud-bom/tests/dependency-convergence/pom.xml
+++ b/java-cloud-bom/tests/dependency-convergence/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>full-convergence-check</artifactId>
   <packaging>pom</packaging>
   <!-- We do not publish this module to Maven Central -->
-  <version>0.85.0-SNAPSHOT</version><!-- {x-version-update:full-convergence-check:current} -->
+  <version>0.84.0</version><!-- {x-version-update:full-convergence-check:current} -->
   <name>Full convergence check for all library dependencies in Google Cloud Java BOM</name>
   <description>
     BOM for Full convergence check on google-cloud-java
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.86.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom:current} -->
+        <version>26.85.1</version><!-- {x-version-update:libraries-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/java-cloud-bom/tests/pom.xml
+++ b/java-cloud-bom/tests/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>java-cloud-bom-tests</artifactId>
-  <version>0.82.0-SNAPSHOT</version><!-- {x-version-update:java-cloud-bom-tests:current} -->
+  <version>0.81.0</version><!-- {x-version-update:java-cloud-bom-tests:current} -->
   <name>A module to test Google Cloud Java BOMs</name>
   <url>https://github.com/googleapis/java-cloud-bom</url>
   <description>

--- a/java-cloud-bom/tests/validate-bom/pom.xml
+++ b/java-cloud-bom/tests/validate-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pom-parent</artifactId>
-    <version>1.89.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
+    <version>1.88.0</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../../../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,7 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-java:1.88.0:1.89.0-SNAPSHOT
+google-cloud-java:1.88.1:1.89.0-SNAPSHOT
 google-cloud-pom-parent:1.88.0:1.89.0-SNAPSHOT
 google-cloud-accessapproval:2.95.0:2.96.0-SNAPSHOT
 grpc-google-cloud-accessapproval-v1:2.95.0:2.96.0-SNAPSHOT
@@ -1060,8 +1060,8 @@ google-cloud-developer-knowledge:0.2.0:0.3.0-SNAPSHOT
 proto-google-cloud-developer-knowledge-v1:0.2.0:0.3.0-SNAPSHOT
 grpc-google-cloud-developer-knowledge-v1:0.2.0:0.3.0-SNAPSHOT
 google-cloud-backstory:0.2.0:0.3.0-SNAPSHOT
-google-cloud-bom:0.266.0:0.267.0-SNAPSHOT
-libraries-bom:26.85.0:26.86.0-SNAPSHOT
+google-cloud-bom:0.266.1:0.266.1
+libraries-bom:26.85.1:26.85.1
 java-cloud-bom-tests:0.81.0:0.82.0-SNAPSHOT
 full-convergence-check:0.84.0:0.85.0-SNAPSHOT
 google-cloud-shared-config:1.18.0:1.19.0-SNAPSHOT


### PR DESCRIPTION
Bumps version of google-cloud-bom to 0.266.1 and libraries-bom to 26.85.1 to import gapic-libraries-bom 1.88.1 (including dataproc 4.91.1).