### PR TITLE
build(release-note-generation): remove unused commons-codec dependency

### DIFF
--- a/java-cloud-bom/release-note-generation/pom.xml
+++ b/java-cloud-bom/release-note-generation/pom.xml
@@ -49,11 +49,6 @@
 			<artifactId>maven-resolver-api</artifactId>
 			<version>1.6.3</version>
 		</dependency>
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<version>1.11</version>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Error logs:
```
[INFO] --- dependency:3.7.0:analyze (default-cli) @ release-note-generation ---
[ERROR] Unused declared dependencies found:
[ERROR]    commons-codec:commons-codec:jar:1.11:compile
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Google Cloud Java BOM 0.266.1 ...................... SUCCESS [  1.758 s]
[INFO] Google Cloud Platform Supported Libraries 26.85.1 .. SUCCESS [  0.016 s]
[INFO] Google Cloud BOM Dashboard 0.0.1-SNAPSHOT .......... SUCCESS [  0.703 s]
[INFO] Google Cloud Java BOM root project 0.1.0 ........... SUCCESS [  0.003 s]
[INFO] Release Note Generation for Cloud SDK for Java 0.1.0 FAILURE [  0.122 s]
[INFO] libraries-release-data 0.1.0 ....................... SKIPPED
[INFO] A module to test Google Cloud Java BOMs 0.81.0 ..... SKIPPED
[INFO] Full convergence check for all library dependencies in Google Cloud Java BOM 0.84.0 SKIPPED
[INFO] BOM Canary Project Creation 1.88.0 ................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.370 s
[INFO] Finished at: 2026-07-24T21:58:03Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.7.0:analyze (default-cli) on project release-note-generation: Dependency problems found -> [Help 1]
```

From https://github.com/googleapis/google-cloud-java/actions/runs/30128066775/job/89596608376?pr=13876