### PR TITLE
chore(bigquery-jdbc): fix Nightly tests within proxy docker

### DIFF
--- a/java-bigquery-jdbc/Makefile
+++ b/java-bigquery-jdbc/Makefile
@@ -85,7 +85,8 @@ run-it-standalone:
 		-v "$(GOOGLE_APPLICATION_CREDENTIALS).p12":/auth/application_creds.p12 \
 		-e "GOOGLE_APPLICATION_CREDENTIALS=/auth/application_creds.json" \
 		-v $(SRC):/src \
-		-e "SA_EMAIL=test_email" \
+		-e "SA_EMAIL=$(SA_EMAIL)" \
+		-e "KMS_RESOURCE_PATH=$(KMS_RESOURCE_PATH)" \
 		-e "SA_SECRET=/auth/application_creds.json" \
 		-e "SA_SECRET_P12=/auth/application_creds.p12" \
 		-e "BIGQUERY_BASE_URL=$(BIGQUERY_BASE_URL)" \

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -26,8 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.cloud.ServiceOptions;
-import com.google.cloud.bigquery.BigQuery;
-import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -60,7 +60,6 @@ public class ITNightlyBigQueryTest extends ITBase {
   static final String PROJECT_ID = ServiceOptions.getDefaultProjectId();
   static Connection bigQueryConnection;
   static Statement bigQueryStatement;
-  static BigQuery bigQuery;
   private static final Random random = new Random();
   private static final int randomNumber = random.nextInt(9999);
   private static final String BASE_QUERY =
@@ -91,7 +90,6 @@ public class ITNightlyBigQueryTest extends ITBase {
     DATASET2 = ITBase.getSharedDataset2();
     bigQueryConnection = DriverManager.getConnection(connection_uri, new Properties());
     bigQueryStatement = bigQueryConnection.createStatement();
-    bigQuery = BigQueryOptions.newBuilder().build().getService();
   }
 
   @AfterAll


### PR DESCRIPTION
Fix Nightly & Integration tests within Proxy container

- Pass `SA_SECRET`/`KMS_RESOURCE_PATH` to Docker if configured
- use `ITBase.bigQuery` client that accounts for proxy or other overrides.