### PR TITLE
fix(spanner): compare null elements in primitive-array Value.equals

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/Value.java
@@ -2552,6 +2552,16 @@ public abstract class Value implements Serializable {
     }
 
     @Override
+    boolean valueEquals(Value v) {
+      // Null elements are stored as the primitive default in the backing array, so the null
+      // bitmasks must be compared in addition to the backing arrays.
+      PrimitiveArrayImpl<?> that = (PrimitiveArrayImpl<?>) v;
+      return Objects.equals(nulls, that.nulls) && arrayEquals(v);
+    }
+
+    abstract boolean arrayEquals(Value v);
+
+    @Override
     int valueHash() {
       return 31 * Objects.hashCode(nulls) + arrayHash();
     }
@@ -2586,7 +2596,7 @@ public abstract class Value implements Serializable {
     }
 
     @Override
-    boolean valueEquals(Value v) {
+    boolean arrayEquals(Value v) {
       BoolArrayImpl that = (BoolArrayImpl) v;
       return Arrays.equals(values, that.values);
     }
@@ -2644,7 +2654,7 @@ public abstract class Value implements Serializable {
     }
 
     @Override
-    boolean valueEquals(Value v) {
+    boolean arrayEquals(Value v) {
       Int64ArrayImpl that = (Int64ArrayImpl) v;
       return Arrays.equals(values, that.values);
     }
@@ -2686,7 +2696,7 @@ public abstract class Value implements Serializable {
     }
 
     @Override
-    boolean valueEquals(Value v) {
+    boolean arrayEquals(Value v) {
       Float32ArrayImpl that = (Float32ArrayImpl) v;
       return Arrays.equals(values, that.values);
     }
@@ -2726,7 +2736,7 @@ public abstract class Value implements Serializable {
     }
 
     @Override
-    boolean valueEquals(Value v) {
+    boolean arrayEquals(Value v) {
       Float64ArrayImpl that = (Float64ArrayImpl) v;
       return Arrays.equals(values, that.values);
     }
@@ -2883,7 +2893,7 @@ public abstract class Value implements Serializable {
     }
 
     @Override
-    boolean valueEquals(Value v) {
+    boolean arrayEquals(Value v) {
       PgOidArrayImpl that = (PgOidArrayImpl) v;
       return Arrays.equals(values, that.values);
     }

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/ValueTest.java
@@ -2347,6 +2347,8 @@ public class ValueTest {
         Value.boolArray(new boolean[] {true, false, true, false}, 1, 2),
         Value.boolArray(plainIterable(false, true)));
     tester.addEqualityGroup(Value.boolArray(Collections.singletonList(false)));
+    tester.addEqualityGroup(
+        Value.boolArray(Arrays.asList(null, true)), Value.boolArray(Arrays.asList(null, true)));
     tester.addEqualityGroup(Value.boolArray((Iterable<Boolean>) null));
 
     tester.addEqualityGroup(
@@ -2355,6 +2357,9 @@ public class ValueTest {
         Value.int64Array(new long[] {0L, 1L, 2L, 3L}, 1, 2),
         Value.int64Array(plainIterable(1L, 2L)));
     tester.addEqualityGroup(Value.int64Array(Collections.singletonList(3L)));
+    tester.addEqualityGroup(
+        Value.int64Array(Arrays.asList(null, 2L)), Value.int64Array(Arrays.asList(null, 2L)));
+    tester.addEqualityGroup(Value.int64Array(Arrays.asList(0L, 2L)));
     tester.addEqualityGroup(Value.int64Array((Iterable<Long>) null));
 
     tester.addEqualityGroup(
@@ -2363,6 +2368,9 @@ public class ValueTest {
         Value.float32Array(new float[] {.0f, .1f, .2f, .3f}, 1, 2),
         Value.float32Array(plainIterable(.1f, .2f)));
     tester.addEqualityGroup(Value.float32Array(Collections.singletonList(.3f)));
+    tester.addEqualityGroup(
+        Value.float32Array(Arrays.asList(null, .2f)), Value.float32Array(Arrays.asList(null, .2f)));
+    tester.addEqualityGroup(Value.float32Array(Arrays.asList(.0f, .2f)));
     tester.addEqualityGroup(Value.float32Array((Iterable<Float>) null));
 
     tester.addEqualityGroup(
@@ -2371,6 +2379,9 @@ public class ValueTest {
         Value.float64Array(new double[] {.0, .1, .2, .3}, 1, 2),
         Value.float64Array(plainIterable(.1, .2)));
     tester.addEqualityGroup(Value.float64Array(Collections.singletonList(.3)));
+    tester.addEqualityGroup(
+        Value.float64Array(Arrays.asList(null, .2)), Value.float64Array(Arrays.asList(null, .2)));
+    tester.addEqualityGroup(Value.float64Array(Arrays.asList(.0, .2)));
     tester.addEqualityGroup(Value.float64Array((Iterable<Double>) null));
 
     tester.addEqualityGroup(
@@ -2392,6 +2403,10 @@ public class ValueTest {
         Value.pgOidArray(plainIterable(1L, 2L)));
     tester.addEqualityGroup(Value.pgOidArray(Collections.singletonList(3L)));
     tester.addEqualityGroup(Value.pgOidArray(Collections.singletonList(null)));
+    tester.addEqualityGroup(Value.pgOidArray(Collections.singletonList(0L)));
+    tester.addEqualityGroup(
+        Value.pgOidArray(Arrays.asList(null, 2L)), Value.pgOidArray(Arrays.asList(null, 2L)));
+    tester.addEqualityGroup(Value.pgOidArray(Arrays.asList(0L, 2L)));
     tester.addEqualityGroup(Value.pgOidArray((Iterable<Long>) null));
 
     tester.addEqualityGroup(


### PR DESCRIPTION
Make the five primitive-array `Value` implementations (`BoolArrayImpl`,
`Int64ArrayImpl`, `Float32ArrayImpl`, `Float64ArrayImpl`, `PgOidArrayImpl`)
consider the `null` values in `equals()`, to avoid treating primitive defaults
(`0`, `0.0`, `false`) as equal to `null` values.