### PR TITLE
deps(shared-deps): switch conscrypt shared dependency to conscrypt-openjdk-uber

### DIFF
--- a/sdk-platform-java/dependencies.txt
+++ b/sdk-platform-java/dependencies.txt
@@ -21,7 +21,7 @@ com.google.j2objc:j2objc-annotations,j2objc-annotations=3.1
 org.threeten:threetenbp,threetenbp=1.7.3
 org.slf4j:slf4j-api,slf4j=2.0.18
 org.jspecify:jspecify,jspecify=1.0.0
-org.conscrypt:conscrypt-openjdk,conscrypt=2.6.0
+org.conscrypt:conscrypt-openjdk-uber,conscrypt=2.6.0
 
 # 1P Shared-Deps
 # These dependencies are declared: https://github.com/googleapis/sdk-platform-java/blob/main/java-shared-dependencies/first-party-dependencies/pom.xml

--- a/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -275,7 +275,7 @@
       </dependency>
       <dependency>
         <groupId>org.conscrypt</groupId>
-        <artifactId>conscrypt-openjdk</artifactId>
+        <artifactId>conscrypt-openjdk-uber</artifactId>
         <version>${conscrypt.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Bundle the uber jar which contains pre-compiled native BoringSSL binaries for all major platforms. Allows users to easily use Conscrypt without any need for platform detectors or any configuration steps on their machines.

Follows the pattern of `grpc-netty-shaded` which also bundles the binaries for major platforms 