### PR TITLE
fix(spanner): cancel the in-flight Commit RPC when the commit is abandoned

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/TransactionRunnerImpl.java
@@ -187,6 +187,14 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
     @GuardedBy("precommitTokenLock")
     private MultiplexedSessionPrecommitToken latestPrecommitToken;
 
+    private final Object commitCancellationLock = new Object();
+
+    @GuardedBy("commitCancellationLock")
+    private boolean commitCancelled;
+
+    @GuardedBy("commitCancellationLock")
+    private ApiFuture<com.google.spanner.v1.CommitResponse> inFlightCommitFuture;
+
     @GuardedBy("lock")
     private volatile SettableApiFuture<Void> finishedAsyncOperations = SettableApiFuture.create();
 
@@ -365,9 +373,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                     rpc.getCommitRetrySettings().getTotalTimeout().getSeconds() + 5,
                     TimeUnit.SECONDS);
       } catch (InterruptedException | TimeoutException e) {
-        if (commitFuture != null) {
-          commitFuture.cancel(true);
-        }
+        cancelInFlightCommit();
         if (e instanceof InterruptedException) {
           throw SpannerExceptionFactory.propagateInterrupt((InterruptedException) e);
         } else {
@@ -378,7 +384,36 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       }
     }
 
-    volatile ApiFuture<CommitResponse> commitFuture;
+    private void cancelInFlightCommit() {
+      ApiFuture<com.google.spanner.v1.CommitResponse> commitFuture;
+      synchronized (commitCancellationLock) {
+        commitCancelled = true;
+        commitFuture = inFlightCommitFuture;
+      }
+      if (commitFuture != null) {
+        commitFuture.cancel(true);
+      }
+    }
+
+    private void publishOrCancelInFlightCommit(
+        ApiFuture<com.google.spanner.v1.CommitResponse> commitFuture) {
+      boolean cancelled;
+      synchronized (commitCancellationLock) {
+        cancelled = commitCancelled;
+        if (!cancelled) {
+          inFlightCommitFuture = commitFuture;
+        }
+      }
+      if (cancelled) {
+        commitFuture.cancel(true);
+      }
+    }
+
+    private boolean isCommitCancelled() {
+      synchronized (commitCancellationLock) {
+        return commitCancelled;
+      }
+    }
 
     ApiFuture<CommitResponse> commitAsync() {
       close();
@@ -429,6 +464,13 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
       finishOps.addListener(
           new CommitRunnable(
               res, finishOps, builder, /* retryAttemptDueToCommitProtocolExtension= */ false),
+          MoreExecutors.directExecutor());
+      res.addListener(
+          () -> {
+            if (res.isCancelled()) {
+              cancelInFlightCommit();
+            }
+          },
           MoreExecutors.directExecutor());
       return res;
     }
@@ -484,6 +526,13 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
                 "Retrying commit operation with a new precommit token obtained from the previous"
                     + " CommitResponse");
           }
+          if (isCommitCancelled()) {
+            res.setException(
+                newSpannerException(
+                    ErrorCode.CANCELLED,
+                    "The commit was cancelled before the Commit RPC was sent"));
+            return;
+          }
           final CommitRequest commitRequest = requestBuilder.build();
           span.addAnnotation("Starting Commit");
           final ApiFuture<com.google.spanner.v1.CommitResponse> commitFuture;
@@ -491,6 +540,7 @@ class TransactionRunnerImpl implements SessionTransaction, TransactionRunner {
           try (IScope ignore = tracer.withSpan(opSpan)) {
             commitFuture = rpc.commitAsync(commitRequest, getTransactionChannelHint());
           }
+          publishOrCancelInFlightCommit(commitFuture);
           session.markUsed(clock.instant());
           commitFuture.addListener(
               () -> {

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/TransactionRunnerImplTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -29,7 +30,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
 import com.google.cloud.grpc.GrpcTransportOptions;
 import com.google.cloud.grpc.GrpcTransportOptions.ExecutorFactory;
 import com.google.cloud.spanner.ErrorHandler.DefaultErrorHandler;
@@ -193,6 +196,129 @@ public class TransactionRunnerImplTest {
     assertEquals(RequestOptions.Priority.PRIORITY_HIGH, capturedOptions.priority());
     assertEquals("tag", capturedOptions.tag());
     assertEquals(clientContext, capturedOptions.clientContext());
+  }
+
+  @Test
+  public void commitCancelsInFlightRpcWhenCallingThreadInterrupted() {
+    when(session.getName()).thenReturn("projects/p/instances/i/databases/d/sessions/s");
+    TransactionContextImpl transaction =
+        TransactionContextImpl.newBuilder()
+            .setSession(session)
+            .setTransactionId(ByteString.copyFromUtf8("test-txn"))
+            .setOptions(Options.fromTransactionOptions())
+            .setRpc(rpc)
+            .setTracer(tracer)
+            .setSpan(span)
+            .build();
+    SettableApiFuture<CommitResponse> inFlightCommit = SettableApiFuture.create();
+    when(rpc.commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap()))
+        .thenAnswer(
+            invocation -> {
+              Thread.currentThread().interrupt();
+              return inFlightCommit;
+            });
+
+    try {
+      SpannerException e = assertThrows(SpannerException.class, transaction::commit);
+      assertEquals(ErrorCode.CANCELLED, e.getErrorCode());
+      assertTrue("in-flight Commit RPC was not cancelled", inFlightCommit.isCancelled());
+    } finally {
+      // Clear the interrupt flag so it cannot leak into other tests.
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void commitAsyncCancelsInFlightRpcWhenReturnedFutureIsCancelled() {
+    when(session.getName()).thenReturn("projects/p/instances/i/databases/d/sessions/s");
+    TransactionContextImpl transaction =
+        TransactionContextImpl.newBuilder()
+            .setSession(session)
+            .setTransactionId(ByteString.copyFromUtf8("test-txn"))
+            .setOptions(Options.fromTransactionOptions())
+            .setRpc(rpc)
+            .setTracer(tracer)
+            .setSpan(span)
+            .build();
+    SettableApiFuture<CommitResponse> inFlightCommit = SettableApiFuture.create();
+    when(rpc.commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap()))
+        .thenReturn(inFlightCommit);
+
+    ApiFuture<com.google.cloud.spanner.CommitResponse> commitFuture = transaction.commitAsync();
+    assertTrue(commitFuture.cancel(true));
+
+    assertTrue("in-flight Commit RPC was not cancelled", inFlightCommit.isCancelled());
+  }
+
+  @Test
+  public void commitAsyncSkipsCommitRpcWhenCancelledBeforeItIsSent() {
+    SettableApiFuture<Transaction> beginTransaction = SettableApiFuture.create();
+    setUpTransactionThatCommitsAfterBeginTransaction(beginTransaction);
+    TransactionContextImpl transaction = newTransactionWithoutTransactionId();
+
+    ApiFuture<com.google.cloud.spanner.CommitResponse> commitFuture = transaction.commitAsync();
+    // The Commit RPC is only sent once BeginTransaction has finished, so cancelling here means
+    // that the commit is abandoned before there is any RPC to cancel.
+    assertTrue(commitFuture.cancel(true));
+    verify(rpc, never()).commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap());
+
+    beginTransaction.set(
+        Transaction.newBuilder().setId(ByteString.copyFromUtf8("test-txn")).build());
+
+    // The commit was already abandoned, so the Commit RPC should not be sent at all.
+    verify(rpc, never()).commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap());
+  }
+
+  @Test
+  public void commitSkipsCommitRpcWhenCallingThreadInterruptedBeforeItIsSent() {
+    SettableApiFuture<Transaction> beginTransaction = SettableApiFuture.create();
+    setUpTransactionThatCommitsAfterBeginTransaction(beginTransaction);
+    TransactionContextImpl transaction = newTransactionWithoutTransactionId();
+
+    try {
+      // Interrupting before commit() waits for the result means that it gives up while
+      // BeginTransaction is still pending, and therefore before the Commit RPC has been sent.
+      Thread.currentThread().interrupt();
+      SpannerException e = assertThrows(SpannerException.class, transaction::commit);
+      assertEquals(ErrorCode.CANCELLED, e.getErrorCode());
+      verify(rpc, never()).commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap());
+
+      // commit() restores the interrupt flag, and BeginTransaction finishes on a gax thread that
+      // does not have that flag. Clear it so the listeners below are not interrupted either.
+      Thread.interrupted();
+      beginTransaction.set(
+          Transaction.newBuilder().setId(ByteString.copyFromUtf8("test-txn")).build());
+
+      // The commit was already abandoned, so the Commit RPC should not be sent at all.
+      verify(rpc, never()).commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap());
+    } finally {
+      // Clear the interrupt flag so it cannot leak into other tests.
+      Thread.interrupted();
+    }
+  }
+
+  private void setUpTransactionThatCommitsAfterBeginTransaction(
+      SettableApiFuture<Transaction> beginTransaction) {
+    when(session.getName()).thenReturn("projects/p/instances/i/databases/d/sessions/s");
+    when(session.beginTransactionAsync(
+            Mockito.any(Options.class),
+            Mockito.anyBoolean(),
+            Mockito.anyMap(),
+            Mockito.any(),
+            Mockito.any()))
+        .thenReturn(beginTransaction);
+    when(rpc.commitAsync(Mockito.any(CommitRequest.class), Mockito.anyMap()))
+        .thenReturn(SettableApiFuture.create());
+  }
+
+  private TransactionContextImpl newTransactionWithoutTransactionId() {
+    return TransactionContextImpl.newBuilder()
+        .setSession(session)
+        .setOptions(Options.fromTransactionOptions())
+        .setRpc(rpc)
+        .setTracer(tracer)
+        .setSpan(span)
+        .build();
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
`TransactionContextImpl` did not cancel the Commit RPC when the commit was
abandoned, so the client could give up while the commit still completed
server-side. There are three ways that happened.

**1. The cancellation in `commit()` was dead code.**

`commit()` cancels the in-flight Commit RPC when the calling thread is
interrupted or the bounded `get()` times out:

    } catch (InterruptedException | TimeoutException e) {
      if (commitFuture != null) {
        commitFuture.cancel(true);
      }

But the volatile field `commitFuture` was never assigned. The only assignment in
`CommitRunnable.run()` was to a local variable that shadowed it, so the field
stayed `null` and `commitFuture.cancel(true)` was unreachable.

**2. `commitAsync()` never propagated cancellation.**

The `SettableApiFuture` returned to the caller was not wired back to the RPC, so
cancelling it completed the returned future while leaving the Commit RPC
running. A listener now cancels the RPC when the returned future is cancelled.

**3. A commit abandoned before the RPC was sent was never cancelled.**

Recording the cancellation and publishing the RPC future were unsynchronized, so
a commit abandoned before `CommitRunnable` had sent the RPC left the call
running: the cancel saw a `null` field, and the RPC was sent afterwards with
nothing left to cancel it. `CommitRunnable` now checks for the cancellation
before sending and skips the Commit RPC entirely, and both recording the
cancellation and publishing the RPC future happen under
`commitCancellationLock`, so a cancellation that lands between that check and
the send still cancels the RPC.
