### PR TITLE
test(spanner): disable annotation copying on ServerStream mocks causing Java 8 crash

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/PartitionedDmlTransactionTest.java
@@ -370,7 +370,8 @@ public class PartitionedDmlTransactionTest {
     ResultSetStats stats = ResultSetStats.newBuilder().setRowCountLowerBound(1000L).build();
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
     PartialResultSet p2 = PartialResultSet.newBuilder().setStats(stats).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, false);
     when(iterator.next())
@@ -382,7 +383,8 @@ public class PartitionedDmlTransactionTest {
                 GrpcStatusCode.of(Code.INTERNAL),
                 true));
     when(stream1.iterator()).thenReturn(iterator);
-    ServerStream<PartialResultSet> stream2 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream2 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     when(stream2.iterator()).thenReturn(ImmutableList.of(p1, p2).iterator());
     when(rpc.executeStreamingPartitionedDml(
             Mockito.eq(executeRequestWithoutResumeToken), anyMap(), any(), any(Duration.class)))
@@ -407,7 +409,8 @@ public class PartitionedDmlTransactionTest {
   @Test
   public void testExecuteStreamingPartitionedUpdateGenericInternalException() {
     PartialResultSet p1 = PartialResultSet.newBuilder().setResumeToken(resumeToken).build();
-    ServerStream<PartialResultSet> stream1 = mock(ServerStream.class);
+    ServerStream<PartialResultSet> stream1 =
+        mock(ServerStream.class, withSettings().withoutAnnotations());
     Iterator<PartialResultSet> iterator = mock(Iterator.class);
     when(iterator.hasNext()).thenReturn(true, true, false);
     when(iterator.next())


### PR DESCRIPTION
### Problem
In JSpecify 1.0.0, the `@NullMarked` annotation targets `ElementType.MODULE`. Because `ElementType.MODULE` was introduced in Java 9, reflecting on `@NullMarked` classes under Java 8 (JDK 1.8) throws `EnumConstantNotPresentExceptionProxy` wrapped in an `ArrayStoreException`.

In `PartitionedDmlTransactionTest`, two mock declarations for `ServerStream` were created using the default `mock(ServerStream.class)` without setting `.withoutAnnotations()`. Mockito attempts to copy annotations on the mock subclasses, triggering the reflection crash on the JSpecify `@NullMarked` annotation during Java 8 CI pipelines.

### Solution
Replaced `mock(ServerStream.class)` with `mock(ServerStream.class, withSettings().withoutAnnotations())` in `testExecuteStreamingPartitionedUpdateRSTstream` and `testExecuteStreamingPartitionedUpdateGenericInternalException` to match the other passing tests. This disables annotation copying on the mocked `ServerStream` instances and bypasses the Java 8 reflection limitations.
