### PR TITLE
test(spanner): apply withoutAnnotations to all GAX mocks for Java 8 compatibility

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AbstractReadContextTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.gax.core.ExecutorProvider;
 import com.google.cloud.spanner.Options.RpcPriority;
@@ -148,7 +149,7 @@ public class AbstractReadContextTest {
             .setSession(session)
             .setRpc(mock(SpannerRpc.class))
             .setDefaultQueryOptions(defaultQueryOptions)
-            .setExecutorProvider(mock(ExecutorProvider.class))
+            .setExecutorProvider(mock(ExecutorProvider.class, withSettings().withoutAnnotations()))
             .build();
   }
 
@@ -361,7 +362,7 @@ public class AbstractReadContextTest {
             .setSession(session)
             .setRpc(mock(SpannerRpc.class))
             .setDefaultQueryOptions(defaultQueryOptions)
-            .setExecutorProvider(mock(ExecutorProvider.class))
+            .setExecutorProvider(mock(ExecutorProvider.class, withSettings().withoutAnnotations()))
             .build();
 
     ExecuteSqlRequest request =

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.core.ExecutorProvider;
@@ -64,7 +65,7 @@ public class AsyncResultSetImplTest {
 
   @Before
   public void setup() {
-    mockedProvider = mock(ExecutorProvider.class);
+    mockedProvider = mock(ExecutorProvider.class, withSettings().withoutAnnotations());
     when(mockedProvider.getExecutor()).thenReturn(mock(ScheduledExecutorService.class));
     simpleProvider = SpannerOptions.createAsyncExecutorProvider(1, 1L, TimeUnit.SECONDS);
   }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CompositeTracerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CompositeTracerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.gax.tracing.ApiTracer;
 import com.google.api.gax.tracing.ApiTracer.Scope;
@@ -46,30 +47,33 @@ import org.mockito.junit.MockitoRule;
 public class CompositeTracerTest {
   @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-  @Mock private ApiTracer child1;
-  @Mock private ApiTracer child2;
+  private ApiTracer child1;
+  private ApiTracer child2;
   @Mock private OpenTelemetryApiTracer child3;
-  @Mock private MetricsTracer child4;
+  private MetricsTracer child4;
 
   private CompositeTracer compositeTracer;
 
   @Before
   public void setup() {
+    child1 = mock(ApiTracer.class, withSettings().withoutAnnotations());
+    child2 = mock(ApiTracer.class, withSettings().withoutAnnotations());
+    child4 = mock(MetricsTracer.class, withSettings().withoutAnnotations());
     compositeTracer = new CompositeTracer(ImmutableList.of(child1, child2, child3, child4));
   }
 
   @Test
   public void testInScope() {
-    Scope scope1 = mock(Scope.class);
+    Scope scope1 = mock(Scope.class, withSettings().withoutAnnotations());
     when(child1.inScope()).thenReturn(scope1);
 
-    Scope scope2 = mock(Scope.class);
+    Scope scope2 = mock(Scope.class, withSettings().withoutAnnotations());
     when(child2.inScope()).thenReturn(scope2);
 
-    Scope scope3 = mock(Scope.class);
+    Scope scope3 = mock(Scope.class, withSettings().withoutAnnotations());
     when(child3.inScope()).thenReturn(scope3);
 
-    Scope scope4 = mock(Scope.class);
+    Scope scope4 = mock(Scope.class, withSettings().withoutAnnotations());
     when(child4.inScope()).thenReturn(scope4);
 
     Scope parentScope = compositeTracer.inScope();

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.rpc.AbortedException;
@@ -117,7 +118,8 @@ public class PartitionedDmlTransactionTest {
     ResultSetStats stats = ResultSetStats.newBuilder().setRowCountLowerBound(1000L).build();
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
     PartialResultSet p2 = PartialResultSet.newBuilder().setStats(stats).build();
-    ServerStream<PartialResultSet> stream = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     when(stream.iterator()).thenReturn(ImmutableList.of(p1, p2).iterator());
     when(rpc.executeStreamingPartitionedDml(
             Mockito.eq(executeRequestWithoutResumeToken), anyMap(), any(), any(Duration.class)))
@@ -137,7 +139,8 @@ public class PartitionedDmlTransactionTest {
     ResultSetStats stats = ResultSetStats.newBuilder().setRowCountLowerBound(1000L).build();
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
     PartialResultSet p2 = PartialResultSet.newBuilder().setStats(stats).build();
-    ServerStream<PartialResultSet> stream = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     when(stream.iterator()).thenReturn(ImmutableList.of(p1, p2).iterator());
     when(rpc.executeStreamingPartitionedDml(
             Mockito.eq(executeRequestWithRequestOptions), anyMap(), any(), any(Duration.class)))
@@ -159,7 +162,8 @@ public class PartitionedDmlTransactionTest {
     ResultSetStats stats = ResultSetStats.newBuilder().setRowCountLowerBound(1000L).build();
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
     PartialResultSet p2 = PartialResultSet.newBuilder().setStats(stats).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, false);
     when(iterator.next())
@@ -168,7 +172,8 @@ public class PartitionedDmlTransactionTest {
             new AbortedException(
                 "transaction aborted", null, GrpcStatusCode.of(Code.ABORTED), true));
     when(stream1.iterator()).thenReturn(iterator);
-    ServerStream<PartialResultSet> stream2 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream2 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     when(stream2.iterator()).thenReturn(ImmutableList.of(p1, p2).iterator());
     when(rpc.executeStreamingPartitionedDml(
             any(ExecuteSqlRequest.class), anyMap(), any(), any(Duration.class)))
@@ -188,7 +193,8 @@ public class PartitionedDmlTransactionTest {
     ResultSetStats stats = ResultSetStats.newBuilder().setRowCountLowerBound(1000L).build();
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
     PartialResultSet p2 = PartialResultSet.newBuilder().setStats(stats).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, false);
     when(iterator.next())
@@ -197,7 +203,8 @@ public class PartitionedDmlTransactionTest {
             new UnavailableException(
                 "temporary unavailable", null, GrpcStatusCode.of(Code.UNAVAILABLE), true));
     when(stream1.iterator()).thenReturn(iterator);
-    ServerStream<PartialResultSet> stream2 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream2 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     when(stream2.iterator()).thenReturn(ImmutableList.of(p1, p2).iterator());
     when(rpc.executeStreamingPartitionedDml(
             Mockito.eq(executeRequestWithoutResumeToken), anyMap(), any(), any(Duration.class)))
@@ -221,7 +228,8 @@ public class PartitionedDmlTransactionTest {
   @Test
   public void testExecuteStreamingPartitionedUpdateUnavailableAndThenDeadlineExceeded() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, false);
     when(iterator.next())
@@ -249,7 +257,8 @@ public class PartitionedDmlTransactionTest {
   @Test
   public void testExecuteStreamingPartitionedUpdateAbortedAndThenDeadlineExceeded() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, false);
     when(iterator.next())
@@ -277,7 +286,8 @@ public class PartitionedDmlTransactionTest {
   @Test
   public void testExecuteStreamingPartitionedUpdateMultipleAbortsUntilDeadlineExceeded() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true);
     when(iterator.next())
@@ -319,7 +329,8 @@ public class PartitionedDmlTransactionTest {
     ResultSetStats stats = ResultSetStats.newBuilder().setRowCountLowerBound(1000L).build();
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
     PartialResultSet p2 = PartialResultSet.newBuilder().setStats(stats).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, false);
     when(iterator.next())
@@ -331,7 +342,8 @@ public class PartitionedDmlTransactionTest {
                 GrpcStatusCode.of(Code.INTERNAL),
                 true));
     when(stream1.iterator()).thenReturn(iterator);
-    ServerStream<PartialResultSet> stream2 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream2 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     when(stream2.iterator()).thenReturn(ImmutableList.of(p1, p2).iterator());
     when(rpc.executeStreamingPartitionedDml(
             Mockito.eq(executeRequestWithoutResumeToken), anyMap(), any(), any(Duration.class)))

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/SpannerCloudMonitoringExporterTest.java
@@ -35,6 +35,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.Distribution;
 import com.google.api.core.ApiFuture;
@@ -139,7 +140,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = Mockito.mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        Mockito.mock(UnaryCallable.class, withSettings().withoutAnnotations());
     Mockito.when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     Mockito.when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
@@ -203,7 +205,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = Mockito.mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        Mockito.mock(UnaryCallable.class, withSettings().withoutAnnotations());
     Mockito.when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     Mockito.when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
@@ -271,7 +274,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        mock(UnaryCallable.class, withSettings().withoutAnnotations());
     when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
@@ -311,7 +315,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        mock(UnaryCallable.class, withSettings().withoutAnnotations());
     when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
@@ -355,7 +360,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        mock(UnaryCallable.class, withSettings().withoutAnnotations());
     when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
@@ -404,7 +410,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        mock(UnaryCallable.class, withSettings().withoutAnnotations());
     when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
@@ -476,7 +483,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        mock(UnaryCallable.class, withSettings().withoutAnnotations());
     when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);
@@ -552,7 +560,8 @@ public class SpannerCloudMonitoringExporterTest {
     ArgumentCaptor<CreateTimeSeriesRequest> argumentCaptor =
         ArgumentCaptor.forClass(CreateTimeSeriesRequest.class);
 
-    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable = mock(UnaryCallable.class);
+    UnaryCallable<CreateTimeSeriesRequest, Empty> mockCallable =
+        mock(UnaryCallable.class, withSettings().withoutAnnotations());
     when(mockMetricServiceStub.createServiceTimeSeriesCallable()).thenReturn(mockCallable);
     ApiFuture<Empty> future = ApiFutures.immediateFuture(Empty.getDefaultInstance());
     when(mockCallable.futureCall(argumentCaptor.capture())).thenReturn(future);

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/ConnectionImplTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
@@ -228,7 +229,7 @@ public class ConnectionImplTest {
       DdlClient ddlClient = mock(DdlClient.class);
       @SuppressWarnings("unchecked")
       final OperationFuture<Void, UpdateDatabaseDdlMetadata> operation =
-          mock(OperationFuture.class);
+          mock(OperationFuture.class, withSettings().withoutAnnotations());
       when(operation.get()).thenReturn(null);
       UpdateDatabaseDdlMetadata metadata = UpdateDatabaseDdlMetadata.getDefaultInstance();
       ApiFuture<UpdateDatabaseDdlMetadata> futureMetadata = ApiFutures.immediateFuture(metadata);

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlBatchTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
@@ -91,7 +92,7 @@ public class DdlBatchTest {
       DdlClient ddlClient = mock(DdlClient.class);
       @SuppressWarnings("unchecked")
       final OperationFuture<Void, UpdateDatabaseDdlMetadata> operation =
-          mock(OperationFuture.class);
+          mock(OperationFuture.class, withSettings().withoutAnnotations());
       if (waitForMillis > 0L) {
         when(operation.get())
             .thenAnswer(
@@ -440,7 +441,8 @@ public class DdlBatchTest {
             .build();
     ApiFuture<UpdateDatabaseDdlMetadata> metadataFuture = ApiFutures.immediateFuture(metadata);
     @SuppressWarnings("unchecked")
-    OperationFuture<Void, UpdateDatabaseDdlMetadata> operationFuture = mock(OperationFuture.class);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> operationFuture =
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
     when(operationFuture.get()).thenReturn(null);
     when(operationFuture.getMetadata()).thenReturn(metadataFuture);
     when(client.executeDdl(argThat(isListOfStringsWithSize(2)), isNull()))
@@ -480,7 +482,8 @@ public class DdlBatchTest {
             .build();
     ApiFuture<UpdateDatabaseDdlMetadata> metadataFuture = ApiFutures.immediateFuture(metadata);
     @SuppressWarnings("unchecked")
-    OperationFuture<Void, UpdateDatabaseDdlMetadata> operationFuture = mock(OperationFuture.class);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> operationFuture =
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
     when(operationFuture.get())
         .thenThrow(
             new ExecutionException(
@@ -533,7 +536,8 @@ public class DdlBatchTest {
             .build();
     ApiFuture<UpdateDatabaseDdlMetadata> metadataFuture = ApiFutures.immediateFuture(metadata);
     @SuppressWarnings("unchecked")
-    OperationFuture<Void, UpdateDatabaseDdlMetadata> operationFuture = mock(OperationFuture.class);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> operationFuture =
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
     when(operationFuture.get())
         .thenThrow(
             new ExecutionException(

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlClientTests.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/DdlClientTests.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.spanner.Database;
@@ -81,7 +82,8 @@ public class DdlClientTests {
     Database database = mock(Database.class);
     Database.Builder databaseBuilder = mock(Database.Builder.class);
     @SuppressWarnings("unchecked")
-    OperationFuture<Void, UpdateDatabaseDdlMetadata> operation = mock(OperationFuture.class);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> operation =
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(operation.get()).thenReturn(null);
     when(client.newDatabaseBuilder((DatabaseId.of(projectId, instanceId, databaseId))))

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/EmulatorUtilTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/EmulatorUtilTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.NoCredentials;
@@ -71,7 +72,7 @@ public class EmulatorUtilTest {
     InstanceAdminClient instanceClient = mock(InstanceAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Instance, CreateInstanceMetadata> instanceOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getInstanceAdminClient()).thenReturn(instanceClient);
     when(instanceClient.createInstance(any(InstanceInfo.class)))
@@ -81,7 +82,7 @@ public class EmulatorUtilTest {
     DatabaseAdminClient databaseClient = mock(DatabaseAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Database, CreateDatabaseMetadata> databaseOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getDatabaseAdminClient()).thenReturn(databaseClient);
     when(databaseClient.createDatabase(
@@ -122,7 +123,7 @@ public class EmulatorUtilTest {
     InstanceAdminClient instanceClient = mock(InstanceAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Instance, CreateInstanceMetadata> instanceOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getInstanceAdminClient()).thenReturn(instanceClient);
     when(instanceClient.createInstance(any(InstanceInfo.class)))
@@ -136,7 +137,7 @@ public class EmulatorUtilTest {
     DatabaseAdminClient databaseClient = mock(DatabaseAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Database, CreateDatabaseMetadata> databaseOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getDatabaseAdminClient()).thenReturn(databaseClient);
     when(databaseClient.createDatabase(
@@ -181,7 +182,7 @@ public class EmulatorUtilTest {
     InstanceAdminClient instanceClient = mock(InstanceAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Instance, CreateInstanceMetadata> instanceOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getInstanceAdminClient()).thenReturn(instanceClient);
     when(instanceClient.createInstance(any(InstanceInfo.class)))
@@ -214,7 +215,7 @@ public class EmulatorUtilTest {
     InstanceAdminClient instanceClient = mock(InstanceAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Instance, CreateInstanceMetadata> instanceOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getInstanceAdminClient()).thenReturn(instanceClient);
     when(instanceClient.createInstance(any(InstanceInfo.class)))
@@ -243,7 +244,7 @@ public class EmulatorUtilTest {
     InstanceAdminClient instanceClient = mock(InstanceAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Instance, CreateInstanceMetadata> instanceOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getInstanceAdminClient()).thenReturn(instanceClient);
     when(instanceClient.createInstance(any(InstanceInfo.class)))
@@ -253,7 +254,7 @@ public class EmulatorUtilTest {
     DatabaseAdminClient databaseClient = mock(DatabaseAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Database, CreateDatabaseMetadata> databaseOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getDatabaseAdminClient()).thenReturn(databaseClient);
     when(databaseClient.createDatabase(
@@ -290,7 +291,7 @@ public class EmulatorUtilTest {
     InstanceAdminClient instanceClient = mock(InstanceAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Instance, CreateInstanceMetadata> instanceOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getInstanceAdminClient()).thenReturn(instanceClient);
     when(instanceClient.createInstance(any(InstanceInfo.class)))
@@ -300,7 +301,7 @@ public class EmulatorUtilTest {
     DatabaseAdminClient databaseClient = mock(DatabaseAdminClient.class);
     @SuppressWarnings("unchecked")
     OperationFuture<Database, CreateDatabaseMetadata> databaseOperationFuture =
-        mock(OperationFuture.class);
+        mock(OperationFuture.class, withSettings().withoutAnnotations());
 
     when(spanner.getDatabaseAdminClient()).thenReturn(databaseClient);
     when(databaseClient.createDatabase(

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SingleUseTransactionTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.gax.longrunning.OperationFuture;
@@ -314,7 +315,7 @@ public class SingleUseTransactionTest {
       DdlClient ddlClient = mock(DdlClient.class);
       @SuppressWarnings("unchecked")
       final OperationFuture<Void, UpdateDatabaseDdlMetadata> operation =
-          mock(OperationFuture.class);
+          mock(OperationFuture.class, withSettings().withoutAnnotations());
       when(operation.get()).thenReturn(null);
       when(ddlClient.executeDdl(anyString(), any())).thenCallRealMethod();
       when(ddlClient.executeDdl(anyList(), any())).thenReturn(operation);
@@ -622,7 +623,7 @@ public class SingleUseTransactionTest {
     ParsedStatement ddl = createParsedDdl(sql);
     DdlClient ddlClient = createDefaultMockDdlClient();
     when(ddlClient.executeCreateDatabase(sql, Dialect.GOOGLE_STANDARD_SQL))
-        .thenReturn(mock(OperationFuture.class));
+        .thenReturn(mock(OperationFuture.class, withSettings().withoutAnnotations()));
 
     SingleUseTransaction singleUseTransaction = createDdlSubject(ddlClient);
     get(singleUseTransaction.executeDdlAsync(CallType.SYNC, ddl));


### PR DESCRIPTION
Apply Mockito's withSettings().withoutAnnotations() to all mocks of GAX interfaces and classes across google-cloud-spanner tests to prevent Java 8 ArrayStoreException during reflection over JSpecify type-use annotations.