### PR TITLE
ci: optimize GHA caching in ci.yaml using prime-maven-cache composite action

### DIFF
--- a/.github/actions/prime-maven-cache/action.yml
+++ b/.github/actions/prime-maven-cache/action.yml
@@ -1,0 +1,30 @@
+name: 'Prime Maven Cache'
+description: 'Pre-populates Maven dependencies into ~/.m2/repository and GitHub Actions Cache'
+
+runs:
+  using: 'composite'
+  steps:
+    # JDK version does not impact priming or matching the Maven cache, as cache keys are derived
+    # from ${{ runner.os }} and SHA-256 hashes of pom.xml files, not the JDK version.
+    # We default to the latest LTS version (25) to run the pre-population step.
+    # Furthermore, GitHub Actions Cache entries are immutable by primary key: downstream jobs
+    # restoring this cache can run 'mvn install' or add SNAPSHOT JARs locally without ever
+    # polluting or overwriting the remote cache.
+    - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      id: setup-java
+      with:
+        java-version: 25
+        distribution: 'temurin'
+        cache: 'maven'
+    # Only run mvn test-compile if this is a primary key CACHE MISS (new/modified pom.xml).
+    # If cache-hit == 'true', ~/.m2/repository is already warm in GitHub Actions Cache and
+    # this step is skipped entirely (~3s total job execution!).
+    # Why 'mvn test-compile'?
+    # Using test-compile (instead of compile) downloads both production dependencies (compile scope)
+    # AND test libraries (test scope: JUnit, Mockito, Truth, Testcontainers) into ~/.m2/repository.
+    # When this job completes, setup-java saves ~/.m2/repository to GitHub Actions Cache.
+    # Downstream unit test jobs restore this cache and run offline without downloading any JARs from Maven Central.
+    - name: Prime Maven Cache
+      if: steps.setup-java.outputs.cache-hit != 'true'
+      shell: bash
+      run: mvn test-compile -DskipTests -Pquick-build -T 1C --batch-mode --no-transfer-progress

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,18 +58,24 @@ jobs:
             - '.github/workflows/ci.yaml'
             - '.kokoro/**'
   # these unit tests are "bulk" (non-handwritten) libraries
+  # prime-cache populates ~/.m2/repository once for the entire workflow.
+  # This downloads all required JARs so downstream unit test jobs do not need to download any JARs from Maven Central.
+  prime-cache:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/prime-maven-cache
+
   units:
     runs-on: ubuntu-latest
-    needs: bulk-filter
+    needs: [bulk-filter, prime-cache]
     strategy:
       fail-fast: false
       matrix:
         java: [11, 17, 21, 25, 26]
     steps:
-    - name: Get current week within the year
-      id: date
-      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
-      run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       with:
@@ -79,14 +85,9 @@ jobs:
       with:
         distribution: temurin
         java-version: ${{matrix.java}}
+        cache: maven
     - run: java -version
       if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      id: mvn-cache
-      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.week_of_year }}
     - run: .kokoro/build.sh
       if: ${{ needs.bulk-filter.outputs.runnable == 'true' && (needs.bulk-filter.outputs.src == 'true' || needs.bulk-filter.outputs.ci == 'true') }}
       env:
@@ -94,13 +95,9 @@ jobs:
         JOB_NAME: units-${{matrix.java}}
   units-8-runtime:
     runs-on: ubuntu-latest
-    needs: bulk-filter
+    needs: [bulk-filter, prime-cache]
     name: "units (8)"
     steps:
-    - name: Get current week within the year
-      id: date
-      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
-      run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
       with:
@@ -122,12 +119,6 @@ jobs:
         java-version: 11
         distribution: temurin
         cache: maven
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      id: mvn-cache
-      if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.week_of_year }}
     - run: .kokoro/build.sh
       if: ${{ needs.bulk-filter.outputs.runnable == 'true' && (needs.bulk-filter.outputs.src == 'true' || needs.bulk-filter.outputs.ci == 'true') }}
       shell: bash      
@@ -136,7 +127,7 @@ jobs:
         JOB_NAME: units-8-runtime-${{matrix.java}}
   # detect which libraries have changed
   changes:
-    needs: bulk-filter
+    needs: [bulk-filter, prime-cache]
     if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     permissions:
@@ -271,9 +262,6 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
         java: [11, 17, 21, 25, 26]
     steps:
-    - name: Get current week within the year
-      id: date
-      run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         persist-credentials: false
@@ -281,6 +269,7 @@ jobs:
       with:
         distribution: temurin
         java-version: ${{matrix.java}}
+        cache: maven
     - run: .kokoro/build.sh
       env:
         BUILD_SUBDIR: ${{matrix.package}}
@@ -296,9 +285,6 @@ jobs:
         package: ${{ fromJSON(needs.changes.outputs.packages) }}
         java: [8]
     steps:
-    - name: Get current week within the year
-      id: date
-      run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         persist-credentials: false
@@ -308,11 +294,6 @@ jobs:
         distribution: temurin
         cache: maven
     - run: java -version
-    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      id: mvn-cache
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-unified-${{ steps.date.outputs.week_of_year }}
     - name: Install all modules using Java 11
       shell: bash
       run: .kokoro/build.sh
@@ -353,6 +334,7 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
+        cache: maven
     - run: .kokoro/build.sh
       env:
         BUILD_SUBDIR: ${{matrix.package}}
@@ -372,6 +354,7 @@ jobs:
       with:
         distribution: temurin
         java-version: 17
+        cache: maven
     - run: .kokoro/dependencies.sh
       env:
         BUILD_SUBDIR: ${{matrix.package}}
@@ -387,7 +370,7 @@ jobs:
       - name: Success otherwise
         run: echo "Success!"
   windows:
-    needs: bulk-filter
+    needs: [bulk-filter, prime-cache]
     if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: windows-latest
     steps:
@@ -407,7 +390,7 @@ jobs:
         JOB_TYPE: test
         JOB_NAME: windows-units
   lint:
-    needs: bulk-filter
+    needs: [bulk-filter, prime-cache]
     if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -419,6 +402,7 @@ jobs:
       with:
         distribution: temurin
         java-version: 17
+        cache: maven
     - run: java -version
     - run: .kokoro/build.sh
       env:
@@ -426,13 +410,10 @@ jobs:
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
   enforcer:
-    needs: bulk-filter
+    needs: [bulk-filter, prime-cache]
     if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:
-    - name: Get current week within the year
-      id: date
-      run: echo "::set-output name=week_of_year::$(date +'%W' --utc)"
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         persist-credentials: false
@@ -449,7 +430,7 @@ jobs:
     - run: java -version
     - run: mvn -B -ntp enforcer:enforce@enforce -T 1C
   gapic-libraries-bom:
-    needs: bulk-filter
+    needs: [bulk-filter, prime-cache]
     if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
[DRAFT] - No need to review for now

Just an idea inspired from the zizmor workflow to have pre-reqs. Re-use the cache to try and speed up the setup time.

Part of https://github.com/googleapis/google-cloud-java/issues/13296