### PR TITLE
test(storage-nio): disable copying annotations for storage-nio

### DIFF
--- a/java-storage-nio/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageIsDirectoryTest.java
+++ b/java-storage-nio/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageIsDirectoryTest.java
@@ -69,7 +69,7 @@ public class CloudStorageIsDirectoryTest {
         CloudStorageFileSystem.forBucket("bucket", CloudStorageConfiguration.DEFAULT, mockOptions);
     when(mockStorage.get(BlobId.of("bucket", "test", null)))
         .thenThrow(new IllegalArgumentException());
-    Page<Blob> pages = mock(Page.class);
+    Page<Blob> pages = Mockito.mock(Page.class, Mockito.withSettings().withoutAnnotations());
     Blob blob = mock(Blob.class);
     when(blob.getBlobId()).thenReturn(BlobId.of("bucket", "test/hello.txt"));
     when(pages.getValues()).thenReturn(Lists.newArrayList(blob));
@@ -91,7 +91,7 @@ public class CloudStorageIsDirectoryTest {
             mockOptions);
     when(mockStorage.get(BlobId.of("bucket", "test", null)))
         .thenThrow(new IllegalArgumentException());
-    Page<Blob> pages = mock(Page.class);
+    Page<Blob> pages = Mockito.mock(Page.class, Mockito.withSettings().withoutAnnotations());
     Blob blob = mock(Blob.class);
     when(blob.getBlobId()).thenReturn(BlobId.of("bucket", "test/hello.txt"));
     when(pages.getValues()).thenReturn(Lists.newArrayList(blob));

--- a/java-storage-nio/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageIsDirectoryTest.java
+++ b/java-storage-nio/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageIsDirectoryTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 
 /** Unit tests for {@code Files.isDirectory()}. */
 @RunWith(JUnit4.class)


### PR DESCRIPTION
In JSpecify 1.0.0, the `@NullMarked` annotation includes `ElementType.MODULE` in its `@Target` metadata. Because `ElementType.MODULE` was introduced in Java 9, reflecting on `@NullMarked` classes under Java 8 (JDK 1.8) throws `EnumConstantNotPresentExceptionProxy` wrapped in an `ArrayStoreException`.

When unit tests run on Java 8, Mockito's default mock generation (via ByteBuddy) attempts to copy all runtime class annotations from target classes onto mock subclasses. This triggers the reflection crash when mocking `Page` classes that are transitively annotated with `@NullMarked`.

To bypass this Java 8 limitation:

* Replaced default Mockito mock instantiation of `Page` classes with `Mockito.mock(Page.class, Mockito.withSettings().withoutAnnotations())` in `CloudStorageIsDirectoryTest`.
* Disabling annotation copying prevents Mockito/ByteBuddy from invoking `Class.getAnnotations()` on the target class during proxy creation, allowing tests to run and mock stubs successfully on Java 8 pipelines.

Modified Mockito mock setups in:
* `CloudStorageIsDirectoryTest`
