### PR TITLE
build(ci): add bulkTests profile to grpc-gcp-java

### DIFF
--- a/grpc-gcp-java/pom.xml
+++ b/grpc-gcp-java/pom.xml
@@ -312,4 +312,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>bulkTests</id>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
grpc-gcp-java has its own split-units config. BulkTests filter should ignore those unit tests from running on the units CI

```
[INFO] --- surefire:3.5.2:test (default-test) @ grpc-gcp ---
[INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.google.cloud.grpc.ChannelIdPropagationTest
[INFO] Running com.google.cloud.grpc.GcpManagedChannelOtelMetricsTest
[INFO] Running com.google.cloud.grpc.GcpManagedChannelTest
```

Logs of it running in units CI.