### PR TITLE
fix(release): resolve first-party-dependencies SNAPSHOT in libraries-bom

### DIFF
--- a/java-cloud-bom/libraries-bom/pom.xml
+++ b/java-cloud-bom/libraries-bom/pom.xml
@@ -44,7 +44,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <first-party-dependencies.version>3.65.0-SNAPSHOT</first-party-dependencies.version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+    <first-party-dependencies.version>3.64.0</first-party-dependencies.version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
     <enforcer.skip>true</enforcer.skip>
   </properties>
 


### PR DESCRIPTION
Resolves the stale SNAPSHOT version of first-party-dependencies in libraries-bom which caused release builds to fail.