### PR TITLE
test(spanner): disable Mockito annotation copying for Credentials, ServiceAccountCredentials, and RequestMetadataCallback

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MutableCredentialsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MutableCredentialsTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.auth.CredentialTypeForMetrics;
 import com.google.auth.RequestMetadataCallback;
@@ -45,10 +46,14 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class MutableCredentialsTest {
-  ServiceAccountCredentials initialCredentials = mock(ServiceAccountCredentials.class);
-  ServiceAccountCredentials initialScopedCredentials = mock(ServiceAccountCredentials.class);
-  ServiceAccountCredentials updatedCredentials = mock(ServiceAccountCredentials.class);
-  ServiceAccountCredentials updatedScopedCredentials = mock(ServiceAccountCredentials.class);
+  ServiceAccountCredentials initialCredentials =
+      mock(ServiceAccountCredentials.class, withSettings().withoutAnnotations());
+  ServiceAccountCredentials initialScopedCredentials =
+      mock(ServiceAccountCredentials.class, withSettings().withoutAnnotations());
+  ServiceAccountCredentials updatedCredentials =
+      mock(ServiceAccountCredentials.class, withSettings().withoutAnnotations());
+  ServiceAccountCredentials updatedScopedCredentials =
+      mock(ServiceAccountCredentials.class, withSettings().withoutAnnotations());
   Set<String> scopes = new HashSet<>(Arrays.asList("scope-a", "scope-b"));
   Map<String, List<String>> initialMetadata =
       Collections.singletonMap("Authorization", Collections.singletonList("v1"));

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MutableCredentialsTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/MutableCredentialsTest.java
@@ -75,7 +75,8 @@ public class MutableCredentialsTest {
     MutableCredentials credentials = new MutableCredentials(initialCredentials, scopes);
     URI testUri = URI.create("https://spanner.googleapis.com");
     Executor executor = mock(Executor.class);
-    RequestMetadataCallback callback = mock(RequestMetadataCallback.class);
+    RequestMetadataCallback callback =
+        mock(RequestMetadataCallback.class, withSettings().withoutAnnotations());
 
     validateInitialDelegatedCredentialsAreSet(credentials, testUri);
 
@@ -116,7 +117,8 @@ public class MutableCredentialsTest {
     MutableCredentials credentials = new MutableCredentials(initialCredentials, scopes);
     URI testUri = URI.create("https://example.com");
     Executor executor = mock(Executor.class);
-    RequestMetadataCallback callback = mock(RequestMetadataCallback.class);
+    RequestMetadataCallback callback =
+        mock(RequestMetadataCallback.class, withSettings().withoutAnnotations());
 
     validateInitialDelegatedCredentialsAreSet(credentials, testUri);
 

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/connection/SpannerPoolTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import com.google.auth.Credentials;
 import com.google.cloud.NoCredentials;
@@ -477,7 +478,7 @@ public class SpannerPoolTest {
             .setUri(
                 "cloudspanner://localhost:9010/projects/p1/instances/i/databases/d"
                     + "?minSessions=200;maxSessions=400;numChannels=8;usePlainText=true;userAgent=test-agent")
-            .setCredentials(mock(Credentials.class))
+            .setCredentials(mock(Credentials.class, withSettings().withoutAnnotations()))
             .build();
     // options2 equals the default session pool options, and is therefore equal to ConnectionOptions
     // without any session pool configuration.


### PR DESCRIPTION
### Problem
In JSpecify 1.0.0, the `@NullMarked` annotation targets `ElementType.MODULE`. Because `ElementType.MODULE` was introduced in Java 9, reflecting on `@NullMarked` classes under Java 8 (JDK 1.8) throws `EnumConstantNotPresentExceptionProxy` wrapped in an `ArrayStoreException`.

In `MutableCredentialsTest` and `SpannerPoolTest`, mock declarations for `Credentials`, `ServiceAccountCredentials`, and `RequestMetadataCallback` were created using the default `mock(Class.class)` without setting `.withoutAnnotations()`. Mockito attempts to copy annotations on the mock subclasses, triggering the reflection crash on the JSpecify `@NullMarked` annotation during Java 8 CI pipelines.

### Solution
Replaced default `mock(...)` calls with `mock(..., withSettings().withoutAnnotations())` for:
* `Credentials` in `SpannerPoolTest`
* `ServiceAccountCredentials` and `RequestMetadataCallback` in `MutableCredentialsTest`

This disables annotation copying on these mocked instances and bypasses the Java 8 reflection limitations.
