### PR TITLE
fix(sql): ran mvn formatting commands on generated gRPC stub files

### DIFF
--- a/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlAvailableDatabaseVersionsServiceGrpc.java
+++ b/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlAvailableDatabaseVersionsServiceGrpc.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.sql.v1;
 
-
 /**
  *
  *

--- a/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlEventsServiceGrpc.java
+++ b/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlEventsServiceGrpc.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.sql.v1;
 
-
 /**
  *
  *

--- a/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlFeatureEligibilityServiceGrpc.java
+++ b/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlFeatureEligibilityServiceGrpc.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.sql.v1;
 
-
 /**
  *
  *

--- a/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlIamPoliciesServiceGrpc.java
+++ b/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlIamPoliciesServiceGrpc.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.sql.v1;
 
-
 /**
  *
  *

--- a/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlInstanceNamesServiceGrpc.java
+++ b/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlInstanceNamesServiceGrpc.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.sql.v1;
 
-
 /**
  *
  *

--- a/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlRegionsServiceGrpc.java
+++ b/java-sql/grpc-google-cloud-sql-v1/src/main/java/com/google/cloud/sql/v1/SqlRegionsServiceGrpc.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.sql.v1;
 
-
 /**
  *
  *


### PR DESCRIPTION
## Description
Formats the 6 generated gRPC stub files in `java-sql/grpc-google-cloud-sql-v1`.

## Root Cause
These files were generated by `protoc-gen-grpc-java` and checked in without running a post-generation `mvn fmt:format` pass. As a result, PRs running full-repo lint checks were encountering `fmt:check` failures.

## Changes
- Executed `mvn fmt:format -pl java-sql/grpc-google-cloud-sql-v1`.

## Verification
- Verified with `mvn fmt:check -pl java-sql/grpc-google-cloud-sql-v1`:
  `Processed 16 files (0 non-complying). BUILD SUCCESS`
