### PR TITLE
feat(bigquery): support us-east7 endpoint overrides in integration tests

### DIFF
--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelper.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/testing/RemoteBigQueryHelper.java
@@ -99,14 +99,17 @@ public class RemoteBigQueryHelper {
               .setConnectTimeout(CONNECT_TIMEOUT_IN_MS)
               .setReadTimeout(CONNECT_TIMEOUT_IN_MS)
               .build();
-      BigQueryOptions bigqueryOptions =
+      BigQueryOptions.Builder builder =
           BigQueryOptions.newBuilder()
               .setCredentials(ServiceAccountCredentials.fromStream(keyStream))
               .setProjectId(projectId)
               .setRetrySettings(retrySettings())
-              .setTransportOptions(transportOptions)
-              .build();
-      return new RemoteBigQueryHelper(bigqueryOptions);
+              .setTransportOptions(transportOptions);
+      String endpoint = System.getenv("BIGQUERY_ENDPOINT");
+      if (endpoint != null) {
+        builder.setHost(endpoint);
+      }
+      return new RemoteBigQueryHelper(builder.build());
     } catch (IOException ex) {
       if (log.isLoggable(Level.WARNING)) {
         log.log(Level.WARNING, ex.getMessage());
@@ -140,6 +143,10 @@ public class RemoteBigQueryHelper {
         bigqueryOptionsBuilder
             .setRetrySettings(retrySettings())
             .setTransportOptions(transportOptions);
+    String endpoint = System.getenv("BIGQUERY_ENDPOINT");
+    if (endpoint != null) {
+      builder.setHost(endpoint);
+    }
     return new RemoteBigQueryHelper(builder.build());
   }
 

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryBigDecimalByteStringEncoderTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryBigDecimalByteStringEncoderTest.java
@@ -65,7 +65,7 @@ class ITBigQueryBigDecimalByteStringEncoderTest {
 
   @BeforeAll
   static void beforeAll() throws IOException {
-    client = BigQueryWriteClient.create();
+    client = com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryWriteClient();
 
     RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
     bigquery = bigqueryHelper.getOptions().getService();

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageLongRunningTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageLongRunningTest.java
@@ -67,7 +67,7 @@ class ITBigQueryStorageLongRunningTest {
   static void beforeAll() throws IOException {
     Assumptions.assumeTrue(
         Boolean.getBoolean(LONG_TESTS_ENABLED_PROPERTY), LONG_TESTS_DISABLED_MESSAGE);
-    client = BigQueryReadClient.create();
+    client = com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryReadClient();
     parentProjectId = String.format("projects/%s", ServiceOptions.getDefaultProjectId());
 
     LOG.info(

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageReadClientTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageReadClientTest.java
@@ -504,7 +504,7 @@ class ITBigQueryStorageReadClientTest {
 
   @BeforeAll
   static void beforeAll() throws IOException, DescriptorValidationException, InterruptedException {
-    readClient = BigQueryReadClient.create();
+    readClient = com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryReadClient();
     projectName = ServiceOptions.getDefaultProjectId();
     parentProjectId = String.format("projects/%s", projectName);
 
@@ -1598,7 +1598,7 @@ class ITBigQueryStorageReadClientTest {
   @Test
   void testSimpleReadWithBackgroundExecutorProvider() throws IOException {
     BigQueryReadSettings bigQueryReadSettings =
-        BigQueryReadSettings.newBuilder()
+        com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryReadSettingsBuilder()
             .setBackgroundExecutorProvider(
                 InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(14).build())
             .build();
@@ -1761,7 +1761,7 @@ class ITBigQueryStorageReadClientTest {
     OpenTelemetry otel = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
 
     BigQueryReadSettings otelSettings =
-        BigQueryReadSettings.newBuilder()
+        com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryReadSettingsBuilder()
             .setEnableOpenTelemetryTracing(true)
             .setOpenTelemetryTracerProvider(tracerProvider)
             .build();

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageWriteClientTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryStorageWriteClientTest.java
@@ -187,10 +187,12 @@ class ITBigQueryStorageWriteClientTest {
 
   @BeforeAll
   static void beforeAll() throws IOException {
-    readClient = BigQueryReadClient.create();
+    readClient = com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryReadClient();
 
     BigQueryWriteSettings settings =
-        BigQueryWriteSettings.newBuilder().setHeaderProvider(USER_AGENT_HEADER_PROVIDER).build();
+        com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryWriteSettingsBuilder()
+            .setHeaderProvider(USER_AGENT_HEADER_PROVIDER)
+            .build();
     writeClient = BigQueryWriteClient.create(settings);
     parentProjectId = String.format("projects/%s", ServiceOptions.getDefaultProjectId());
 

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryTimeEncoderTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryTimeEncoderTest.java
@@ -63,7 +63,7 @@ class ITBigQueryTimeEncoderTest {
 
   @BeforeAll
   static void beforeAll() throws IOException {
-    client = BigQueryWriteClient.create();
+    client = com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryWriteClient();
 
     RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
     bigquery = bigqueryHelper.getOptions().getService();

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteNonQuotaRetryTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteNonQuotaRetryTest.java
@@ -67,7 +67,7 @@ class ITBigQueryWriteNonQuotaRetryTest {
 
   @BeforeAll
   static void beforeAll() throws IOException {
-    client = BigQueryWriteClient.create();
+    client = com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryWriteClient();
 
     RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
     bigquery = bigqueryHelper.getOptions().getService();

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteQuotaRetryTest.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/ITBigQueryWriteQuotaRetryTest.java
@@ -50,7 +50,7 @@ public class ITBigQueryWriteQuotaRetryTest {
 
   @BeforeAll
   static void beforeAll() throws IOException {
-    client = BigQueryWriteClient.create();
+    client = com.google.cloud.bigquery.storage.v1.it.util.Helper.createBigQueryWriteClient();
 
     RemoteBigQueryHelper bigqueryHelper = RemoteBigQueryHelper.create();
     bigquery = bigqueryHelper.getOptions().getService();

--- a/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/Helper.java
+++ b/java-bigquerystorage/google-cloud-bigquerystorage/src/test/java/com/google/cloud/bigquery/storage/v1/it/util/Helper.java
@@ -25,6 +25,9 @@ import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.storage.v1.AppendRowsResponse;
 import com.google.cloud.bigquery.storage.v1.AvroSerializationOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadSettings;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
+import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
@@ -200,5 +203,45 @@ public class Helper {
               rows.add(new GenericRecordBuilder(record).build());
             });
     return rows;
+  }
+
+  /**
+   * Returns a {@link BigQueryReadSettings.Builder} configured with potential endpoint overrides for
+   * testing.
+   */
+  public static BigQueryReadSettings.Builder createBigQueryReadSettingsBuilder() {
+    BigQueryReadSettings.Builder builder = BigQueryReadSettings.newBuilder();
+    String endpoint = System.getenv("BIGQUERY_STORAGE_ENDPOINT");
+    if (endpoint != null) {
+      builder.setEndpoint(endpoint);
+    }
+    return builder;
+  }
+
+  /**
+   * Returns a {@link BigQueryReadClient} configured with potential endpoint overrides for testing.
+   */
+  public static BigQueryReadClient createBigQueryReadClient() throws IOException {
+    return BigQueryReadClient.create(createBigQueryReadSettingsBuilder().build());
+  }
+
+  /**
+   * Returns a {@link BigQueryWriteSettings.Builder} configured with potential endpoint overrides
+   * for testing.
+   */
+  public static BigQueryWriteSettings.Builder createBigQueryWriteSettingsBuilder() {
+    BigQueryWriteSettings.Builder builder = BigQueryWriteSettings.newBuilder();
+    String endpoint = System.getenv("BIGQUERY_STORAGE_ENDPOINT");
+    if (endpoint != null) {
+      builder.setEndpoint(endpoint);
+    }
+    return builder;
+  }
+
+  /**
+   * Returns a {@link BigQueryWriteClient} configured with potential endpoint overrides for testing.
+   */
+  public static BigQueryWriteClient createBigQueryWriteClient() throws IOException {
+    return BigQueryWriteClient.create(createBigQueryWriteSettingsBuilder().build());
   }
 }


### PR DESCRIPTION
Exposes BIGQUERY_ENDPOINT and BIGQUERY_STORAGE_ENDPOINT environment variables to override endpoints in integration tests, making it possible to target regional canary endpoints like us-east7.

b/472499857