### PR TITLE
ci: restore Java 8 test runtimes for migrated libraries

### DIFF
--- a/.github/workflows/java-bigtable-ci.yaml
+++ b/.github/workflows/java-bigtable-ci.yaml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: 11
+          java-version: 8
           distribution: temurin
       - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
         # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
@@ -98,7 +98,7 @@ jobs:
     - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 8
     - run: java -version
     - run: .kokoro/build.sh
       env:

--- a/.github/workflows/java-cloud-bom-ci.yaml
+++ b/.github/workflows/java-cloud-bom-ci.yaml
@@ -79,7 +79,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
-          java-version: 11
+          java-version: 8
           distribution: temurin
           cache: 'maven'
       - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
@@ -112,7 +112,7 @@ jobs:
     - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 8
         cache: 'maven'
     - run: java -version
     - name: Pre-install all BOM modules to populate local cache

--- a/.github/workflows/java-firestore-ci.yaml
+++ b/.github/workflows/java-firestore-ci.yaml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: 11
+          java-version: 8
           distribution: temurin
       - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
         # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
@@ -98,7 +98,7 @@ jobs:
     - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 8
     - run: java -version
     - run: .kokoro/build.sh
       env:

--- a/.github/workflows/java-pubsub-ci.yaml
+++ b/.github/workflows/java-pubsub-ci.yaml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: 11
+          java-version: 8
           distribution: temurin
       - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
         # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
@@ -98,7 +98,7 @@ jobs:
     - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 8
     - run: java -version
     - run: .kokoro/build.sh
       env:

--- a/.github/workflows/java-shared-config-ci.yaml
+++ b/.github/workflows/java-shared-config-ci.yaml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
-          java-version: 11
+          java-version: 8
           distribution: temurin
       - name: "Set jvm system property environment variable for surefire plugin (unit tests)"
         # Maven surefire plugin (unit tests) allows us to specify JVM to run the tests.
@@ -98,7 +98,7 @@ jobs:
     - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 8
     - run: java -version
     - run: .kokoro/build.sh
       env:


### PR DESCRIPTION
Some modules may have accidentally changed `unit (8)` to be tested on JDK 11 as part of the migration