### PR TITLE
ci(bom): print full mvn-install.log on pre-install failure

### DIFF
--- a/java-cloud-bom/tests/pre-install.sh
+++ b/java-cloud-bom/tests/pre-install.sh
@@ -35,9 +35,9 @@ set -eo pipefail
 
 if ! mvn install -pl $(cat bom_projects.txt) -am -amd -DskipTests=true -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Denforcer.skip=true -Danimal.sniffer.skip=true -Dclirr.skip=true -Dgcloud.download.skip=true -B -V -T 1C -l java-cloud-bom/tests/mvn-install.log; then
   echo "========================================================================"
-  echo "mvn install failed! Printing the last 200 lines of mvn-install.log:"
+  echo "mvn install failed! Printing mvn-install.log:"
   echo "========================================================================"
-  tail -n 200 java-cloud-bom/tests/mvn-install.log
+  cat java-cloud-bom/tests/mvn-install.log
   exit 1
 fi
 rm bom_projects.txt


### PR DESCRIPTION
## Description
Updates `java-cloud-bom/tests/pre-install.sh` to print the complete `mvn-install.log` on failure instead of truncating output with `tail -n 200`.

## Rationale
When a module fails compilation during `pre-install.sh`, Maven skips installing its JAR into local cache (`~/.m2/repository`). Downstream modules subsequently fail dependency resolution when attempting to fetch missing in-repo SNAPSHOT artifacts from Maven Central.

Because `pre-install.sh` previously ran `tail -n 200`, only the trailing downstream dependency resolution errors were printed in CI, concealing the actual root-cause compilation errors that occurred earlier in the log.