### PR TITLE
test(showcase): add integration tests showing LRO drops error details

### DIFF
--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -20,19 +20,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiException;
+import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
 import com.google.showcase.v1beta1.EchoClient;
+import com.google.showcase.v1beta1.PoetryError;
 import com.google.showcase.v1beta1.WaitMetadata;
 import com.google.showcase.v1beta1.WaitRequest;
 import com.google.showcase.v1beta1.WaitResponse;
 import com.google.showcase.v1beta1.it.util.TestClientInitializer;
-import com.google.api.gax.rpc.ApiException;
-import com.google.rpc.Code;
-import com.google.rpc.Status;
-import com.google.protobuf.Any;
-import com.google.showcase.v1beta1.PoetryError;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 import org.threeten.bp.Duration;
@@ -212,14 +212,10 @@ class ITLongRunningOperation {
               .setMessage("The resource already exists")
               .addDetails(Any.pack(poetryError))
               .build();
-      WaitRequest waitRequest =
-          WaitRequest.newBuilder()
-              .setError(status)
-              .build();
+      WaitRequest waitRequest = WaitRequest.newBuilder().setError(status).build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           grpcClient.waitOperationCallable().futureCall(waitRequest);
-      ExecutionException exception =
-          assertThrows(ExecutionException.class, operationFuture::get);
+      ExecutionException exception = assertThrows(ExecutionException.class, operationFuture::get);
       assertThat(exception.getCause()).isInstanceOf(ApiException.class);
       ApiException apiException = (ApiException) exception.getCause();
 
@@ -244,14 +240,10 @@ class ITLongRunningOperation {
               .setMessage("The resource already exists")
               .addDetails(Any.pack(poetryError))
               .build();
-      WaitRequest waitRequest =
-          WaitRequest.newBuilder()
-              .setError(status)
-              .build();
+      WaitRequest waitRequest = WaitRequest.newBuilder().setError(status).build();
       OperationFuture<WaitResponse, WaitMetadata> operationFuture =
           httpjsonClient.waitOperationCallable().futureCall(waitRequest);
-      ExecutionException exception =
-          assertThrows(ExecutionException.class, operationFuture::get);
+      ExecutionException exception = assertThrows(ExecutionException.class, operationFuture::get);
       assertThat(exception.getCause()).isInstanceOf(ApiException.class);
       ApiException apiException = (ApiException) exception.getCause();
 

--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITLongRunningOperation.java
@@ -26,6 +26,12 @@ import com.google.showcase.v1beta1.WaitMetadata;
 import com.google.showcase.v1beta1.WaitRequest;
 import com.google.showcase.v1beta1.WaitResponse;
 import com.google.showcase.v1beta1.it.util.TestClientInitializer;
+import com.google.api.gax.rpc.ApiException;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
+import com.google.protobuf.Any;
+import com.google.showcase.v1beta1.PoetryError;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
@@ -187,6 +193,70 @@ class ITLongRunningOperation {
       assertThrows(CancellationException.class, operationFuture::get);
       int attemptCount = operationFuture.getPollingFuture().getAttemptSettings().getAttemptCount();
       assertThat(attemptCount).isGreaterThan(1);
+    } finally {
+      httpjsonClient.close();
+      httpjsonClient.awaitTermination(
+          TestClientInitializer.AWAIT_TERMINATION_SECONDS, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void testGRPC_LROErrorResponse_dropsErrorDetails() throws Exception {
+    EchoClient grpcClient = TestClientInitializer.createGrpcEchoClient();
+    try {
+      PoetryError poetryError =
+          PoetryError.newBuilder().setPoem("Roses are red, violets are blue").build();
+      Status status =
+          Status.newBuilder()
+              .setCode(Code.ALREADY_EXISTS_VALUE)
+              .setMessage("The resource already exists")
+              .addDetails(Any.pack(poetryError))
+              .build();
+      WaitRequest waitRequest =
+          WaitRequest.newBuilder()
+              .setError(status)
+              .build();
+      OperationFuture<WaitResponse, WaitMetadata> operationFuture =
+          grpcClient.waitOperationCallable().futureCall(waitRequest);
+      ExecutionException exception =
+          assertThrows(ExecutionException.class, operationFuture::get);
+      assertThat(exception.getCause()).isInstanceOf(ApiException.class);
+      ApiException apiException = (ApiException) exception.getCause();
+
+      // Current behavior: Error details are dropped during LRO error parsing
+      assertThat(apiException.getErrorDetails()).isNull();
+    } finally {
+      grpcClient.close();
+      grpcClient.awaitTermination(
+          TestClientInitializer.AWAIT_TERMINATION_SECONDS, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void testHttpJson_LROErrorResponse_dropsErrorDetails() throws Exception {
+    EchoClient httpjsonClient = TestClientInitializer.createHttpJsonEchoClient();
+    try {
+      PoetryError poetryError =
+          PoetryError.newBuilder().setPoem("Roses are red, violets are blue").build();
+      Status status =
+          Status.newBuilder()
+              .setCode(Code.ALREADY_EXISTS_VALUE)
+              .setMessage("The resource already exists")
+              .addDetails(Any.pack(poetryError))
+              .build();
+      WaitRequest waitRequest =
+          WaitRequest.newBuilder()
+              .setError(status)
+              .build();
+      OperationFuture<WaitResponse, WaitMetadata> operationFuture =
+          httpjsonClient.waitOperationCallable().futureCall(waitRequest);
+      ExecutionException exception =
+          assertThrows(ExecutionException.class, operationFuture::get);
+      assertThat(exception.getCause()).isInstanceOf(ApiException.class);
+      ApiException apiException = (ApiException) exception.getCause();
+
+      // Current behavior: Error details are dropped during LRO error parsing
+      assertThat(apiException.getErrorDetails()).isNull();
     } finally {
       httpjsonClient.close();
       httpjsonClient.awaitTermination(


### PR DESCRIPTION
This PR adds two new integration test cases to the `gapic-showcase` client targeting LRO error scenarios:
* `testGRPC_LROErrorResponse_dropsErrorDetails`
* `testHttpJson_LROErrorResponse_dropsErrorDetails`

These tests reproduce the defect described in #13369. They configure the showcase LRO `Wait` endpoint to fail with structured error details (a gRPC `Status` with packed `PoetryError` details) and assert that under the current code generator output, the thrown `ApiException.getErrorDetails()` returns `null` for both transports.

These test cases serve as a baseline showcase to demonstrate the issue. Once the planned generator changes are implemented, we will update these test cases to assert that the structured error details are correctly parsed and populated inside `getErrorDetails()`.