### PR TITLE
fix(spanner): stop AsyncResultSetImpl producer when callback throws with a full buffer

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -373,7 +373,7 @@ class AsyncResultSetImpl extends ForwardingStructReader
         while (!stop && hasNext) {
           try {
             synchronized (monitor) {
-              stop = state.shouldStop;
+              stop = state.shouldStop || cursorReturnedDoneOrException;
             }
             if (!stop) {
               while (buffer.remainingCapacity() == 0 && !stop) {
@@ -390,7 +390,11 @@ class AsyncResultSetImpl extends ForwardingStructReader
                         MAX_WAIT_FOR_BUFFER_CONSUMPTION));
                 bufferConsumptionLatch.await();
                 synchronized (monitor) {
-                  stop = state.shouldStop;
+                  // Also stop if the callback will never consume any more rows, for example
+                  // because it threw an exception. The callback runner is not restarted once
+                  // cursorReturnedDoneOrException has been set, so continuing to produce rows
+                  // against a full buffer would otherwise spin forever.
+                  stop = state.shouldStop || cursorReturnedDoneOrException;
                 }
               }
             }

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -448,9 +448,9 @@ class AsyncResultSetImpl extends ForwardingStructReader
 
     /**
      * Returns whether the producer should permanently stop putting rows into the buffer. This is
-     * the case once the result set has entered a terminal state (cancelled/done), or once the
-     * cursor has returned {@code DONE} or thrown an exception. After the latter the callback runner
-     * is not restarted, so continuing to produce rows against a full buffer would spin forever.
+     * the case once the result set has entered a terminal state, or once the cursor has returned
+     * {@link CursorState#DONE} or thrown an exception. After the latter the callback runner is not
+     * restarted, so continuing to produce rows against a full buffer would spin forever.
      */
     private boolean shouldStopProducing() {
       synchronized (monitor) {

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -446,14 +446,12 @@ class AsyncResultSetImpl extends ForwardingStructReader
       }
     }
 
-    /**
-     * Returns whether the producer should permanently stop putting rows into the buffer. This is
-     * the case once the result set has entered a terminal state, or once the cursor has returned
-     * {@link CursorState#DONE} or thrown an exception. After the latter the callback runner is not
-     * restarted, so continuing to produce rows against a full buffer would spin forever.
-     */
     private boolean shouldStopProducing() {
       synchronized (monitor) {
+        // A callback that throws leaves the state at CONSUMING, unlike DONE and CANCELLED, so
+        // shouldStop alone would not catch it. The callback runner is never dispatched again and
+        // bufferConsumptionLatch is left at zero, so the producer would otherwise spin on a full
+        // buffer that nothing will drain.
         return state.shouldStop || cursorReturnedDoneOrException;
       }
     }

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/AsyncResultSetImpl.java
@@ -372,9 +372,7 @@ class AsyncResultSetImpl extends ForwardingStructReader
       try {
         while (!stop && hasNext) {
           try {
-            synchronized (monitor) {
-              stop = state.shouldStop || cursorReturnedDoneOrException;
-            }
+            stop = shouldStopProducing();
             if (!stop) {
               while (buffer.remainingCapacity() == 0 && !stop) {
                 waitIfPaused();
@@ -389,13 +387,7 @@ class AsyncResultSetImpl extends ForwardingStructReader
                         Math.min(buffer.size() / 2 + 1, buffer.size()),
                         MAX_WAIT_FOR_BUFFER_CONSUMPTION));
                 bufferConsumptionLatch.await();
-                synchronized (monitor) {
-                  // Also stop if the callback will never consume any more rows, for example
-                  // because it threw an exception. The callback runner is not restarted once
-                  // cursorReturnedDoneOrException has been set, so continuing to produce rows
-                  // against a full buffer would otherwise spin forever.
-                  stop = state.shouldStop || cursorReturnedDoneOrException;
-                }
+                stop = shouldStopProducing();
               }
             }
             if (!stop) {
@@ -451,6 +443,18 @@ class AsyncResultSetImpl extends ForwardingStructReader
             result.set(null);
           }
         }
+      }
+    }
+
+    /**
+     * Returns whether the producer should permanently stop putting rows into the buffer. This is
+     * the case once the result set has entered a terminal state (cancelled/done), or once the
+     * cursor has returned {@code DONE} or thrown an exception. After the latter the callback runner
+     * is not restarted, so continuing to produce rows against a full buffer would spin forever.
+     */
+    private boolean shouldStopProducing() {
+      synchronized (monitor) {
+        return state.shouldStop || cursorReturnedDoneOrException;
       }
     }
 

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
@@ -518,7 +518,6 @@ public class AsyncResultSetImplTest {
         assertThat(se.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
         assertThat(se.getMessage()).contains("async test");
         assertThat(callbackCounter.get()).isEqualTo(1);
-        // The producer should have stopped reading from the delegate and closed it.
         Mockito.verify(delegate).close();
       }
     } finally {

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
@@ -496,29 +496,33 @@ public class AsyncResultSetImplTest {
 
   @Test
   public void callbackThrowsExceptionWhileBufferIsFull_shouldStopProducer() throws Exception {
-    Executor executor = Executors.newSingleThreadExecutor();
-    ResultSet delegate = mock(ResultSet.class);
-    // Return more rows than the buffer can hold, so the producer is waiting for the callback to
-    // consume rows from the full buffer when the callback throws an exception.
-    when(delegate.next()).thenReturn(true);
-    when(delegate.getCurrentRowAsStruct()).thenReturn(mock(Struct.class));
-    final AtomicInteger callbackCounter = new AtomicInteger();
-    try (AsyncResultSetImpl rs = new AsyncResultSetImpl(simpleProvider, delegate, 1)) {
-      rs.setCallback(
-          executor,
-          resultSet -> {
-            callbackCounter.incrementAndGet();
-            throw new RuntimeException("async test");
-          });
-      ExecutionException e =
-          assertThrows(ExecutionException.class, () -> rs.getResult().get(10L, TimeUnit.SECONDS));
-      assertThat(e.getCause()).isInstanceOf(SpannerException.class);
-      SpannerException se = (SpannerException) e.getCause();
-      assertThat(se.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
-      assertThat(se.getMessage()).contains("async test");
-      assertThat(callbackCounter.get()).isEqualTo(1);
-      // The producer should have stopped reading from the delegate and closed it.
-      Mockito.verify(delegate).close();
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      ResultSet delegate = mock(ResultSet.class);
+      // Return more rows than the buffer can hold, so the producer is waiting for the callback to
+      // consume rows from the full buffer when the callback throws an exception.
+      when(delegate.next()).thenReturn(true);
+      when(delegate.getCurrentRowAsStruct()).thenReturn(mock(Struct.class));
+      final AtomicInteger callbackCounter = new AtomicInteger();
+      try (AsyncResultSetImpl rs = new AsyncResultSetImpl(simpleProvider, delegate, 1)) {
+        rs.setCallback(
+            executor,
+            resultSet -> {
+              callbackCounter.incrementAndGet();
+              throw new RuntimeException("async test");
+            });
+        ExecutionException e =
+            assertThrows(ExecutionException.class, () -> rs.getResult().get(10L, TimeUnit.SECONDS));
+        assertThat(e.getCause()).isInstanceOf(SpannerException.class);
+        SpannerException se = (SpannerException) e.getCause();
+        assertThat(se.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
+        assertThat(se.getMessage()).contains("async test");
+        assertThat(callbackCounter.get()).isEqualTo(1);
+        // The producer should have stopped reading from the delegate and closed it.
+        Mockito.verify(delegate).close();
+      }
+    } finally {
+      executor.shutdown();
     }
   }
 

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/AsyncResultSetImplTest.java
@@ -495,6 +495,34 @@ public class AsyncResultSetImplTest {
   }
 
   @Test
+  public void callbackThrowsExceptionWhileBufferIsFull_shouldStopProducer() throws Exception {
+    Executor executor = Executors.newSingleThreadExecutor();
+    ResultSet delegate = mock(ResultSet.class);
+    // Return more rows than the buffer can hold, so the producer is waiting for the callback to
+    // consume rows from the full buffer when the callback throws an exception.
+    when(delegate.next()).thenReturn(true);
+    when(delegate.getCurrentRowAsStruct()).thenReturn(mock(Struct.class));
+    final AtomicInteger callbackCounter = new AtomicInteger();
+    try (AsyncResultSetImpl rs = new AsyncResultSetImpl(simpleProvider, delegate, 1)) {
+      rs.setCallback(
+          executor,
+          resultSet -> {
+            callbackCounter.incrementAndGet();
+            throw new RuntimeException("async test");
+          });
+      ExecutionException e =
+          assertThrows(ExecutionException.class, () -> rs.getResult().get(10L, TimeUnit.SECONDS));
+      assertThat(e.getCause()).isInstanceOf(SpannerException.class);
+      SpannerException se = (SpannerException) e.getCause();
+      assertThat(se.getErrorCode()).isEqualTo(ErrorCode.UNKNOWN);
+      assertThat(se.getMessage()).contains("async test");
+      assertThat(callbackCounter.get()).isEqualTo(1);
+      // The producer should have stopped reading from the delegate and closed it.
+      Mockito.verify(delegate).close();
+    }
+  }
+
+  @Test
   public void callbackReturnsDoneBeforeEnd_shouldStopIteration() throws Exception {
     Executor executor = Executors.newSingleThreadExecutor();
     ResultSet delegate = mock(ResultSet.class);


### PR DESCRIPTION
Check `cursorReturnedDoneOrException` when deciding if rows should
continue to be produced in `AsyncResultSetImpl`, to avoid busy-spinning
forever if a user-supplied `ReadyCallback` threw an exception while the
row buffer was full.