### PR TITLE
test(bigquerystorage): fix JSpecify CI issues on Java 8

### DIFF
--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStubSettingsTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/stub/EnhancedBigQueryReadStubSettingsTest.java
@@ -40,9 +40,11 @@ public class EnhancedBigQueryReadStubSettingsTest {
   @Test
   void testSettingsArePreserved() {
     String endpoint = "some.other.host:123";
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    CredentialsProvider credentialsProvider =
+        Mockito.mock(CredentialsProvider.class, Mockito.withSettings().withoutAnnotations());
     Duration watchdogInterval = Duration.ofSeconds(12);
-    WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
+    WatchdogProvider watchdogProvider =
+        Mockito.mock(WatchdogProvider.class, Mockito.withSettings().withoutAnnotations());
 
     EnhancedBigQueryReadStubSettings.Builder builder =
         EnhancedBigQueryReadStubSettings.newBuilder()

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/stub/EnhancedBigQueryStorageStubSettingsTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta1/stub/EnhancedBigQueryStorageStubSettingsTest.java
@@ -44,9 +44,11 @@ public class EnhancedBigQueryStorageStubSettingsTest {
   @Test
   void testSettingsArePreserved() {
     String endpoint = "some.other.host:123";
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    CredentialsProvider credentialsProvider =
+        Mockito.mock(CredentialsProvider.class, Mockito.withSettings().withoutAnnotations());
     Duration watchdogInterval = Duration.ofSeconds(12);
-    WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
+    WatchdogProvider watchdogProvider =
+        Mockito.mock(WatchdogProvider.class, Mockito.withSettings().withoutAnnotations());
 
     EnhancedBigQueryStorageStubSettings.Builder builder =
         EnhancedBigQueryStorageStubSettings.newBuilder()

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/stub/EnhancedBigQueryReadStubSettingsTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1beta2/stub/EnhancedBigQueryReadStubSettingsTest.java
@@ -40,9 +40,11 @@ public class EnhancedBigQueryReadStubSettingsTest {
   @Test
   void testSettingsArePreserved() {
     String endpoint = "some.other.host:123";
-    CredentialsProvider credentialsProvider = Mockito.mock(CredentialsProvider.class);
+    CredentialsProvider credentialsProvider =
+        Mockito.mock(CredentialsProvider.class, Mockito.withSettings().withoutAnnotations());
     Duration watchdogInterval = Duration.ofSeconds(12);
-    WatchdogProvider watchdogProvider = Mockito.mock(WatchdogProvider.class);
+    WatchdogProvider watchdogProvider =
+        Mockito.mock(WatchdogProvider.class, Mockito.withSettings().withoutAnnotations());
 
     EnhancedBigQueryReadStubSettings.Builder builder =
         EnhancedBigQueryReadStubSettings.newBuilder()


### PR DESCRIPTION
Disable annotations in Mockito mocks for Gax callables and providers to avoid ArrayStoreException on Java 8 when reflecting on JSpecify annotations.