### PR TITLE
ci(librarian): remove unused setup-python steps from workflows

### DIFF
--- a/.github/workflows/librarian_generation_check.yaml
+++ b/.github/workflows/librarian_generation_check.yaml
@@ -66,10 +66,6 @@ jobs:
           sudo apt-get update && sudo apt-get install -y maven
         fi
         mvn -version
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-      with:
-        python-version: "3.12"
-        cache: 'pip'
     - name: Run librarian install
       run: |
         librarian install

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -114,11 +114,6 @@ jobs:
           sudo apt-get update && sudo apt-get install -y maven
         fi
         mvn -version
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-      if: steps.detect_librarian.outputs.has_changes == 'true'
-      with:
-        python-version: "3.12"
-        cache: 'pip'
     - name: Run librarian install
       if: steps.detect_librarian.outputs.has_changes == 'true'
       run: |


### PR DESCRIPTION
Remove unused python setup step in workflows. They are unused since https://github.com/googleapis/google-cloud-java/pull/13912 and causing problems in clean up steps.

Fixes https://github.com/googleapis/librarian/issues/7096