### PR TITLE
fix: fix java-cloud-bom README update workflow after monorepo migration

### DIFF
--- a/.github/workflows/java-cloud-bom-update-readme-table.yaml
+++ b/.github/workflows/java-cloud-bom-update-readme-table.yaml
@@ -24,7 +24,7 @@ jobs:
       pull-requests: write
     steps:
     - name: Check out repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/java-cloud-bom-update-readme-table.yaml
+++ b/.github/workflows/java-cloud-bom-update-readme-table.yaml
@@ -26,7 +26,9 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
+        # Token and persist-credentials are required so subsequent git push steps can authenticate
         token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+        persist-credentials: true
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/.github/workflows/java-cloud-bom-update-readme-table.yaml
+++ b/.github/workflows/java-cloud-bom-update-readme-table.yaml
@@ -25,10 +25,6 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-      with:
-        # Token and persist-credentials are required so subsequent git push steps can authenticate
-        token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
-        persist-credentials: true
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/.github/workflows/java-cloud-bom-update-readme-table.yaml
+++ b/.github/workflows/java-cloud-bom-update-readme-table.yaml
@@ -25,6 +25,9 @@ jobs:
     steps:
     - name: Check out repository
       uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        # Explicitly persist credentials so subsequent git push steps can authenticate with origin
+        persist-credentials: true
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/.github/workflows/java-cloud-bom-update-readme-table.yaml
+++ b/.github/workflows/java-cloud-bom-update-readme-table.yaml
@@ -24,9 +24,9 @@ jobs:
       pull-requests: write
     steps:
     - name: Check out repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       with:
-        persist-credentials: false
+        token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6

--- a/.github/workflows/java-cloud-bom-update-readme-table.yaml
+++ b/.github/workflows/java-cloud-bom-update-readme-table.yaml
@@ -13,24 +13,12 @@ on:
 env:
   BUILD_SUBDIR: java-cloud-bom
 jobs:
-  filter:
-    runs-on: ubuntu-latest
-    outputs:
-      library: ${{ steps.filter.outputs.library }}
-    steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      with:
-        persist-credentials: false
-    - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
-      id: filter
-      with:
-        filters: |
-          library:
-            - 'java-cloud-bom/**'
   update-readme:
-    needs: filter
-    if: ${{ needs.filter.outputs.library == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'libraries-bom/') }}
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: java-cloud-bom
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Fixes b/537369259

### Context
After the monorepo migration (PR #13498), the `java-cloud-bom` repository was moved into the `java-cloud-bom/` subdirectory. The GitHub Actions workflow `.github/workflows/java-cloud-bom-update-readme-table.yaml` was copied over from the split repository without updating its paths or filter triggers.

### Root Causes
1. **Path-Filter Always Skips on Release Events:** On a `release` event, `dorny/paths-filter` compares the release tag commit against `main`. Since release commits are already merged to `main` prior to tagging, the diff is empty, causing `dorny/paths-filter` to evaluate to `false` and skip the `update-readme` job.
2. **Missing Working Directory:** The workflow attempted to run `python libraries-bom-table-generation/updateREADMETable.py` from the repository root, but both the script and target `README.md` are located within the `java-cloud-bom/` subdirectory.

### Fix
- **Removed redundant `filter` job:** Replaced it with a direct job condition:
  ```yaml
  if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'libraries-bom/') }}
  ```
  This matches the release tag pattern (`libraries-bom/v*`) used by `create_additional_release_tag.yaml` and `java-cloud-bom-release-note-generation.yaml`.
- **Configured Working Directory:** Added `defaults.run.working-directory: java-cloud-bom` to the `update-readme` job so all steps execute inside `java-cloud-bom/`.