### PR TITLE
test(firestore): fix JSpecify compatibility issues on Java 8

### DIFF
--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ConformanceTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/ConformanceTest.java
@@ -85,7 +85,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
@@ -616,13 +615,15 @@ public class ConformanceTest {
       extends BaseConformanceTestRunner<ListenTest> {
 
     @Captor private ArgumentCaptor<BidiStreamObserver<Message, Message>> streamObserverCapture;
-    @Mock private ClientStream<ListenRequest> noOpRequestObserver;
+    private final ClientStream<ListenRequest> noOpRequestObserver;
 
     private final Query watchQuery;
 
     private ConformanceListenTestRunner(
         String description, TestDefinition.ListenTest testParameters) {
       super(description, testParameters);
+      noOpRequestObserver =
+          Mockito.mock(ClientStream.class, Mockito.withSettings().withoutAnnotations());
       watchQuery = collection(ROOT_COLLECTION_PATH + "C").orderBy("a");
     }
 

--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/LocalFirestoreHelper.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
@@ -415,7 +416,7 @@ public final class LocalFirestoreHelper {
     return invocation -> {
       Object[] args = invocation.getArguments();
       ResponseObserver<T> observer = (ResponseObserver<T>) args[1];
-      observer.onStart(mock(StreamController.class));
+      observer.onStart(mock(StreamController.class, withSettings().withoutAnnotations()));
       for (T resp : response) {
         observer.onResponse(resp);
       }
@@ -432,7 +433,7 @@ public final class LocalFirestoreHelper {
     return invocation -> {
       Object[] args = invocation.getArguments();
       ResponseObserver<T> observer = (ResponseObserver<T>) args[1];
-      observer.onStart(mock(StreamController.class));
+      observer.onStart(mock(StreamController.class, withSettings().withoutAnnotations()));
       for (T resp : response) {
         observer.onResponse(resp);
       }

--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/SilenceableBidiStreamTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/SilenceableBidiStreamTest.java
@@ -24,22 +24,22 @@ import com.google.api.gax.rpc.StreamController;
 import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SilenceableBidiStreamTest {
 
-  @Mock BidiStreamObserver<Integer, String> mockObserver;
+  BidiStreamObserver<Integer, String> mockObserver;
 
-  @Mock ClientStream<Integer> mockClientStream;
+  ClientStream<Integer> mockClientStream;
 
   SilenceableBidiStream<Integer, String> sut;
 
   @Before
   public void before() {
+    mockObserver =
+        Mockito.mock(BidiStreamObserver.class, Mockito.withSettings().withoutAnnotations());
+    mockClientStream =
+        Mockito.mock(ClientStream.class, Mockito.withSettings().withoutAnnotations());
     Consumer captureCall = Mockito.mock(Consumer.class);
     sut =
         new SilenceableBidiStream<>(
@@ -76,7 +76,8 @@ public class SilenceableBidiStreamTest {
 
   @Test
   public void byDefault_theStreamWillPassThroughData_onStart() {
-    StreamController controller = Mockito.mock(StreamController.class);
+    StreamController controller =
+        Mockito.mock(StreamController.class, Mockito.withSettings().withoutAnnotations());
     sut.onStart(controller);
     Mockito.verify(mockObserver, Mockito.times(1)).onStart(controller);
     Mockito.verifyNoMoreInteractions(mockClientStream, mockObserver, controller);
@@ -84,7 +85,8 @@ public class SilenceableBidiStreamTest {
 
   @Test
   public void byDefault_theStreamWillPassThroughData_onReady() {
-    ClientStream<Integer> client = Mockito.mock(ClientStream.class);
+    ClientStream<Integer> client =
+        Mockito.mock(ClientStream.class, Mockito.withSettings().withoutAnnotations());
     sut.onReady(client);
     Mockito.verify(mockObserver, Mockito.times(1)).onReady(client);
     Mockito.verifyNoMoreInteractions(mockClientStream, mockObserver, client);


### PR DESCRIPTION
Update Mockito mocks in Firestore tests to ignore annotations, preventing ArrayStoreException when running tests on Java 8. Specifically, mock StreamController, BidiStreamObserver, and ClientStream classes with Mockito.withSettings().withoutAnnotations(). Refactor SilenceableBidiStreamTest to use programmatic mocks instead of @Mock annotations to allow configuring settings.