### PR TITLE
feat(bigquery): add QueryResultsFormat and ArrowSerializationOptions configurations

### DIFF
--- a/google-cloud-jar-parent/pom.xml
+++ b/google-cloud-jar-parent/pom.xml
@@ -142,7 +142,7 @@
       <dependency>
         <groupId>com.google.apis</groupId>
         <artifactId>google-api-services-bigquery</artifactId>
-        <version>v2-rev20260612-2.0.0</version>
+        <version>v2-rev20260707-2.0.0</version>
       </dependency>
 
     </dependencies>

--- a/java-bigquery/google-cloud-bigquery/pom.xml
+++ b/java-bigquery/google-cloud-bigquery/pom.xml
@@ -204,6 +204,10 @@
       <scope>test</scope>
       <version>1.102.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-datacatalog-v1:current} -->
     </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.opentelemetry</groupId>

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -58,10 +58,9 @@ public final class ArrowSerializationOptions implements Serializable {
   /** <b>[Beta]</b> Timestamp precision for Apache Arrow timestamp types. */
   @BetaApi
   public enum TimestampPrecision {
-    PRECISION_MILLIS("PRECISION_MILLIS"),
-    PRECISION_MICROS("PRECISION_MICROS"),
-    PRECISION_NANOS("PRECISION_NANOS"),
-    PRECISION_PICOS("PRECISION_PICOS");
+    MICROS("PRECISION_MICROS"),
+    NANOS("PRECISION_NANOS"),
+    PICOS("PRECISION_PICOS");
 
     private final String value;
 
@@ -155,7 +154,7 @@ public final class ArrowSerializationOptions implements Serializable {
   @BetaApi
   public static final class Builder {
     private CompressionCodec bufferCompression = CompressionCodec.UNCOMPRESSED;
-    private TimestampPrecision picosTimestampPrecision = TimestampPrecision.PRECISION_MICROS;
+    private TimestampPrecision picosTimestampPrecision = TimestampPrecision.MICROS;
 
     private Builder() {}
 

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -32,8 +32,55 @@ public final class ArrowSerializationOptions implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private final @Nullable String bufferCompression;
-  private final @Nullable String picosTimestampPrecision;
+  /** <b>[Beta]</b> Buffer compression codec for Apache Arrow record batches. */
+  @BetaApi
+  public enum CompressionCodec {
+    UNCOMPRESSED("UNCOMPRESSED"),
+    LZ4_FRAME("LZ4_FRAME"),
+    ZSTD("ZSTD");
+
+    private final String value;
+
+    CompressionCodec(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
+
+  /** <b>[Beta]</b> Timestamp precision for Apache Arrow timestamp types. */
+  @BetaApi
+  public enum TimestampPrecision {
+    PRECISION_MILLIS("PRECISION_MILLIS"),
+    PRECISION_MICROS("PRECISION_MICROS"),
+    PRECISION_NANOS("PRECISION_NANOS"),
+    PRECISION_PICOS("PRECISION_PICOS");
+
+    private final String value;
+
+    TimestampPrecision(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
+
+  private final CompressionCodec bufferCompression;
+  private final TimestampPrecision picosTimestampPrecision;
 
   private ArrowSerializationOptions(Builder builder) {
     this.bufferCompression = builder.bufferCompression;
@@ -42,14 +89,16 @@ public final class ArrowSerializationOptions implements Serializable {
 
   /**
    * <b>[Beta]</b> Returns the buffer compression algorithm (e.g., LZ4_FRAME, ZSTD, UNCOMPRESSED).
+   * Defaults to {@link CompressionCodec#UNCOMPRESSED}.
    */
   @BetaApi
-  public @Nullable String getBufferCompression() {
+  public CompressionCodec getBufferCompression() {
     return bufferCompression;
   }
 
   /**
-   * <b>[Beta]</b> Returns the timestamp precision for Arrow timestamp types.
+   * <b>[Beta]</b> Returns the timestamp precision for Arrow timestamp types. Defaults to {@link
+   * TimestampPrecision#PRECISION_MICROS}.
    *
    * <p>Note: Only applies when {@link QueryResultsFormat#ARROW} is enabled. For Arrow result
    * streams, this precision setting governs binary Arrow timestamp column types and takes
@@ -57,7 +106,7 @@ public final class ArrowSerializationOptions implements Serializable {
    * {@link QueryResultsFormat#STRUCT_ENCODING} JSON results.
    */
   @BetaApi
-  public @Nullable String getPicosTimestampPrecision() {
+  public TimestampPrecision getPicosTimestampPrecision() {
     return picosTimestampPrecision;
   }
 
@@ -84,8 +133,8 @@ public final class ArrowSerializationOptions implements Serializable {
       return false;
     }
     ArrowSerializationOptions that = (ArrowSerializationOptions) o;
-    return Objects.equals(bufferCompression, that.bufferCompression)
-        && Objects.equals(picosTimestampPrecision, that.picosTimestampPrecision);
+    return bufferCompression == that.bufferCompression
+        && picosTimestampPrecision == that.picosTimestampPrecision;
   }
 
   @Override
@@ -105,8 +154,8 @@ public final class ArrowSerializationOptions implements Serializable {
   /** <b>[Beta]</b> Builder for {@link ArrowSerializationOptions}. */
   @BetaApi
   public static final class Builder {
-    private @Nullable String bufferCompression;
-    private @Nullable String picosTimestampPrecision;
+    private CompressionCodec bufferCompression = CompressionCodec.UNCOMPRESSED;
+    private TimestampPrecision picosTimestampPrecision = TimestampPrecision.PRECISION_MICROS;
 
     private Builder() {}
 
@@ -114,7 +163,7 @@ public final class ArrowSerializationOptions implements Serializable {
      * <b>[Beta]</b> Sets the buffer compression algorithm (e.g., LZ4_FRAME, ZSTD, UNCOMPRESSED).
      */
     @BetaApi
-    public Builder setBufferCompression(String bufferCompression) {
+    public Builder setBufferCompression(CompressionCodec bufferCompression) {
       this.bufferCompression = checkNotNull(bufferCompression, "bufferCompression cannot be null");
       return this;
     }
@@ -128,7 +177,7 @@ public final class ArrowSerializationOptions implements Serializable {
      * {@link QueryResultsFormat#STRUCT_ENCODING} JSON results.
      */
     @BetaApi
-    public Builder setPicosTimestampPrecision(String picosTimestampPrecision) {
+    public Builder setPicosTimestampPrecision(TimestampPrecision picosTimestampPrecision) {
       this.picosTimestampPrecision =
           checkNotNull(picosTimestampPrecision, "picosTimestampPrecision cannot be null");
       return this;

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -73,27 +73,13 @@ public final class ArrowSerializationOptions implements Serializable {
     return Objects.hash(bufferCompression, picosTimestampPrecision);
   }
 
-  com.google.api.services.bigquery.model.ArrowSerializationOptions toPb() {
-    com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb =
-        new com.google.api.services.bigquery.model.ArrowSerializationOptions();
-    if (bufferCompression != null) {
-      optionsPb.setBufferCompression(bufferCompression);
-    }
-    if (picosTimestampPrecision != null) {
-      optionsPb.setPicosTimestampPrecision(picosTimestampPrecision);
-    }
-    return optionsPb;
+  Object toPb() {
+    return ArrowSerializationOptionsConverter.toPb(this);
   }
 
   static ArrowSerializationOptions fromPb(
       com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb) {
-    if (optionsPb == null) {
-      return null;
-    }
-    return newBuilder()
-        .setBufferCompression(optionsPb.getBufferCompression())
-        .setPicosTimestampPrecision(optionsPb.getPicosTimestampPrecision())
-        .build();
+    return ArrowSerializationOptionsConverter.fromPb(optionsPb);
   }
 
   public static final class Builder {

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -20,15 +20,18 @@ import com.google.api.core.BetaApi;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** <b>[Beta]</b> Options specific to the Apache Arrow output format. */
 @BetaApi
+@NullMarked
 public final class ArrowSerializationOptions implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private final String bufferCompression;
-  private final String picosTimestampPrecision;
+  private final @Nullable String bufferCompression;
+  private final @Nullable String picosTimestampPrecision;
 
   private ArrowSerializationOptions(Builder builder) {
     this.bufferCompression = builder.bufferCompression;
@@ -39,13 +42,13 @@ public final class ArrowSerializationOptions implements Serializable {
    * <b>[Beta]</b> Returns the buffer compression algorithm (e.g., LZ4_FRAME, ZSTD, UNCOMPRESSED).
    */
   @BetaApi
-  public String getBufferCompression() {
+  public @Nullable String getBufferCompression() {
     return bufferCompression;
   }
 
   /** <b>[Beta]</b> Returns the timestamp precision for Arrow timestamp types. */
   @BetaApi
-  public String getPicosTimestampPrecision() {
+  public @Nullable String getPicosTimestampPrecision() {
     return picosTimestampPrecision;
   }
 
@@ -64,7 +67,7 @@ public final class ArrowSerializationOptions implements Serializable {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(@Nullable Object o) {
     if (this == o) {
       return true;
     }
@@ -93,8 +96,8 @@ public final class ArrowSerializationOptions implements Serializable {
   /** <b>[Beta]</b> Builder for {@link ArrowSerializationOptions}. */
   @BetaApi
   public static final class Builder {
-    private String bufferCompression;
-    private String picosTimestampPrecision;
+    private @Nullable String bufferCompression;
+    private @Nullable String picosTimestampPrecision;
 
     private Builder() {}
 
@@ -102,14 +105,14 @@ public final class ArrowSerializationOptions implements Serializable {
      * <b>[Beta]</b> Sets the buffer compression algorithm (e.g., LZ4_FRAME, ZSTD, UNCOMPRESSED).
      */
     @BetaApi
-    public Builder setBufferCompression(String bufferCompression) {
+    public Builder setBufferCompression(@Nullable String bufferCompression) {
       this.bufferCompression = bufferCompression;
       return this;
     }
 
     /** <b>[Beta]</b> Sets the timestamp precision for Arrow timestamp types. */
     @BetaApi
-    public Builder setPicosTimestampPrecision(String picosTimestampPrecision) {
+    public Builder setPicosTimestampPrecision(@Nullable String picosTimestampPrecision) {
       this.picosTimestampPrecision = picosTimestampPrecision;
       return this;
     }

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -73,7 +73,7 @@ public final class ArrowSerializationOptions implements Serializable {
     return Objects.hash(bufferCompression, picosTimestampPrecision);
   }
 
-  Object toPb() {
+  com.google.api.services.bigquery.model.ArrowSerializationOptions toPb() {
     return ArrowSerializationOptionsConverter.toPb(this);
   }
 

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -21,7 +21,7 @@ import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
 
-/** Options specific to the Apache Arrow output format. */
+/** <b>[Beta]</b> Options specific to the Apache Arrow output format. */
 @BetaApi
 public final class ArrowSerializationOptions implements Serializable {
 
@@ -35,14 +35,22 @@ public final class ArrowSerializationOptions implements Serializable {
     this.picosTimestampPrecision = builder.picosTimestampPrecision;
   }
 
+  /**
+   * <b>[Beta]</b> Returns the buffer compression algorithm (e.g., LZ4_FRAME, ZSTD, UNCOMPRESSED).
+   */
+  @BetaApi
   public String getBufferCompression() {
     return bufferCompression;
   }
 
+  /** <b>[Beta]</b> Returns the timestamp precision for Arrow timestamp types. */
+  @BetaApi
   public String getPicosTimestampPrecision() {
     return picosTimestampPrecision;
   }
 
+  /** <b>[Beta]</b> Returns a new builder for {@link ArrowSerializationOptions}. */
+  @BetaApi
   public static Builder newBuilder() {
     return new Builder();
   }
@@ -82,22 +90,32 @@ public final class ArrowSerializationOptions implements Serializable {
     return ArrowSerializationOptionsConverter.fromPb(optionsPb);
   }
 
+  /** <b>[Beta]</b> Builder for {@link ArrowSerializationOptions}. */
+  @BetaApi
   public static final class Builder {
     private String bufferCompression;
     private String picosTimestampPrecision;
 
     private Builder() {}
 
+    /**
+     * <b>[Beta]</b> Sets the buffer compression algorithm (e.g., LZ4_FRAME, ZSTD, UNCOMPRESSED).
+     */
+    @BetaApi
     public Builder setBufferCompression(String bufferCompression) {
       this.bufferCompression = bufferCompression;
       return this;
     }
 
+    /** <b>[Beta]</b> Sets the timestamp precision for Arrow timestamp types. */
+    @BetaApi
     public Builder setPicosTimestampPrecision(String picosTimestampPrecision) {
       this.picosTimestampPrecision = picosTimestampPrecision;
       return this;
     }
 
+    /** <b>[Beta]</b> Builds a new instance of {@link ArrowSerializationOptions}. */
+    @BetaApi
     public ArrowSerializationOptions build() {
       return new ArrowSerializationOptions(this);
     }

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.bigquery;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.api.core.BetaApi;
 import com.google.common.base.MoreObjects;
 import java.io.Serializable;
@@ -46,7 +48,14 @@ public final class ArrowSerializationOptions implements Serializable {
     return bufferCompression;
   }
 
-  /** <b>[Beta]</b> Returns the timestamp precision for Arrow timestamp types. */
+  /**
+   * <b>[Beta]</b> Returns the timestamp precision for Arrow timestamp types.
+   *
+   * <p>Note: Only applies when {@link QueryResultsFormat#ARROW} is enabled. For Arrow result
+   * streams, this precision setting governs binary Arrow timestamp column types and takes
+   * precedence over {@link DataFormatOptions.TimestampFormatOptions}, which applies to default
+   * {@link QueryResultsFormat#STRUCT_ENCODING} JSON results.
+   */
   @BetaApi
   public @Nullable String getPicosTimestampPrecision() {
     return picosTimestampPrecision;
@@ -105,15 +114,23 @@ public final class ArrowSerializationOptions implements Serializable {
      * <b>[Beta]</b> Sets the buffer compression algorithm (e.g., LZ4_FRAME, ZSTD, UNCOMPRESSED).
      */
     @BetaApi
-    public Builder setBufferCompression(@Nullable String bufferCompression) {
-      this.bufferCompression = bufferCompression;
+    public Builder setBufferCompression(String bufferCompression) {
+      this.bufferCompression = checkNotNull(bufferCompression, "bufferCompression cannot be null");
       return this;
     }
 
-    /** <b>[Beta]</b> Sets the timestamp precision for Arrow timestamp types. */
+    /**
+     * <b>[Beta]</b> Sets the timestamp precision for Arrow timestamp types.
+     *
+     * <p>Note: Only applies when {@link QueryResultsFormat#ARROW} is enabled. For Arrow result
+     * streams, this precision setting governs binary Arrow timestamp column types and takes
+     * precedence over {@link DataFormatOptions.TimestampFormatOptions}, which applies to default
+     * {@link QueryResultsFormat#STRUCT_ENCODING} JSON results.
+     */
     @BetaApi
-    public Builder setPicosTimestampPrecision(@Nullable String picosTimestampPrecision) {
-      this.picosTimestampPrecision = picosTimestampPrecision;
+    public Builder setPicosTimestampPrecision(String picosTimestampPrecision) {
+      this.picosTimestampPrecision =
+          checkNotNull(picosTimestampPrecision, "picosTimestampPrecision cannot be null");
       return this;
     }
 

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery;
+
+import com.google.api.core.BetaApi;
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Options specific to the Apache Arrow output format. */
+@BetaApi
+public final class ArrowSerializationOptions implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String bufferCompression;
+  private final String picosTimestampPrecision;
+
+  private ArrowSerializationOptions(Builder builder) {
+    this.bufferCompression = builder.bufferCompression;
+    this.picosTimestampPrecision = builder.picosTimestampPrecision;
+  }
+
+  public String getBufferCompression() {
+    return bufferCompression;
+  }
+
+  public String getPicosTimestampPrecision() {
+    return picosTimestampPrecision;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  @Override
+  public String toString() {
+    return com.google.common.base.MoreObjects.toStringHelper(this)
+        .add("bufferCompression", bufferCompression)
+        .add("picosTimestampPrecision", picosTimestampPrecision)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ArrowSerializationOptions that = (ArrowSerializationOptions) o;
+    return Objects.equals(bufferCompression, that.bufferCompression)
+        && Objects.equals(picosTimestampPrecision, that.picosTimestampPrecision);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bufferCompression, picosTimestampPrecision);
+  }
+
+  com.google.api.services.bigquery.model.ArrowSerializationOptions toPb() {
+    com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb =
+        new com.google.api.services.bigquery.model.ArrowSerializationOptions();
+    if (bufferCompression != null) {
+      optionsPb.setBufferCompression(bufferCompression);
+    }
+    if (picosTimestampPrecision != null) {
+      optionsPb.setPicosTimestampPrecision(picosTimestampPrecision);
+    }
+    return optionsPb;
+  }
+
+  static ArrowSerializationOptions fromPb(
+      com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb) {
+    if (optionsPb == null) {
+      return null;
+    }
+    return newBuilder()
+        .setBufferCompression(optionsPb.getBufferCompression())
+        .setPicosTimestampPrecision(optionsPb.getPicosTimestampPrecision())
+        .build();
+  }
+
+  public static final class Builder {
+    private String bufferCompression;
+    private String picosTimestampPrecision;
+
+    private Builder() {}
+
+    public Builder setBufferCompression(String bufferCompression) {
+      this.bufferCompression = bufferCompression;
+      return this;
+    }
+
+    public Builder setPicosTimestampPrecision(String picosTimestampPrecision) {
+      this.picosTimestampPrecision = picosTimestampPrecision;
+      return this;
+    }
+
+    public ArrowSerializationOptions build() {
+      return new ArrowSerializationOptions(this);
+    }
+  }
+}

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptions.java
@@ -17,6 +17,7 @@
 package com.google.cloud.bigquery;
 
 import com.google.api.core.BetaApi;
+import com.google.common.base.MoreObjects;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -48,7 +49,7 @@ public final class ArrowSerializationOptions implements Serializable {
 
   @Override
   public String toString() {
-    return com.google.common.base.MoreObjects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("bufferCompression", bufferCompression)
         .add("picosTimestampPrecision", picosTimestampPrecision)
         .toString();

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
@@ -31,12 +31,8 @@ final class ArrowSerializationOptionsConverter {
     }
     com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb =
         new com.google.api.services.bigquery.model.ArrowSerializationOptions();
-    if (options.getBufferCompression() != null) {
-      optionsPb.setBufferCompression(options.getBufferCompression());
-    }
-    if (options.getPicosTimestampPrecision() != null) {
-      optionsPb.setPicosTimestampPrecision(options.getPicosTimestampPrecision());
-    }
+    optionsPb.setBufferCompression(options.getBufferCompression().getValue());
+    optionsPb.setPicosTimestampPrecision(options.getPicosTimestampPrecision().getValue());
     return optionsPb;
   }
 
@@ -46,9 +42,25 @@ final class ArrowSerializationOptionsConverter {
     }
     com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb =
         (com.google.api.services.bigquery.model.ArrowSerializationOptions) optionsPbObj;
-    return ArrowSerializationOptions.newBuilder()
-        .setBufferCompression(optionsPb.getBufferCompression())
-        .setPicosTimestampPrecision(optionsPb.getPicosTimestampPrecision())
-        .build();
+    ArrowSerializationOptions.Builder builder = ArrowSerializationOptions.newBuilder();
+    if (optionsPb.getBufferCompression() != null) {
+      for (ArrowSerializationOptions.CompressionCodec codec :
+          ArrowSerializationOptions.CompressionCodec.values()) {
+        if (codec.getValue().equalsIgnoreCase(optionsPb.getBufferCompression())) {
+          builder.setBufferCompression(codec);
+          break;
+        }
+      }
+    }
+    if (optionsPb.getPicosTimestampPrecision() != null) {
+      for (ArrowSerializationOptions.TimestampPrecision precision :
+          ArrowSerializationOptions.TimestampPrecision.values()) {
+        if (precision.getValue().equalsIgnoreCase(optionsPb.getPicosTimestampPrecision())) {
+          builder.setPicosTimestampPrecision(precision);
+          break;
+        }
+      }
+    }
+    return builder.build();
   }
 }

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
@@ -16,18 +16,17 @@
 
 package com.google.cloud.bigquery;
 
-import com.google.api.services.bigquery.model.ArrowSerializationOptions;
-
 final class ArrowSerializationOptionsConverter {
 
   private ArrowSerializationOptionsConverter() {}
 
-  static ArrowSerializationOptions toPb(
-      com.google.cloud.bigquery.ArrowSerializationOptions options) {
+  static com.google.api.services.bigquery.model.ArrowSerializationOptions toPb(
+      ArrowSerializationOptions options) {
     if (options == null) {
       return null;
     }
-    ArrowSerializationOptions optionsPb = new ArrowSerializationOptions();
+    com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb =
+        new com.google.api.services.bigquery.model.ArrowSerializationOptions();
     if (options.getBufferCompression() != null) {
       optionsPb.setBufferCompression(options.getBufferCompression());
     }
@@ -37,12 +36,13 @@ final class ArrowSerializationOptionsConverter {
     return optionsPb;
   }
 
-  static com.google.cloud.bigquery.ArrowSerializationOptions fromPb(
-      ArrowSerializationOptions optionsPb) {
-    if (optionsPb == null) {
+  static ArrowSerializationOptions fromPb(Object optionsPbObj) {
+    if (optionsPbObj == null) {
       return null;
     }
-    return com.google.cloud.bigquery.ArrowSerializationOptions.newBuilder()
+    com.google.api.services.bigquery.model.ArrowSerializationOptions optionsPb =
+        (com.google.api.services.bigquery.model.ArrowSerializationOptions) optionsPbObj;
+    return ArrowSerializationOptions.newBuilder()
         .setBufferCompression(optionsPb.getBufferCompression())
         .setPicosTimestampPrecision(optionsPb.getPicosTimestampPrecision())
         .build();

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery;
+
+import com.google.api.services.bigquery.model.ArrowSerializationOptions;
+
+final class ArrowSerializationOptionsConverter {
+
+  private ArrowSerializationOptionsConverter() {}
+
+  static ArrowSerializationOptions toPb(
+      com.google.cloud.bigquery.ArrowSerializationOptions options) {
+    if (options == null) {
+      return null;
+    }
+    ArrowSerializationOptions optionsPb = new ArrowSerializationOptions();
+    if (options.getBufferCompression() != null) {
+      optionsPb.setBufferCompression(options.getBufferCompression());
+    }
+    if (options.getPicosTimestampPrecision() != null) {
+      optionsPb.setPicosTimestampPrecision(options.getPicosTimestampPrecision());
+    }
+    return optionsPb;
+  }
+
+  static com.google.cloud.bigquery.ArrowSerializationOptions fromPb(
+      ArrowSerializationOptions optionsPb) {
+    if (optionsPb == null) {
+      return null;
+    }
+    return com.google.cloud.bigquery.ArrowSerializationOptions.newBuilder()
+        .setBufferCompression(optionsPb.getBufferCompression())
+        .setPicosTimestampPrecision(optionsPb.getPicosTimestampPrecision())
+        .build();
+  }
+}

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/ArrowSerializationOptionsConverter.java
@@ -16,12 +16,16 @@
 
 package com.google.cloud.bigquery;
 
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
 final class ArrowSerializationOptionsConverter {
 
   private ArrowSerializationOptionsConverter() {}
 
-  static com.google.api.services.bigquery.model.ArrowSerializationOptions toPb(
-      ArrowSerializationOptions options) {
+  static com.google.api.services.bigquery.model.@Nullable ArrowSerializationOptions toPb(
+      @Nullable ArrowSerializationOptions options) {
     if (options == null) {
       return null;
     }
@@ -36,7 +40,7 @@ final class ArrowSerializationOptionsConverter {
     return optionsPb;
   }
 
-  static ArrowSerializationOptions fromPb(Object optionsPbObj) {
+  static @Nullable ArrowSerializationOptions fromPb(@Nullable Object optionsPbObj) {
     if (optionsPbObj == null) {
       return null;
     }

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -147,7 +147,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
     private Long maxResults;
     private JobCreationMode jobCreationMode;
     private String reservation;
-    private QueryResultsFormat queryResultsFormat;
+    private QueryResultsFormat queryResultsFormat = QueryResultsFormat.STRUCT_ENCODING;
     private ArrowSerializationOptions arrowSerializationOptions;
 
     private Builder() {

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -75,6 +75,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
   private final Long maxResults;
   private final JobCreationMode jobCreationMode;
   private final String reservation;
+  private final QueryResultsFormat queryResultsFormat;
+  private final ArrowSerializationOptions arrowSerializationOptions;
 
   /**
    * Priority levels for a query. If not specified the priority is assumed to be {@link
@@ -144,6 +146,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
     private Long maxResults;
     private JobCreationMode jobCreationMode;
     private String reservation;
+    private QueryResultsFormat queryResultsFormat;
+    private ArrowSerializationOptions arrowSerializationOptions;
 
     private Builder() {
       super(Type.QUERY);
@@ -181,6 +185,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
       this.maxResults = jobConfiguration.maxResults;
       this.jobCreationMode = jobConfiguration.jobCreationMode;
       this.reservation = jobConfiguration.reservation;
+      this.queryResultsFormat = jobConfiguration.queryResultsFormat;
+      this.arrowSerializationOptions = jobConfiguration.arrowSerializationOptions;
     }
 
     private Builder(com.google.api.services.bigquery.model.JobConfiguration configurationPb) {
@@ -701,6 +707,17 @@ public final class QueryJobConfiguration extends JobConfiguration {
       return this;
     }
 
+    public Builder setQueryResultsFormat(QueryResultsFormat queryResultsFormat) {
+      this.queryResultsFormat = queryResultsFormat;
+      return this;
+    }
+
+    public Builder setArrowSerializationOptions(
+        ArrowSerializationOptions arrowSerializationOptions) {
+      this.arrowSerializationOptions = arrowSerializationOptions;
+      return this;
+    }
+
     public QueryJobConfiguration build() {
       return new QueryJobConfiguration(this);
     }
@@ -747,6 +764,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
     this.maxResults = builder.maxResults;
     this.jobCreationMode = builder.jobCreationMode;
     this.reservation = builder.reservation;
+    this.queryResultsFormat = builder.queryResultsFormat;
+    this.arrowSerializationOptions = builder.arrowSerializationOptions;
   }
 
   /**
@@ -973,6 +992,14 @@ public final class QueryJobConfiguration extends JobConfiguration {
     return new Builder(this);
   }
 
+  public QueryResultsFormat getQueryResultsFormat() {
+    return queryResultsFormat;
+  }
+
+  public ArrowSerializationOptions getArrowSerializationOptions() {
+    return arrowSerializationOptions;
+  }
+
   @Override
   ToStringHelper toStringHelper() {
     return super.toStringHelper()
@@ -1004,13 +1031,23 @@ public final class QueryJobConfiguration extends JobConfiguration {
         .add("rangePartitioning", rangePartitioning)
         .add("connectionProperties", connectionProperties)
         .add("jobCreationMode", jobCreationMode)
-        .add("reservation", reservation);
+        .add("reservation", reservation)
+        .add("queryResultsFormat", queryResultsFormat)
+        .add("arrowSerializationOptions", arrowSerializationOptions);
   }
 
   @Override
   public boolean equals(Object obj) {
-    return obj == this
-        || obj instanceof QueryJobConfiguration && baseEquals((QueryJobConfiguration) obj);
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || !(obj instanceof QueryJobConfiguration)) {
+      return false;
+    }
+    QueryJobConfiguration other = (QueryJobConfiguration) obj;
+    return baseEquals(other)
+        && Objects.equals(queryResultsFormat, other.queryResultsFormat)
+        && Objects.equals(arrowSerializationOptions, other.arrowSerializationOptions);
   }
 
   @Override
@@ -1043,7 +1080,9 @@ public final class QueryJobConfiguration extends JobConfiguration {
         labels,
         rangePartitioning,
         connectionProperties,
-        reservation);
+        reservation,
+        queryResultsFormat,
+        arrowSerializationOptions);
   }
 
   @Override

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -707,11 +707,34 @@ public final class QueryJobConfiguration extends JobConfiguration {
       return this;
     }
 
+    /**
+     * Sets the query results response format. Defaults to {@link
+     * QueryResultsFormat#STRUCT_ENCODING}.
+     *
+     * <p>When set to {@link QueryResultsFormat#ARROW}, query results are returned in binary Apache
+     * Arrow format, utilizing gRPC Storage Read streams for subsequent pages.
+     *
+     * <p><b>Prerequisite:</b> Requires the BigQuery Storage Read API ({@code
+     * bigquerystorage.googleapis.com}) to be enabled on your GCP project and your credentials to
+     * have Storage Read permissions (e.g. {@code bigquery.readsessions.create}).
+     *
+     * @param queryResultsFormat the format for query result payloads
+     * @return the Builder
+     */
     public Builder setQueryResultsFormat(QueryResultsFormat queryResultsFormat) {
       this.queryResultsFormat = queryResultsFormat;
       return this;
     }
 
+    /**
+     * Sets Arrow serialization options. Defaults to null.
+     *
+     * <p>Note: Only applied in the request payload when {@code queryResultsFormat} is {@code
+     * ARROW}.
+     *
+     * @param arrowSerializationOptions the Arrow serialization options to set
+     * @return the Builder
+     */
     public Builder setArrowSerializationOptions(
         ArrowSerializationOptions arrowSerializationOptions) {
       this.arrowSerializationOptions = arrowSerializationOptions;

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+import com.google.api.core.BetaApi;
 import com.google.api.services.bigquery.model.JobConfigurationQuery;
 import com.google.api.services.bigquery.model.QueryParameter;
 import com.google.cloud.bigquery.JobInfo.CreateDisposition;
@@ -708,26 +709,26 @@ public final class QueryJobConfiguration extends JobConfiguration {
     }
 
     /**
-     * Sets the query results response format. Defaults to {@link
+     * <b>[Beta]</b> Sets the query results response format. Defaults to {@link
      * QueryResultsFormat#STRUCT_ENCODING}.
      *
      * <p>When set to {@link QueryResultsFormat#ARROW}, query results are returned in binary Apache
      * Arrow format, utilizing gRPC Storage Read streams for subsequent pages.
      *
      * <p><b>Prerequisite:</b> Requires the BigQuery Storage Read API ({@code
-     * bigquerystorage.googleapis.com}) to be enabled on your GCP project and your credentials to
-     * have Storage Read permissions (e.g. {@code bigquery.readsessions.create}).
+     * bigquerystorage.googleapis.com}) to be enabled on your GCP project.
      *
      * @param queryResultsFormat the format for query result payloads
      * @return the Builder
      */
+    @BetaApi
     public Builder setQueryResultsFormat(QueryResultsFormat queryResultsFormat) {
       this.queryResultsFormat = queryResultsFormat;
       return this;
     }
 
     /**
-     * Sets Arrow serialization options. Defaults to null.
+     * <b>[Beta]</b> Sets Arrow serialization options. Defaults to null.
      *
      * <p>Note: Only applied in the request payload when {@code queryResultsFormat} is {@code
      * ARROW}.
@@ -735,6 +736,7 @@ public final class QueryJobConfiguration extends JobConfiguration {
      * @param arrowSerializationOptions the Arrow serialization options to set
      * @return the Builder
      */
+    @BetaApi
     public Builder setArrowSerializationOptions(
         ArrowSerializationOptions arrowSerializationOptions) {
       this.arrowSerializationOptions = arrowSerializationOptions;
@@ -1015,10 +1017,14 @@ public final class QueryJobConfiguration extends JobConfiguration {
     return new Builder(this);
   }
 
+  /** <b>[Beta]</b> Returns the query results response format. */
+  @BetaApi
   public QueryResultsFormat getQueryResultsFormat() {
     return queryResultsFormat;
   }
 
+  /** <b>[Beta]</b> Returns Arrow serialization options, or null if unset. */
+  @BetaApi
   public ArrowSerializationOptions getArrowSerializationOptions() {
     return arrowSerializationOptions;
   }

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -725,7 +725,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
      */
     @BetaApi
     public Builder setQueryResultsFormat(QueryResultsFormat queryResultsFormat) {
-      this.queryResultsFormat = queryResultsFormat;
+      this.queryResultsFormat =
+          checkNotNull(queryResultsFormat, "queryResultsFormat cannot be null");
       return this;
     }
 
@@ -741,7 +742,8 @@ public final class QueryJobConfiguration extends JobConfiguration {
     @BetaApi
     public Builder setArrowSerializationOptions(
         ArrowSerializationOptions arrowSerializationOptions) {
-      this.arrowSerializationOptions = arrowSerializationOptions;
+      this.arrowSerializationOptions =
+          checkNotNull(arrowSerializationOptions, "arrowSerializationOptions cannot be null");
       return this;
     }
 

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryJobConfiguration.java
@@ -716,7 +716,9 @@ public final class QueryJobConfiguration extends JobConfiguration {
      * Arrow format, utilizing gRPC Storage Read streams for subsequent pages.
      *
      * <p><b>Prerequisite:</b> Requires the BigQuery Storage Read API ({@code
-     * bigquerystorage.googleapis.com}) to be enabled on your GCP project.
+     * bigquerystorage.googleapis.com}) to be enabled on your GCP project. See the <a
+     * href="https://docs.cloud.google.com/apis/docs/getting-started#enabling_apis">Google Cloud
+     * Enabling APIs Guide</a>.
      *
      * @param queryResultsFormat the format for query result payloads
      * @return the Builder

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryResultsFormat.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryResultsFormat.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery;
+
+import com.google.api.core.BetaApi;
+
+/** The format of the query results. */
+@BetaApi
+public enum QueryResultsFormat {
+  /** Serialized row data in Apache Arrow format. */
+  ARROW,
+
+  /** Default encoding of results as JSON struct array. */
+  STRUCT_ENCODING
+}

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryResultsFormat.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryResultsFormat.java
@@ -17,9 +17,11 @@
 package com.google.cloud.bigquery;
 
 import com.google.api.core.BetaApi;
+import org.jspecify.annotations.NullMarked;
 
 /** <b>[Beta]</b> The format of the query results. */
 @BetaApi
+@NullMarked
 public enum QueryResultsFormat {
   /** Serialized row data in Apache Arrow format. */
   ARROW,

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryResultsFormat.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/QueryResultsFormat.java
@@ -18,7 +18,7 @@ package com.google.cloud.bigquery;
 
 import com.google.api.core.BetaApi;
 
-/** The format of the query results. */
+/** <b>[Beta]</b> The format of the query results. */
 @BetaApi
 public enum QueryResultsFormat {
   /** Serialized row data in Apache Arrow format. */

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
@@ -248,8 +248,7 @@ public class QueryJobConfigurationTest {
     ArrowSerializationOptions options =
         ArrowSerializationOptions.newBuilder()
             .setBufferCompression(ArrowSerializationOptions.CompressionCodec.LZ4_FRAME)
-            .setPicosTimestampPrecision(
-                ArrowSerializationOptions.TimestampPrecision.PRECISION_MILLIS)
+            .setPicosTimestampPrecision(ArrowSerializationOptions.TimestampPrecision.NANOS)
             .build();
     QueryJobConfiguration job =
         QueryJobConfiguration.newBuilder(QUERY)
@@ -268,7 +267,7 @@ public class QueryJobConfigurationTest {
 
     // Test toPb/fromPb (not preserved)
     QueryJobConfiguration jobFromPb = QueryJobConfiguration.fromPb(job.toPb());
-    assertNull(jobFromPb.getQueryResultsFormat());
+    assertEquals(QueryResultsFormat.STRUCT_ENCODING, jobFromPb.getQueryResultsFormat());
     assertNull(jobFromPb.getArrowSerializationOptions());
   }
 
@@ -279,7 +278,7 @@ public class QueryJobConfigurationTest {
         ArrowSerializationOptions.CompressionCodec.UNCOMPRESSED,
         builder.build().getBufferCompression());
     assertEquals(
-        ArrowSerializationOptions.TimestampPrecision.PRECISION_MICROS,
+        ArrowSerializationOptions.TimestampPrecision.MICROS,
         builder.build().getPicosTimestampPrecision());
 
     NullPointerException ex1 =
@@ -289,6 +288,36 @@ public class QueryJobConfigurationTest {
     NullPointerException ex2 =
         assertThrows(NullPointerException.class, () -> builder.setPicosTimestampPrecision(null));
     assertEquals("picosTimestampPrecision cannot be null", ex2.getMessage());
+  }
+
+  @Test
+  public void testQueryJobConfigurationDefaults() {
+    QueryJobConfiguration defaultJob = QueryJobConfiguration.newBuilder(QUERY).build();
+
+    // Default query format is STRUCT_ENCODING; Arrow options are null by default
+    assertEquals(QueryResultsFormat.STRUCT_ENCODING, defaultJob.getQueryResultsFormat());
+    assertNull(defaultJob.getArrowSerializationOptions());
+
+    // Verify toBuilder preserves defaults
+    QueryJobConfiguration copiedJob = defaultJob.toBuilder().build();
+    assertEquals(QueryResultsFormat.STRUCT_ENCODING, copiedJob.getQueryResultsFormat());
+    assertNull(copiedJob.getArrowSerializationOptions());
+  }
+
+  @Test
+  public void testArrowFormatWithNullSerializationOptions() {
+    QueryJobConfiguration job =
+        QueryJobConfiguration.newBuilder(QUERY)
+            .setQueryResultsFormat(QueryResultsFormat.ARROW)
+            .build();
+
+    assertEquals(QueryResultsFormat.ARROW, job.getQueryResultsFormat());
+    assertNull(job.getArrowSerializationOptions());
+
+    // Verify toBuilder preserves ARROW format with null options
+    QueryJobConfiguration copiedJob = job.toBuilder().build();
+    assertEquals(QueryResultsFormat.ARROW, copiedJob.getQueryResultsFormat());
+    assertNull(copiedJob.getArrowSerializationOptions());
   }
 
   @Test
@@ -338,5 +367,7 @@ public class QueryJobConfigurationTest {
     assertEquals(expected.getPositionalParameters(), value.getPositionalParameters());
     assertEquals(expected.getNamedParameters(), value.getNamedParameters());
     assertEquals(expected.getReservation(), value.getReservation());
+    assertEquals(expected.getQueryResultsFormat(), value.getQueryResultsFormat());
+    assertEquals(expected.getArrowSerializationOptions(), value.getArrowSerializationOptions());
   }
 }

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
@@ -247,8 +247,9 @@ public class QueryJobConfigurationTest {
     QueryResultsFormat format = QueryResultsFormat.ARROW;
     ArrowSerializationOptions options =
         ArrowSerializationOptions.newBuilder()
-            .setBufferCompression("LZ4")
-            .setPicosTimestampPrecision("PRECISION_MILLIS")
+            .setBufferCompression(ArrowSerializationOptions.CompressionCodec.LZ4_FRAME)
+            .setPicosTimestampPrecision(
+                ArrowSerializationOptions.TimestampPrecision.PRECISION_MILLIS)
             .build();
     QueryJobConfiguration job =
         QueryJobConfiguration.newBuilder(QUERY)
@@ -274,8 +275,12 @@ public class QueryJobConfigurationTest {
   @Test
   public void testArrowSerializationOptionsNullChecks() {
     ArrowSerializationOptions.Builder builder = ArrowSerializationOptions.newBuilder();
-    assertNull(builder.build().getBufferCompression());
-    assertNull(builder.build().getPicosTimestampPrecision());
+    assertEquals(
+        ArrowSerializationOptions.CompressionCodec.UNCOMPRESSED,
+        builder.build().getBufferCompression());
+    assertEquals(
+        ArrowSerializationOptions.TimestampPrecision.PRECISION_MICROS,
+        builder.build().getPicosTimestampPrecision());
 
     NullPointerException ex1 =
         assertThrows(NullPointerException.class, () -> builder.setBufferCompression(null));
@@ -284,6 +289,19 @@ public class QueryJobConfigurationTest {
     NullPointerException ex2 =
         assertThrows(NullPointerException.class, () -> builder.setPicosTimestampPrecision(null));
     assertEquals("picosTimestampPrecision cannot be null", ex2.getMessage());
+  }
+
+  @Test
+  public void testQueryJobConfigurationArrowNullChecks() {
+    QueryJobConfiguration.Builder builder = QueryJobConfiguration.newBuilder(QUERY);
+
+    NullPointerException ex1 =
+        assertThrows(NullPointerException.class, () -> builder.setQueryResultsFormat(null));
+    assertEquals("queryResultsFormat cannot be null", ex1.getMessage());
+
+    NullPointerException ex2 =
+        assertThrows(NullPointerException.class, () -> builder.setArrowSerializationOptions(null));
+    assertEquals("arrowSerializationOptions cannot be null", ex2.getMessage());
   }
 
   private void compareQueryJobConfiguration(

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
@@ -241,6 +241,35 @@ public class QueryJobConfigurationTest {
         QUERY_JOB_CONFIGURATION_SET_JOB_CREATION_MODE.toBuilder().build());
   }
 
+  @Test
+  public void testArrowConfigurations() {
+    QueryResultsFormat format = QueryResultsFormat.ARROW;
+    ArrowSerializationOptions options =
+        ArrowSerializationOptions.newBuilder()
+            .setBufferCompression("LZ4")
+            .setPicosTimestampPrecision("PRECISION_MILLIS")
+            .build();
+    QueryJobConfiguration job =
+        QueryJobConfiguration.newBuilder(QUERY)
+            .setQueryResultsFormat(format)
+            .setArrowSerializationOptions(options)
+            .build();
+
+    assertEquals(format, job.getQueryResultsFormat());
+    assertEquals(options, job.getArrowSerializationOptions());
+
+    // Test toBuilder
+    QueryJobConfiguration copiedJob = job.toBuilder().build();
+    assertEquals(job, copiedJob);
+    assertEquals(format, copiedJob.getQueryResultsFormat());
+    assertEquals(options, copiedJob.getArrowSerializationOptions());
+
+    // Test toPb/fromPb (not preserved)
+    QueryJobConfiguration jobFromPb = QueryJobConfiguration.fromPb(job.toPb());
+    assertNull(jobFromPb.getQueryResultsFormat());
+    assertNull(jobFromPb.getArrowSerializationOptions());
+  }
+
   private void compareQueryJobConfiguration(
       QueryJobConfiguration expected, QueryJobConfiguration value) {
     assertEquals(expected, value);

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/QueryJobConfigurationTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigquery;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.cloud.bigquery.JobInfo.CreateDisposition;
 import com.google.cloud.bigquery.JobInfo.SchemaUpdateOption;
@@ -268,6 +269,21 @@ public class QueryJobConfigurationTest {
     QueryJobConfiguration jobFromPb = QueryJobConfiguration.fromPb(job.toPb());
     assertNull(jobFromPb.getQueryResultsFormat());
     assertNull(jobFromPb.getArrowSerializationOptions());
+  }
+
+  @Test
+  public void testArrowSerializationOptionsNullChecks() {
+    ArrowSerializationOptions.Builder builder = ArrowSerializationOptions.newBuilder();
+    assertNull(builder.build().getBufferCompression());
+    assertNull(builder.build().getPicosTimestampPrecision());
+
+    NullPointerException ex1 =
+        assertThrows(NullPointerException.class, () -> builder.setBufferCompression(null));
+    assertEquals("bufferCompression cannot be null", ex1.getMessage());
+
+    NullPointerException ex2 =
+        assertThrows(NullPointerException.class, () -> builder.setPicosTimestampPrecision(null));
+    assertEquals("picosTimestampPrecision cannot be null", ex2.getMessage());
   }
 
   private void compareQueryJobConfiguration(


### PR DESCRIPTION
Stacked PR 1 of 3: Exposes the public configuration API surface (`QueryResultsFormat` and `ArrowSerializationOptions`) and binds them to QueryJobConfiguration.

Note: The new classes and methods are annotated with `@BetaApi` to indicate that the API surface is experimental while implementation PRs (PR 2 of 3 and PR 3 of 3) are merged. The `@BetaApi` annotation will be removed upon completion of the final PR in the stack.

b/540476814