### PR TITLE
test(bigquery-jdbc): fix JSpecify compatibility issues on Java 8

### DIFF
--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.paging.Page;
@@ -535,7 +536,7 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
       BigQuery mockBigQuery = mock(BigQuery.class);
       connection.bigQuery = mockBigQuery;
 
-      Page<Project> mockPage = mock(Page.class);
+      Page<Project> mockPage = mock(Page.class, withSettings().withoutAnnotations());
       Project project1 = mock(Project.class);
       when(project1.getProjectId()).thenReturn("discovered-p1");
       Project project2 = mock(Project.class);

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryDatabaseMetaDataTest.java
@@ -1009,7 +1009,7 @@ public class BigQueryDatabaseMetaDataTest {
     Routine func1 = mockBigQueryRoutine(catalog, schema, "func_123", "FUNCTION", "f1");
     Routine otherProc = mockBigQueryRoutine(catalog, schema, "another_proc", "PROCEDURE", "p3");
 
-    Page<Routine> page = mock(Page.class);
+    Page<Routine> page = mock(Page.class, withSettings().withoutAnnotations());
     when(page.iterateAll()).thenReturn(Arrays.asList(proc1, func1, proc2, otherProc));
     when(bigqueryClient.listRoutines(eq(datasetId), any(BigQuery.RoutineListOption[].class)))
         .thenReturn(page);
@@ -1053,7 +1053,7 @@ public class BigQueryDatabaseMetaDataTest {
     Routine proc1 = mockBigQueryRoutine(catalog, schema, "proc_abc", "PROCEDURE", "p1");
     Routine func1 = mockBigQueryRoutine(catalog, schema, "func_123", "FUNCTION", "f1");
 
-    Page<Routine> page = mock(Page.class);
+    Page<Routine> page = mock(Page.class, withSettings().withoutAnnotations());
     when(page.iterateAll()).thenReturn(Arrays.asList(proc1, func1));
     when(bigqueryClient.listRoutines(eq(datasetId), any(BigQuery.RoutineListOption[].class)))
         .thenReturn(page);
@@ -1545,12 +1545,12 @@ public class BigQueryDatabaseMetaDataTest {
     Routine func1_ds1 = mockBigQueryRoutine(catalog, schema1Name, "func_b", "FUNCTION", "desc b");
     Routine proc2_ds2 = mockBigQueryRoutine(catalog, schema2Name, "proc_c", "PROCEDURE", "desc c");
 
-    Page<Routine> page1 = mock(Page.class);
+    Page<Routine> page1 = mock(Page.class, withSettings().withoutAnnotations());
     when(page1.iterateAll()).thenReturn(Arrays.asList(proc1_ds1, func1_ds1));
     when(bigqueryClient.listRoutines(eq(dataset1.getDatasetId()), any(RoutineListOption.class)))
         .thenReturn(page1);
 
-    Page<Routine> page2 = mock(Page.class);
+    Page<Routine> page2 = mock(Page.class, withSettings().withoutAnnotations());
     when(page2.iterateAll()).thenReturn(Collections.singletonList(proc2_ds2));
     when(bigqueryClient.listRoutines(eq(dataset2.getDatasetId()), any(RoutineListOption.class)))
         .thenReturn(page2);
@@ -3309,20 +3309,20 @@ public class BigQueryDatabaseMetaDataTest {
     when(bigQueryConnection.getDiscoveredProjects()).thenReturn(Arrays.asList("discovered-1"));
     when(bigQueryConnection.getAdditionalProjects()).thenReturn("additional-1");
 
-    Page<Dataset> pagePrimary = mock(Page.class);
+    Page<Dataset> pagePrimary = mock(Page.class, withSettings().withoutAnnotations());
     Dataset dsPrimary = mockBigQueryDataset("primary-project", "dataset_p");
     when(pagePrimary.iterateAll()).thenReturn(Collections.singletonList(dsPrimary));
     when(bigqueryClient.listDatasets(
             eq("primary-project"), any(BigQuery.DatasetListOption[].class)))
         .thenReturn(pagePrimary);
 
-    Page<Dataset> pageAdditional = mock(Page.class);
+    Page<Dataset> pageAdditional = mock(Page.class, withSettings().withoutAnnotations());
     Dataset dsAdditional = mockBigQueryDataset("additional-1", "dataset_a");
     when(pageAdditional.iterateAll()).thenReturn(Collections.singletonList(dsAdditional));
     when(bigqueryClient.listDatasets(eq("additional-1"), any(BigQuery.DatasetListOption[].class)))
         .thenReturn(pageAdditional);
 
-    Page<Dataset> pageDiscovered = mock(Page.class);
+    Page<Dataset> pageDiscovered = mock(Page.class, withSettings().withoutAnnotations());
     Dataset dsDiscovered = mockBigQueryDataset("discovered-1", "dataset_d");
     when(pageDiscovered.iterateAll()).thenReturn(Collections.singletonList(dsDiscovered));
     when(bigqueryClient.listDatasets(eq("discovered-1"), any(BigQuery.DatasetListOption[].class)))
@@ -3354,14 +3354,14 @@ public class BigQueryDatabaseMetaDataTest {
     when(bigQueryConnection.getDiscoveredProjects()).thenReturn(Arrays.asList("discovered-1"));
     when(bigQueryConnection.getAdditionalProjects()).thenReturn("additional-1");
 
-    Page<Dataset> pagePrimary = mock(Page.class);
+    Page<Dataset> pagePrimary = mock(Page.class, withSettings().withoutAnnotations());
     Dataset dsPrimary = mockBigQueryDataset("primary-project", "dataset_p");
     when(pagePrimary.iterateAll()).thenReturn(Collections.singletonList(dsPrimary));
     when(bigqueryClient.listDatasets(
             eq("primary-project"), any(BigQuery.DatasetListOption[].class)))
         .thenReturn(pagePrimary);
 
-    Page<Dataset> pageAdditional = mock(Page.class);
+    Page<Dataset> pageAdditional = mock(Page.class, withSettings().withoutAnnotations());
     Dataset dsAdditional = mockBigQueryDataset("additional-1", "dataset_a");
     when(pageAdditional.iterateAll()).thenReturn(Collections.singletonList(dsAdditional));
     when(bigqueryClient.listDatasets(eq("additional-1"), any(BigQuery.DatasetListOption[].class)))
@@ -3388,7 +3388,7 @@ public class BigQueryDatabaseMetaDataTest {
   }
 
   private void mockDatasetIteration(DatasetId datasetId) {
-    Page<Dataset> pagePrimary = mock(Page.class);
+    Page<Dataset> pagePrimary = mock(Page.class, withSettings().withoutAnnotations());
     Dataset dsPrimary = mock(Dataset.class);
     when(dsPrimary.getDatasetId()).thenReturn(datasetId);
     when(pagePrimary.iterateAll()).thenReturn(Collections.singletonList(dsPrimary));
@@ -3411,7 +3411,7 @@ public class BigQueryDatabaseMetaDataTest {
   }
 
   private void mockTableIteration(DatasetId datasetId, Table... tables) {
-    Page<Table> pageTables = mock(Page.class);
+    Page<Table> pageTables = mock(Page.class, withSettings().withoutAnnotations());
     when(pageTables.iterateAll()).thenReturn(Arrays.asList(tables));
     when(bigqueryClient.listTables(eq(datasetId), any(BigQuery.TableListOption[].class)))
         .thenReturn(pageTables);

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
@@ -596,8 +597,8 @@ public class BigQueryStatementTest {
   }
 
   private ApiException mockApiException(StatusCode.Code code) {
-    ApiException apiExceptionMock = mock(ApiException.class);
-    StatusCode statusCodeMock = mock(StatusCode.class);
+    ApiException apiExceptionMock = mock(ApiException.class, withSettings().withoutAnnotations());
+    StatusCode statusCodeMock = mock(StatusCode.class, withSettings().withoutAnnotations());
     doReturn(statusCodeMock).when(apiExceptionMock).getStatusCode();
     doReturn(code).when(statusCodeMock).getCode();
     return apiExceptionMock;


### PR DESCRIPTION
Update Mockito mocks in BigQuery JDBC tests to ignore annotations, preventing ArrayStoreException when running tests on Java 8. Specifically, mock Page, ApiException, and StatusCode classes with withSettings().withoutAnnotations().