### PR TITLE
fix(bigquery-jdbc): add service resource transformer for standalone IT

### DIFF
--- a/java-bigquery-jdbc/pom-it.xml
+++ b/java-bigquery-jdbc/pom-it.xml
@@ -146,6 +146,7 @@
                 </filter>
               </filters>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.junit.platform.console.ConsoleLauncher</mainClass>
                 </transformer>


### PR DESCRIPTION
Shading `io.grpc` without this transformer breaks some resource discovery