### PR TITLE
test(bigtable): fix JSpecify CI issues on Java 8

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientTests.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminClientTests.java
@@ -88,7 +88,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnit;
@@ -143,168 +142,139 @@ public class BigtableInstanceAdminClientTests {
 
   private BigtableInstanceAdminStub mockStub;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CreateInstanceRequest,
           com.google.bigtable.admin.v2.Instance,
           CreateInstanceMetadata>
       mockCreateInstanceCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.PartialUpdateInstanceRequest,
           com.google.bigtable.admin.v2.Instance,
           UpdateInstanceMetadata>
       mockUpdateInstanceCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.GetInstanceRequest, com.google.bigtable.admin.v2.Instance>
       mockGetInstanceCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ListInstancesRequest,
           com.google.bigtable.admin.v2.ListInstancesResponse>
       mockListInstancesCallable;
 
-  @Mock
   private UnaryCallable<com.google.bigtable.admin.v2.DeleteInstanceRequest, Empty>
       mockDeleteInstanceCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CreateClusterRequest,
           com.google.bigtable.admin.v2.Cluster,
           com.google.bigtable.admin.v2.CreateClusterMetadata>
       mockCreateClusterCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.GetClusterRequest, com.google.bigtable.admin.v2.Cluster>
       mockGetClusterCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ListClustersRequest,
           com.google.bigtable.admin.v2.ListClustersResponse>
       mockListClustersCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.Cluster,
           com.google.bigtable.admin.v2.Cluster,
           UpdateClusterMetadata>
       mockUpdateClusterCallable;
 
-  @Mock
   private OperationCallable<
           PartialUpdateClusterRequest,
           com.google.bigtable.admin.v2.Cluster,
           PartialUpdateClusterMetadata>
       mockPartialUpdateClusterCallable;
 
-  @Mock
   private UnaryCallable<com.google.bigtable.admin.v2.DeleteClusterRequest, Empty>
       mockDeleteClusterCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.CreateAppProfileRequest,
           com.google.bigtable.admin.v2.AppProfile>
       mockCreateAppProfileCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.GetAppProfileRequest,
           com.google.bigtable.admin.v2.AppProfile>
       mockGetAppProfileCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ListAppProfilesRequest, ListAppProfilesPagedResponse>
       mockListAppProfilesCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.UpdateAppProfileRequest,
           com.google.bigtable.admin.v2.AppProfile,
           com.google.bigtable.admin.v2.UpdateAppProfileMetadata>
       mockUpdateAppProfileCallable;
 
-  @Mock
   private UnaryCallable<com.google.bigtable.admin.v2.DeleteAppProfileRequest, Empty>
       mockDeleteAppProfileCallable;
 
-  @Mock
   private UnaryCallable<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       mockGetIamPolicyCallable;
 
-  @Mock
   private UnaryCallable<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       mockSetIamPolicyCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       mockTestIamPermissionsCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CreateMaterializedViewRequest,
           com.google.bigtable.admin.v2.MaterializedView,
           com.google.bigtable.admin.v2.CreateMaterializedViewMetadata>
       mockCreateMaterializedViewCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.GetMaterializedViewRequest,
           com.google.bigtable.admin.v2.MaterializedView>
       mockGetMaterializedViewCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ListMaterializedViewsRequest,
           ListMaterializedViewsPagedResponse>
       mockListMaterializedViewsCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.UpdateMaterializedViewRequest,
           com.google.bigtable.admin.v2.MaterializedView,
           com.google.bigtable.admin.v2.UpdateMaterializedViewMetadata>
       mockUpdateMaterializedViewCallable;
 
-  @Mock
   private UnaryCallable<com.google.bigtable.admin.v2.DeleteMaterializedViewRequest, Empty>
       mockDeleteMaterializedViewCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CreateLogicalViewRequest,
           com.google.bigtable.admin.v2.LogicalView,
           com.google.bigtable.admin.v2.CreateLogicalViewMetadata>
       mockCreateLogicalViewCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.GetLogicalViewRequest,
           com.google.bigtable.admin.v2.LogicalView>
       mockGetLogicalViewCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ListLogicalViewsRequest, ListLogicalViewsPagedResponse>
       mockListLogicalViewsCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.UpdateLogicalViewRequest,
           com.google.bigtable.admin.v2.LogicalView,
           com.google.bigtable.admin.v2.UpdateLogicalViewMetadata>
       mockUpdateLogicalViewCallable;
 
-  @Mock
   private UnaryCallable<com.google.bigtable.admin.v2.DeleteLogicalViewRequest, Empty>
       mockDeleteLogicalViewCallable;
 
@@ -313,6 +283,65 @@ public class BigtableInstanceAdminClientTests {
     mockStub =
         Mockito.mock(BigtableInstanceAdminStub.class, Mockito.withSettings().withoutAnnotations());
     adminClient = BigtableInstanceAdminClient.create(PROJECT_ID, mockStub);
+
+    mockCreateInstanceCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateInstanceCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetInstanceCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListInstancesCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteInstanceCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCreateClusterCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetClusterCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListClustersCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateClusterCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockPartialUpdateClusterCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteClusterCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCreateAppProfileCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetAppProfileCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListAppProfilesCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateAppProfileCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteAppProfileCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetIamPolicyCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockSetIamPolicyCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockTestIamPermissionsCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCreateMaterializedViewCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetMaterializedViewCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListMaterializedViewsCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateMaterializedViewCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteMaterializedViewCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCreateLogicalViewCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetLogicalViewCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListLogicalViewsCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateLogicalViewCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteLogicalViewCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
   }
 
   @Test

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettingsTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableInstanceAdminSettingsTest.java
@@ -60,7 +60,8 @@ public class BigtableInstanceAdminSettingsTest {
 
   @Test
   public void testCredentials() throws IOException {
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    CredentialsProvider credentialsProvider =
+        Mockito.mock(CredentialsProvider.class, Mockito.withSettings().withoutAnnotations());
 
     BigtableInstanceAdminSettings settings =
         BigtableInstanceAdminSettings.newBuilder()

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientTests.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientTests.java
@@ -116,7 +116,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -151,140 +150,117 @@ public class BigtableTableAdminClientTests {
   private BigtableTableAdminClient adminClient;
   private EnhancedBigtableTableAdminStub mockStub;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.CreateTableRequest, com.google.bigtable.admin.v2.Table>
       mockCreateTableCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.UpdateTableRequest,
           com.google.bigtable.admin.v2.Table,
           UpdateTableMetadata>
       mockUpdateTableOperationCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest,
           com.google.bigtable.admin.v2.Table>
       mockModifyTableCallable;
 
-  @Mock private UnaryCallable<DeleteTableRequest, Empty> mockDeleteTableCallable;
+  private UnaryCallable<DeleteTableRequest, Empty> mockDeleteTableCallable;
 
-  @Mock
   private UnaryCallable<GetTableRequest, com.google.bigtable.admin.v2.Table> mockGetTableCallable;
 
-  @Mock private UnaryCallable<ListTablesRequest, ListTablesPagedResponse> mockListTableCallable;
-  @Mock private UnaryCallable<DropRowRangeRequest, Empty> mockDropRowRangeCallable;
-  @Mock private UnaryCallable<TableName, Void> mockAwaitReplicationCallable;
+  private UnaryCallable<ListTablesRequest, ListTablesPagedResponse> mockListTableCallable;
+  private UnaryCallable<DropRowRangeRequest, Empty> mockDropRowRangeCallable;
+  private UnaryCallable<TableName, Void> mockAwaitReplicationCallable;
 
-  @Mock private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
+  private UnaryCallable<ConsistencyRequest, Void> mockAwaitConsistencyCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CreateBackupRequest,
           com.google.bigtable.admin.v2.Backup,
           CreateBackupMetadata>
       mockCreateBackupOperationCallable;
 
-  @Mock
   private UnaryCallable<GetBackupRequest, com.google.bigtable.admin.v2.Backup>
       mockGetBackupCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.UpdateBackupRequest, com.google.bigtable.admin.v2.Backup>
       mockUpdateBackupCallable;
 
-  @Mock private UnaryCallable<ListBackupsRequest, ListBackupsPagedResponse> mockListBackupCallable;
-  @Mock private UnaryCallable<DeleteBackupRequest, Empty> mockDeleteBackupCallable;
+  private UnaryCallable<ListBackupsRequest, ListBackupsPagedResponse> mockListBackupCallable;
+  private UnaryCallable<DeleteBackupRequest, Empty> mockDeleteBackupCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.RestoreTableRequest,
           com.google.bigtable.admin.v2.Table,
           RestoreTableMetadata>
       mockRestoreTableOperationCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CopyBackupRequest,
           com.google.bigtable.admin.v2.Backup,
           CopyBackupMetadata>
       mockCopyBackupOperationCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CreateAuthorizedViewRequest,
           com.google.bigtable.admin.v2.AuthorizedView,
           CreateAuthorizedViewMetadata>
       mockCreateAuthorizedViewOperationCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.UpdateAuthorizedViewRequest,
           com.google.bigtable.admin.v2.AuthorizedView,
           UpdateAuthorizedViewMetadata>
       mockUpdateAuthorizedViewOperationCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.GetAuthorizedViewRequest,
           com.google.bigtable.admin.v2.AuthorizedView>
       mockGetAuthorizedViewCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ListAuthorizedViewsRequest, ListAuthorizedViewsPagedResponse>
       mockListAuthorizedViewsCallable;
 
-  @Mock
   private UnaryCallable<com.google.bigtable.admin.v2.DeleteAuthorizedViewRequest, Empty>
       mockDeleteAuthorizedViewCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.CreateSchemaBundleRequest,
           com.google.bigtable.admin.v2.SchemaBundle,
           CreateSchemaBundleMetadata>
       mockCreateSchemaBundleOperationCallable;
 
-  @Mock
   private OperationCallable<
           com.google.bigtable.admin.v2.UpdateSchemaBundleRequest,
           com.google.bigtable.admin.v2.SchemaBundle,
           UpdateSchemaBundleMetadata>
       mockUpdateSchemaBundleOperationCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.GetSchemaBundleRequest,
           com.google.bigtable.admin.v2.SchemaBundle>
       mockGetSchemaBundleCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.bigtable.admin.v2.ListSchemaBundlesRequest, ListSchemaBundlesPagedResponse>
       mockListSchemaBundlesCallable;
 
-  @Mock
   private UnaryCallable<com.google.bigtable.admin.v2.DeleteSchemaBundleRequest, Empty>
       mockDeleteSchemaBundleCallable;
 
-  @Mock
   private UnaryCallable<com.google.iam.v1.GetIamPolicyRequest, com.google.iam.v1.Policy>
       mockGetIamPolicyCallable;
 
-  @Mock
   private UnaryCallable<com.google.iam.v1.SetIamPolicyRequest, com.google.iam.v1.Policy>
       mockSetIamPolicyCallable;
 
-  @Mock
   private UnaryCallable<
           com.google.iam.v1.TestIamPermissionsRequest, com.google.iam.v1.TestIamPermissionsResponse>
       mockTestIamPermissionsCallable;
 
-  @Mock
   private OperationCallable<Void, Empty, OptimizeRestoredTableMetadata>
       mockOptimizeRestoredTableCallable;
 
@@ -294,6 +270,67 @@ public class BigtableTableAdminClientTests {
         Mockito.mock(
             EnhancedBigtableTableAdminStub.class, Mockito.withSettings().withoutAnnotations());
     adminClient = BigtableTableAdminClient.create(PROJECT_ID, INSTANCE_ID, mockStub);
+
+    mockCreateTableCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateTableOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockModifyTableCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteTableCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetTableCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListTableCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDropRowRangeCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockAwaitReplicationCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockAwaitConsistencyCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCreateBackupOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetBackupCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateBackupCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListBackupCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteBackupCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockRestoreTableOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCopyBackupOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCreateAuthorizedViewOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateAuthorizedViewOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetAuthorizedViewCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListAuthorizedViewsCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteAuthorizedViewCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockCreateSchemaBundleOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockUpdateSchemaBundleOperationCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetSchemaBundleCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockListSchemaBundlesCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockDeleteSchemaBundleCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockGetIamPolicyCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockSetIamPolicyCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockTestIamPermissionsCallable =
+        Mockito.mock(UnaryCallable.class, Mockito.withSettings().withoutAnnotations());
+    mockOptimizeRestoredTableCallable =
+        Mockito.mock(OperationCallable.class, Mockito.withSettings().withoutAnnotations());
   }
 
   @Test

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/BigtableTableAdminClientV2Test.java
@@ -133,7 +133,7 @@ public class BigtableTableAdminClientV2Test {
 
     // 4. Mock the Stub's behavior (resuming the Optimize Op)
     OperationFuture<Empty, OptimizeRestoredTableMetadata> mockOptimizeOp =
-        Mockito.mock(OperationFuture.class);
+        Mockito.mock(OperationFuture.class, Mockito.withSettings().withoutAnnotations());
     Mockito.when(mockOptimizeOp.get()).thenReturn(Empty.getDefaultInstance());
     Mockito.doAnswer(
             invocation -> {


### PR DESCRIPTION
Disable annotations in Mockito mocks for Gax callables and providers to avoid ArrayStoreException on Java 8 when reflecting on JSpecify annotations.