### PR TITLE
chore: update librarian to v0.28.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.27.1
+version: v0.28.0
 repo: googleapis/google-cloud-java
 sources:
   googleapis:


### PR DESCRIPTION
Librarian version upgrade and the `generate -all` command:

```
(.venv) suztomo@suztomo:~/librarian-2026/google-cloud-java$ go run github.com/googleapis/librarian/cmd/librarian@latest update version
(.venv) suztomo@suztomo:~/librarian-2026/google-cloud-java$ V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
(.venv) suztomo@suztomo:~/librarian-2026/google-cloud-java$ echo $V
v0.28.0
(.venv) suztomo@suztomo:~/librarian-2026/google-cloud-java$ go run github.com/googleapis/librarian/cmd/librarian@${V} generate --all
```

This didn't generate any diff.