### PR TITLE
fix: fix session budget penalty logic

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionCreationBudget.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionCreationBudget.java
@@ -22,6 +22,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
@@ -63,7 +64,7 @@ class SessionCreationBudget {
       return Instant.now();
     }
 
-    return delayedCreationTokens.get(0);
+    return Collections.min(delayedCreationTokens);
   }
 
   boolean tryReserveSession() {
@@ -96,10 +97,6 @@ class SessionCreationBudget {
       if (iter.next().isBefore(now)) {
         concurrentRequests--;
         iter.remove();
-      } else {
-        // The list should be roughly sorted. Exit early when we encounter
-        // something expires later.
-        break;
       }
     }
   }


### PR DESCRIPTION
Remove the early break when draining creation failures pool and update the logic when returning the next available budget. The list is not strictly increasing order of the timestamps. Updates to the penalty duration can change the orders of the timestamps in the list:

- An older failure might have a long expiration time (e.g., 10 seconds in the future) at index 0.
- Update config shortens the duration to 2 seconds. 
- A newer failure, using the updated shorter penalty, might have an earlier expiration time (e.g., 2 seconds in the future) at index 1.