### PR TITLE
chore: update librarian to v0.31.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: java
-version: v0.29.1
+version: v0.31.0
 repo: googleapis/google-cloud-java
 sources:
   googleapis:


### PR DESCRIPTION
Update librarian version & re-generate.
```
go run github.com/googleapis/librarian/cmd/librarian@latest update version
```
run generate workflow: https://github.com/googleapis/google-cloud-java/actions/runs/30372018632