### PR TITLE
ci: use GitHub token in create_additional_release_tag push

### DIFF
--- a/.github/workflows/create_additional_release_tag.yaml
+++ b/.github/workflows/create_additional_release_tag.yaml
@@ -7,6 +7,11 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      target_ref:
+        description: 'Git ref (tag or SHA) to check out and tag. Defaults to branch HEAD if empty.'
+        required: false
+        default: ''
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,6 +23,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
+        ref: ${{ inputs.target_ref || github.ref }}
         token: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
         persist-credentials: false
     - name: Set up Git
@@ -38,7 +44,7 @@ jobs:
             continue
           fi
           git tag $TAG_NAME
-          git push origin $TAG_NAME
+          git push https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git $TAG_NAME
           if [ "${ARTIFACT_ID}" = "libraries-bom" ]; then
             echo "Creating GitHub Release for ${TAG_NAME}"
             gh release create "${TAG_NAME}" --title "GCP Libraries BOM ${VERSION}" --notes "libraries-bom release."


### PR DESCRIPTION
This action failed on the [most recent full release](https://github.com/googleapis/google-cloud-java/actions/runs/30555188755) and the [most recent partial release](https://github.com/googleapis/google-cloud-java/actions/runs/29455621433); I suspect it's been broken since [persist-credentials was set to false](https://github.com/googleapis/google-cloud-java/pull/13615/changes#diff-afd3aebecfb843cab8470e95bd7903c6ae60b8072027fc03c6f462f34c7628a3).

Also add ability to specify the ref to check out (e.g. release tag) to make it easier to run this manually when automation fails.