### PR TITLE
build(deps): update dependency org.codehaus.mojo:flatten-maven-plugin to v1.7.3

### DIFF
--- a/java-shared-config/java-shared-config/pom.xml
+++ b/java-shared-config/java-shared-config/pom.xml
@@ -184,7 +184,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.3.0</version>
+          <version>1.6.0</version>
           <executions>
             <!-- enable flattening -->
             <execution>

--- a/java-shared-config/java-shared-config/pom.xml
+++ b/java-shared-config/java-shared-config/pom.xml
@@ -184,7 +184,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.6.0</version>
+          <version>1.7.0</version>
           <executions>
             <!-- enable flattening -->
             <execution>

--- a/java-shared-config/java-shared-config/pom.xml
+++ b/java-shared-config/java-shared-config/pom.xml
@@ -184,7 +184,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>flatten-maven-plugin</artifactId>
-          <version>1.7.0</version>
+          <version>1.7.3</version>
           <executions>
             <!-- enable flattening -->
             <execution>


### PR DESCRIPTION
Update flatten plugin to v1.6.0+ to take advantage of the newly introduced skip flag in v1.6.0. Opt for an older version of the flatten plugin that is relatively stable without many version of bug fixes.

Optionally upgrade to the latest v1.7.x version which has been stable for ~1 year

# Why upgrade from Gemini
1.6.0 Context & Issues:
- flatten.skip Support: 1.6.0 added the flatten.skip flag (PR #385)
- Regressions in 1.6.0: However, 1.6.0 had parent dependency resolution issues (such as Issue #377, where dependencies declared in parent POMs were missing or improperly omitted in flattened POMs) as well as property resolution/interpolation edge cases.

Why 1.7.0+ is the ideal target:
- Fixes Regressions: 1.7.0 explicitly addressed the parent dependency resolution bug (PR #417) and introduced extended property interpolation (PR #384).
- Retains flatten.skip: 1.7.0 maintains full support for flatten.skip.

1.7.3 is the latest stable release in the 1.7.x branch and includes cumulative bug fixes over 1.7.0:
- 1.7.1: Preserves POM element ordering/formatting in resolveCiFriendliesOnly mode ([#446](https://github.com/mojohaus/flatten-maven-plugin/pull/446)) and updates plexus-interpolation compatibility ([#453](https://github.com/mojohaus/flatten-maven-plugin/pull/453)).
- 1.7.2: Ensures target directories are created reliably and optimizes file operations using Java NIO ([#471](https://github.com/mojohaus/flatten-maven-plugin/pull/471)). 
- 1.7.3: Fixes issue where condition-activated profiles were missing from the effective model ([#481](https://github.com/mojohaus/flatten-maven-plugin/pull/481)).