### PR TITLE
chore: remove legacy python and hermetic_build references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,3 @@ monorepo
 *.tfstate.lock.info
 
 .jqwik-database
-
-# Python build artifacts for library_generation tool
-sdk-platform-java/hermetic_build/library_generation/build/

--- a/java-showcase/scripts/generate_showcase.sh
+++ b/java-showcase/scripts/generate_showcase.sh
@@ -5,9 +5,6 @@ set -ex
 echo "******** Generating Showcase ********"
 
 readonly ROOT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/../.."
-# Export PYTHONPATH so that owlbot.py scripts run by Librarian
-# can resolve local synthtool under the hermetic build directory.
-export PYTHONPATH="${ROOT_DIR}/sdk-platform-java/hermetic_build/library_generation/owlbot"
 cd "${ROOT_DIR}"
 
 readonly LIBRARIAN_VER=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,9 +14,6 @@
         "sdk-platform-java/.cloudbuild/graalvm/cloudbuild-test-a.yaml",
         "sdk-platform-java/.cloudbuild/graalvm/cloudbuild-test-b.yaml",
         "sdk-platform-java/.cloudbuild/graalvm/cloudbuild-test-c.yaml",
-        "sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-a.cfg",
-        "sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-b.cfg",
-        "sdk-platform-java/hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg",
         "java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/telemetry/Version.java"
       ]
     }

--- a/sdk-platform-java/release-please-config.json
+++ b/sdk-platform-java/release-please-config.json
@@ -11,9 +11,6 @@
         ".cloudbuild/graalvm/cloudbuild-test-a.yaml",
         ".cloudbuild/graalvm/cloudbuild-test-b.yaml",
         ".cloudbuild/graalvm/cloudbuild-test-c.yaml",
-		"hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-a.cfg",
-		"hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-b.cfg",
-		"hermetic_build/library_generation/owlbot/templates/java_library/.kokoro/presubmit/graalvm-native-c.cfg",
 		"java-showcase/gapic-showcase/src/main/java/com/google/showcase/v1beta1/stub/Version.java"
 
       ]


### PR DESCRIPTION
Remove PYTHONPATH exports and deleted template paths from release-please configs.

Fixes https://github.com/googleapis/librarian/issues/7064