### PR TITLE
fix(bigquery-jdbc): fix minor issues and run integration tests for otel

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1102,6 +1102,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
       BigQueryJdbcRootLogger.closeConnectionHandler(this.connectionId);
       BigQueryJdbcOpenTelemetry.unregisterConnection(this.connectionId);
       BigQueryJdbcOpenTelemetry.releaseSdk(this.openTelemetry);
+      this.openTelemetry = null;
     }
     if (exceptionToThrow != null) {
       throw exceptionToThrow;

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -1101,6 +1101,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
       BigQueryJdbcMdc.clear();
       BigQueryJdbcRootLogger.closeConnectionHandler(this.connectionId);
       BigQueryJdbcOpenTelemetry.unregisterConnection(this.connectionId);
+      BigQueryJdbcOpenTelemetry.releaseSdk(this.openTelemetry);
     }
     if (exceptionToThrow != null) {
       throw exceptionToThrow;
@@ -1211,13 +1212,21 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   }
 
   private String resolveEffectiveCredentials() {
-    String creds = this.gcpTelemetryCredentials;
-    String authTypeStr = this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME);
-    if (creds == null
-        && BigQueryJdbcOAuthUtility.AuthType.GOOGLE_SERVICE_ACCOUNT.name().equals(authTypeStr)) {
-      return this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_PVT_KEY_PROPERTY_NAME);
+    if (this.gcpTelemetryCredentials != null) {
+      return this.gcpTelemetryCredentials;
     }
-    return creds;
+
+    String authTypeStr = this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME);
+    if (!BigQueryJdbcOAuthUtility.AuthType.GOOGLE_SERVICE_ACCOUNT.name().equals(authTypeStr)) {
+      return null;
+    }
+
+    String pvtKey = this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_PVT_KEY_PROPERTY_NAME);
+    if (pvtKey != null) {
+      return pvtKey;
+    }
+
+    return this.authProperties.get(BigQueryJdbcUrlUtility.OAUTH_PVT_KEY_PATH_PROPERTY_NAME);
   }
 
   private void validateTraceConfiguration(boolean isTraceEnabled, String effectiveCredentials) {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 
@@ -104,7 +105,16 @@ public class BigQueryJdbcOpenTelemetry {
     }
   }
 
-  private static final ConcurrentHashMap<SdkCacheKey, OpenTelemetrySdk> sdkCache =
+  private static final class CachedSdk {
+    final OpenTelemetrySdk sdk;
+    final AtomicInteger refCount = new AtomicInteger(0);
+
+    CachedSdk(OpenTelemetrySdk sdk) {
+      this.sdk = sdk;
+    }
+  }
+
+  private static final ConcurrentHashMap<SdkCacheKey, CachedSdk> sdkCache =
       new ConcurrentHashMap<>();
 
   static class TelemetryConfig {
@@ -127,20 +137,6 @@ public class BigQueryJdbcOpenTelemetry {
 
   static {
     ensureGlobalHandlerAttached();
-    Runtime.getRuntime()
-        .addShutdownHook(
-            new Thread(
-                () -> {
-                  for (OpenTelemetrySdk sdk : sdkCache.values()) {
-                    try {
-                      sdk.close();
-                    } catch (Exception e) {
-                      // Ignore failures during shutdown to ensure all SDKs are attempted to be
-                      // closed. Logging is avoided here because the logging system might have
-                      // already been shut down by the JVM.
-                    }
-                  }
-                }));
   }
 
   public static synchronized void ensureGlobalHandlerAttached() {
@@ -204,6 +200,33 @@ public class BigQueryJdbcOpenTelemetry {
       return loggingOptionsBuilder.build().getService();
     } catch (Exception e) {
       throw new BigQueryJdbcRuntimeException("Failed to initialize Logging client", e);
+    }
+  }
+
+  public static void releaseSdk(OpenTelemetry openTelemetry) {
+    if (openTelemetry == null
+        || openTelemetry == GlobalOpenTelemetry.get()
+        || openTelemetry == OpenTelemetry.noop()) {
+      return;
+    }
+
+    for (Map.Entry<SdkCacheKey, CachedSdk> entry : sdkCache.entrySet()) {
+      if (entry.getValue().sdk == openTelemetry) {
+        sdkCache.computeIfPresent(
+            entry.getKey(),
+            (k, cachedSdk) -> {
+              if (cachedSdk.refCount.decrementAndGet() <= 0) {
+                try {
+                  cachedSdk.sdk.close();
+                } catch (Exception e) {
+                  LOG.warning("Failed to close OpenTelemetry SDK: %s", e.getMessage());
+                }
+                return null;
+              }
+              return cachedSdk;
+            });
+        break;
+      }
     }
   }
 
@@ -295,70 +318,82 @@ public class BigQueryJdbcOpenTelemetry {
             gcpTelemetryProjectId,
             getCredentialsIdentifier(gcpTelemetryCredentials),
             enableGcpTraceExporter);
-    return sdkCache.computeIfAbsent(
-        key,
-        k -> {
-          Map<String, String> props = new HashMap<>();
+    return sdkCache.compute(
+            key,
+            (k, cachedSdk) -> {
+              if (cachedSdk != null) {
+                cachedSdk.refCount.incrementAndGet();
+                return cachedSdk;
+              }
 
-          if (enableGcpTraceExporter) {
-            props.put(OTEL_TRACES_EXPORTER, EXPORTER_OTLP);
-            props.put(OTEL_EXPORTER_OTLP_ENDPOINT, OTLP_ENDPOINT_VALUE);
-          } else {
-            props.put(OTEL_TRACES_EXPORTER, EXPORTER_NONE);
-          }
+              Map<String, String> props = new HashMap<>();
 
-          // Logs are handled directly via GCP logging
-          props.put(OTEL_LOGS_EXPORTER, EXPORTER_NONE);
-          // Metrics are deferred to a future phase
-          props.put(OTEL_METRICS_EXPORTER, EXPORTER_NONE);
+              if (enableGcpTraceExporter) {
+                props.put(OTEL_TRACES_EXPORTER, EXPORTER_OTLP);
+                props.put(OTEL_EXPORTER_OTLP_ENDPOINT, OTLP_ENDPOINT_VALUE);
+              } else {
+                props.put(OTEL_TRACES_EXPORTER, EXPORTER_NONE);
+              }
 
-          if (gcpTelemetryProjectId != null) {
-            props.put(GOOGLE_CLOUD_PROJECT, gcpTelemetryProjectId);
-          }
+              // Logs are handled directly via GCP logging
+              props.put(OTEL_LOGS_EXPORTER, EXPORTER_NONE);
+              // Metrics are deferred to a future phase
+              props.put(OTEL_METRICS_EXPORTER, EXPORTER_NONE);
 
-          // Set safe, generous default limits on attribute value lengths (32KB) to protect
-          // customers from GCP Cloud Trace 64KB span ingestion failures when logging massive
-          // exception stack traces or database schema metadata.
-          // Respect any existing user configuration overrides.
-          if (!props.containsKey(OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT)) {
-            props.put(OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, DEFAULT_ATTRIBUTE_LENGTH_LIMIT);
-          }
-          if (!props.containsKey(OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT)) {
-            props.put(OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, DEFAULT_ATTRIBUTE_LENGTH_LIMIT);
-          }
+              if (gcpTelemetryProjectId != null) {
+                props.put(GOOGLE_CLOUD_PROJECT, gcpTelemetryProjectId);
+              }
 
-          AutoConfiguredOpenTelemetrySdk autoConfigured =
-              AutoConfiguredOpenTelemetrySdk.builder()
-                  .addPropertiesSupplier(() -> props)
-                  .addSpanExporterCustomizer(
-                      (spanExporter, configProperties) -> {
-                        if (gcpTelemetryCredentials == null) {
-                          return spanExporter;
-                        }
-                        try {
-                          Credentials credentials =
-                              resolveCredentialsFromString(gcpTelemetryCredentials);
-                          if (spanExporter instanceof OtlpHttpSpanExporter) {
-                            return ((OtlpHttpSpanExporter) spanExporter)
-                                .toBuilder().setHeaders(() -> getAuthHeaders(credentials)).build();
-                          }
-                          if (spanExporter instanceof OtlpGrpcSpanExporter) {
-                            return ((OtlpGrpcSpanExporter) spanExporter)
-                                .toBuilder().setHeaders(() -> getAuthHeaders(credentials)).build();
-                          }
-                        } catch (Exception e) {
-                          LOG.warning(
-                              e,
-                              "Failed to resolve telemetry credentials. Telemetry will be exported using default OpenTelemetry configuration (custom authentication headers will not be injected).");
-                        }
-                        return spanExporter;
-                      })
-                  .build();
+              // Set safe, generous default limits on attribute value lengths (32KB) to protect
+              // customers from GCP Cloud Trace 64KB span ingestion failures when logging massive
+              // exception stack traces or database schema metadata.
+              // Respect any existing user configuration overrides.
+              if (!props.containsKey(OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT)) {
+                props.put(OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT, DEFAULT_ATTRIBUTE_LENGTH_LIMIT);
+              }
+              if (!props.containsKey(OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT)) {
+                props.put(OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, DEFAULT_ATTRIBUTE_LENGTH_LIMIT);
+              }
 
-          OpenTelemetrySdk sdk = autoConfigured.getOpenTelemetrySdk();
+              AutoConfiguredOpenTelemetrySdk autoConfigured =
+                  AutoConfiguredOpenTelemetrySdk.builder()
+                      .addPropertiesSupplier(() -> props)
+                      .addSpanExporterCustomizer(
+                          (spanExporter, configProperties) -> {
+                            if (gcpTelemetryCredentials == null) {
+                              return spanExporter;
+                            }
+                            try {
+                              Credentials credentials =
+                                  resolveCredentialsFromString(gcpTelemetryCredentials);
+                              if (spanExporter instanceof OtlpHttpSpanExporter) {
+                                return ((OtlpHttpSpanExporter) spanExporter)
+                                    .toBuilder()
+                                        .setHeaders(() -> getAuthHeaders(credentials))
+                                        .build();
+                              }
+                              if (spanExporter instanceof OtlpGrpcSpanExporter) {
+                                return ((OtlpGrpcSpanExporter) spanExporter)
+                                    .toBuilder()
+                                        .setHeaders(() -> getAuthHeaders(credentials))
+                                        .build();
+                              }
+                            } catch (Exception e) {
+                              LOG.warning(
+                                  e,
+                                  "Failed to resolve telemetry credentials. Telemetry will be exported using default OpenTelemetry configuration (custom authentication headers will not be injected).");
+                            }
+                            return spanExporter;
+                          })
+                      .build();
 
-          return sdk;
-        });
+              OpenTelemetrySdk sdk = autoConfigured.getOpenTelemetrySdk();
+
+              CachedSdk newCachedSdk = new CachedSdk(sdk);
+              newCachedSdk.refCount.incrementAndGet();
+              return newCachedSdk;
+            })
+        .sdk;
   }
 
   /** Gets a Tracer for the JDBC driver instrumentation scope. */

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -17,6 +17,7 @@
 package com.google.cloud.bigquery.jdbc;
 
 import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.exception.BigQueryJdbcRuntimeException;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.LoggingOptions;
@@ -372,12 +373,13 @@ public class BigQueryJdbcOpenTelemetry {
                       .addPropertiesSupplier(() -> props)
                       .addSpanExporterCustomizer(
                           (spanExporter, configProperties) -> {
-                            if (gcpTelemetryCredentials == null) {
-                              return spanExporter;
-                            }
                             try {
-                              Credentials credentials =
-                                  resolveCredentialsFromString(gcpTelemetryCredentials);
+                              Credentials credentials;
+                              if (gcpTelemetryCredentials != null) {
+                                credentials = resolveCredentialsFromString(gcpTelemetryCredentials);
+                              } else {
+                                credentials = GoogleCredentials.getApplicationDefault();
+                              }
                               if (spanExporter instanceof OtlpHttpSpanExporter) {
                                 return ((OtlpHttpSpanExporter) spanExporter)
                                     .toBuilder()

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
@@ -107,7 +108,7 @@ public class BigQueryJdbcOpenTelemetry {
 
   private static final class CachedSdk {
     final OpenTelemetrySdk sdk;
-    final AtomicInteger refCount = new AtomicInteger(0);
+    final AtomicInteger refCount = new AtomicInteger(1);
 
     CachedSdk(OpenTelemetrySdk sdk) {
       this.sdk = sdk;
@@ -210,6 +211,7 @@ public class BigQueryJdbcOpenTelemetry {
       return;
     }
 
+    AtomicBoolean shouldClose = new AtomicBoolean(false);
     for (Map.Entry<SdkCacheKey, CachedSdk> entry : sdkCache.entrySet()) {
       if (entry.getValue().sdk == openTelemetry) {
         sdkCache.computeIfPresent(
@@ -219,19 +221,23 @@ public class BigQueryJdbcOpenTelemetry {
                 return cachedSdk;
               }
               if (cachedSdk.refCount.decrementAndGet() <= 0) {
-                try {
-                  cachedSdk.sdk.close();
-                } catch (Exception e) {
-                  // Swallow exceptions so that telemetry shutdown failures (e.g. flush timeouts)
-                  // do not propagate and disrupt the core BigQueryConnection.close() logic.
-                  // Throwing here could prevent the core connection from cleaning up correctly.
-                  LOG.warning("Failed to close OpenTelemetry SDK: %s", e.getMessage());
-                }
+                shouldClose.set(true);
                 return null;
               }
               return cachedSdk;
             });
         break;
+      }
+    }
+
+    if (shouldClose.get() && openTelemetry instanceof OpenTelemetrySdk) {
+      try {
+        ((OpenTelemetrySdk) openTelemetry).close();
+      } catch (Exception e) {
+        // Swallow exceptions so that telemetry shutdown failures (e.g. flush timeouts)
+        // do not propagate and disrupt the core BigQueryConnection.close() logic.
+        // Throwing here could prevent the core connection from cleaning up correctly.
+        LOG.warning("Failed to close OpenTelemetry SDK: %s", e.getMessage());
       }
     }
   }
@@ -395,9 +401,7 @@ public class BigQueryJdbcOpenTelemetry {
 
               OpenTelemetrySdk sdk = autoConfigured.getOpenTelemetrySdk();
 
-              CachedSdk newCachedSdk = new CachedSdk(sdk);
-              newCachedSdk.refCount.incrementAndGet();
-              return newCachedSdk;
+              return new CachedSdk(sdk);
             })
         .sdk;
   }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcOpenTelemetry.java
@@ -215,10 +215,16 @@ public class BigQueryJdbcOpenTelemetry {
         sdkCache.computeIfPresent(
             entry.getKey(),
             (k, cachedSdk) -> {
+              if (cachedSdk.sdk != openTelemetry) {
+                return cachedSdk;
+              }
               if (cachedSdk.refCount.decrementAndGet() <= 0) {
                 try {
                   cachedSdk.sdk.close();
                 } catch (Exception e) {
+                  // Swallow exceptions so that telemetry shutdown failures (e.g. flush timeouts)
+                  // do not propagate and disrupt the core BigQueryConnection.close() logic.
+                  // Throwing here could prevent the core connection from cleaning up correctly.
                   LOG.warning("Failed to close OpenTelemetry SDK: %s", e.getMessage());
                 }
                 return null;

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITOpenTelemetryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITOpenTelemetryTest.java
@@ -306,8 +306,8 @@ public class ITOpenTelemetryTest extends ITBase {
 
   private <T> T pollWithRetry(java.util.concurrent.Callable<T> task) throws InterruptedException {
     int attempts = 0;
-    int maxAttempts = 120; // 120 attempts * 500ms = 60 seconds max delay
-    long delayMs = 500; // 500ms linear polling
+    int maxAttempts = 20; // 20 attempts * 3000ms = 60 seconds max delay
+    long delayMs = 3000; // 3000ms linear polling
 
     while (attempts < maxAttempts) {
       attempts++;

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITOpenTelemetryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITOpenTelemetryTest.java
@@ -306,7 +306,7 @@ public class ITOpenTelemetryTest extends ITBase {
 
   private <T> T pollWithRetry(java.util.concurrent.Callable<T> task) throws InterruptedException {
     int attempts = 0;
-    int maxAttempts = 30; // 30 attempts * 500ms = 15 seconds max delay
+    int maxAttempts = 120; // 120 attempts * 500ms = 60 seconds max delay
     long delayMs = 500; // 500ms linear polling
 
     while (attempts < maxAttempts) {
@@ -321,6 +321,7 @@ public class ITOpenTelemetryTest extends ITBase {
         throw new RuntimeException("Test execution interrupted", e);
       } catch (Exception e) {
         // Ignore exceptions during remote lookup and retry
+        e.printStackTrace();
       }
       if (attempts < maxAttempts) {
         Thread.sleep(delayMs);

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/suites/ITPresubmitTests.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/suites/ITPresubmitTests.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.jdbc.it.ITConnectionTest;
 import com.google.cloud.bigquery.jdbc.it.ITDatabaseMetadataTest;
 import com.google.cloud.bigquery.jdbc.it.ITDriverTest;
 import com.google.cloud.bigquery.jdbc.it.ITLocalSslValidationTest;
+import com.google.cloud.bigquery.jdbc.it.ITOpenTelemetryTest;
 import com.google.cloud.bigquery.jdbc.it.ITResultSetMetadataTest;
 import com.google.cloud.bigquery.jdbc.it.ITStatementTest;
 import org.junit.platform.suite.api.SelectClasses;
@@ -39,6 +40,7 @@ import org.junit.platform.suite.api.Suite;
   ITDatabaseMetadataTest.class,
   ITDriverTest.class,
   ITLocalSslValidationTest.class,
+  ITOpenTelemetryTest.class,
   ITResultSetMetadataTest.class,
   ITStatementTest.class
 })

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/suites/ITPresubmitTests.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/suites/ITPresubmitTests.java
@@ -24,7 +24,6 @@ import com.google.cloud.bigquery.jdbc.it.ITConnectionTest;
 import com.google.cloud.bigquery.jdbc.it.ITDatabaseMetadataTest;
 import com.google.cloud.bigquery.jdbc.it.ITDriverTest;
 import com.google.cloud.bigquery.jdbc.it.ITLocalSslValidationTest;
-import com.google.cloud.bigquery.jdbc.it.ITOpenTelemetryTest;
 import com.google.cloud.bigquery.jdbc.it.ITResultSetMetadataTest;
 import com.google.cloud.bigquery.jdbc.it.ITStatementTest;
 import org.junit.platform.suite.api.SelectClasses;
@@ -40,7 +39,6 @@ import org.junit.platform.suite.api.Suite;
   ITDatabaseMetadataTest.class,
   ITDriverTest.class,
   ITLocalSslValidationTest.class,
-  ITOpenTelemetryTest.class,
   ITResultSetMetadataTest.class,
   ITStatementTest.class
 })


### PR DESCRIPTION
b/537284101

This PR fixes multiple OpenTelemetry resource leaks.

### Key Changes
1. **Fix Thread Leaks (Reference Counting):** Wrapped `OpenTelemetrySdk` in a `CachedSdk` to track usage. The SDK and its background threads are now explicitly closed when the last JDBC `Connection` using them is closed.
2. **Fix Classloader Leaks:** Removed the redundant `Runtime.addShutdownHook` in `BigQueryJdbcOpenTelemetry`. This prevents severe `Metaspace` memory leaks when the driver is undeployed in Application Servers (like Tomcat/JBoss).
3. **Fix Service Account Path Fallback:** Updated `resolveEffectiveCredentials()` to properly detect `OAUTH_PVT_KEY_PATH_PROPERTY_NAME` (key file paths), preventing erroneous fallbacks to Application Default Credentials.
4. **Fix Test Quota Limits:** Increased the polling delay in `ITOpenTelemetryTest` from 500ms to 3000ms. This prevents the GCP Logging API from rejecting the test with `RESOURCE_EXHAUSTED` (Status 429) errors due to exceeding the 60 requests/minute quota limit.
5. **Fix ADC support**
