### PR TITLE
test(bigtable): disable deep stub answers causing Java 8 Mockito reflection crash

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientTests.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/BigtableDataClientTests.java
@@ -58,7 +58,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Answers;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -79,8 +78,7 @@ public class BigtableDataClientTests {
 
   @Mock private EnhancedBigtableStub mockStub;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private ServerStreamingCallable<Query, Row> mockReadRowsCallable;
+  @Mock private ServerStreamingCallable<Query, Row> mockReadRowsCallable;
 
   @Mock private UnaryCallable<Query, Row> mockReadRowCallable;
   @Mock private UnaryCallable<String, List<KeyOffset>> mockSampleRowKeysCallable;
@@ -96,11 +94,11 @@ public class BigtableDataClientTests {
   @Mock private Batcher<ByteString, Row> mockBulkReadRowsBatcher;
   @Mock private UnaryCallable<PrepareQueryRequest, PrepareResponse> mockPrepareQueryCallable;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  @Mock
   private ServerStreamingCallable<String, ByteStringRange>
       mockGenerateInitialChangeStreamPartitionsCallable;
 
-  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  @Mock
   private ServerStreamingCallable<ReadChangeStreamQuery, ChangeStreamRecord>
       mockReadChangeStreamCallable;
 


### PR DESCRIPTION
### Problem
In JSpecify 1.0.0, the `@NullMarked` annotation targets `ElementType.MODULE`. Because `ElementType.MODULE` was introduced in Java 9, reflecting on `@NullMarked` classes under Java 8 (JDK 1.8) throws `EnumConstantNotPresentExceptionProxy` wrapped in an `ArrayStoreException`.

In `BigtableDataClientTests`, Mockito's mock declarations for `ServerStreamingCallable` were configured with `answer = Answers.RETURNS_DEEP_STUBS`. When Mockito generates deep stubs, it dynamically reflects on the return type to build intermediate mocks, triggering this reflection crash on `@NullMarked` classes under Java 8 CI pipelines.

### Solution
Since the tests do not actually call or rely on deep stubs for these streaming callables, we can safely remove `(answer = Answers.RETURNS_DEEP_STUBS)`. Removing deep stubs prevents Mockito from performing the reflection that causes the Java 8 pipeline crash, allowing the test suite to execute successfully.
