### PR TITLE
fix(release): support generic XML version tags in apply_versions.sh

### DIFF
--- a/generation/apply_versions.sh
+++ b/generation/apply_versions.sh
@@ -38,7 +38,7 @@ trap 'rm -f "$SED_SCRIPT_FILE"' EXIT
 for KV in $(cut -f1,"${column_index}" -d: $versions_file |grep -v "#"); do
   K=${KV%:*}; V=${KV#*:}
   echo Key:$K, Value:$V;
-  echo "/x-version-update:$K:current/{s|<version>.*<\/version>|<version>$V<\/version>|;}" >> "$SED_SCRIPT_FILE"
+  echo '/x-version-update:'"$K"':current/{s|<\([^>]*\)>[^<]*</\1>|<\1>'"$V"'</\1>|;}' >> "$SED_SCRIPT_FILE"
 done
 
 echo "Running sed command. It may take few minutes."


### PR DESCRIPTION
Updates apply_versions.sh to use a generic XML tag replacement regex with backreferences. This allows the script to update dependency versions defined in custom XML properties (such as first-party-dependencies.version in libraries-bom/pom.xml), rather than only matching standard <version> tags.