### PR TITLE
fix(pubsub): return cancelled messages to the publisher's waiter

### DIFF
--- a/java-pubsub/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/java-pubsub/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -322,6 +322,10 @@ public class Publisher implements PublisherInterface {
       }
 
       batchesToSend = messagesBatch.add(outstandingPublish);
+      // Counted while messagesBatchLock is held, so that "in a MessagesBatch" and "counted" are
+      // one state: the failure callback decrements for what it cancels out of a MessagesBatch.
+      // Lock ordering is messagesBatchLock -> Waiter monitor here and nowhere the reverse.
+      messagesWaiter.incrementPendingCount(1);
       if (!batchesToSend.isEmpty() && messagesBatch.isEmpty()) {
         messagesBatches.remove(orderingKey);
       }
@@ -339,8 +343,6 @@ public class Publisher implements PublisherInterface {
     } finally {
       messagesBatchLock.unlock();
     }
-
-    messagesWaiter.incrementPendingCount(1);
 
     // For messages without ordering keys, it is okay to send batches without holding
     // messagesBatchLock.
@@ -546,9 +548,8 @@ public class Publisher implements PublisherInterface {
 
           @Override
           public void onFailure(Throwable t) {
-            // Messages cancelled below are dropped without ever becoming part of an
-            // OutstandingBatch, so they are owed back to messagesWaiter here; nothing else will
-            // ever decrement for them.
+            // Cancelled below without ever becoming part of an OutstandingBatch, so nothing
+            // else will decrement for them.
             int cancelledMessagesCount = 0;
             try {
               if (outstandingBatch.orderingKey != null && !outstandingBatch.orderingKey.isEmpty()) {

--- a/java-pubsub/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/java-pubsub/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -546,6 +546,10 @@ public class Publisher implements PublisherInterface {
 
           @Override
           public void onFailure(Throwable t) {
+            // Messages cancelled below are dropped without ever becoming part of an
+            // OutstandingBatch, so they are owed back to messagesWaiter here; nothing else will
+            // ever decrement for them.
+            int cancelledMessagesCount = 0;
             try {
               if (outstandingBatch.orderingKey != null && !outstandingBatch.orderingKey.isEmpty()) {
                 messagesBatchLock.lock();
@@ -556,6 +560,7 @@ public class Publisher implements PublisherInterface {
                       outstanding.publishResult.setException(
                           SequentialExecutorService.CallbackExecutor.CANCELLATION_EXCEPTION);
                     }
+                    cancelledMessagesCount = messagesBatch.getMessagesCount();
                     messagesBatches.remove(outstandingBatch.orderingKey);
                   }
                 } finally {
@@ -564,7 +569,8 @@ public class Publisher implements PublisherInterface {
               }
               outstandingBatch.onFailure(t);
             } finally {
-              messagesWaiter.incrementPendingCount(-outstandingBatch.size());
+              messagesWaiter.incrementPendingCount(
+                  -(outstandingBatch.size() + cancelledMessagesCount));
             }
           }
         };

--- a/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -643,6 +643,59 @@ public class PublisherImplTest {
     }
   }
 
+  /**
+   * When a batch for an ordering key fails, its failure callback also cancels the messages still
+   * accumulating in that key's un-flushed batch. Those messages incremented {@code messagesWaiter}
+   * when they were published and never become part of any {@code OutstandingBatch}, so they have to
+   * be returned to the waiter there — otherwise {@code pendingCount} can never reach zero again and
+   * {@code shutdown()}, which waits on it uninterruptibly and without a timeout, never returns.
+   */
+  @Test(timeout = 60_000)
+  public void testShutdownAfterOrderingKeyFailureWithMoreOfThatKeyStillBatched() throws Exception {
+    Publisher publisher =
+        getTestPublisherBuilder()
+            .setBatchingSettings(
+                Publisher.Builder.DEFAULT_BATCHING_SETTINGS.toBuilder()
+                    .setElementCountThreshold(2L)
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
+                    .build())
+            .setEnableMessageOrdering(true)
+            .build();
+
+    // Queued before publishing, so the fake never blocks in publishResponses.take() (see #13394).
+    testPublisherServiceImpl.addPublishError(new StatusException(Status.INVALID_ARGUMENT));
+
+    // m1 and m2 meet the threshold and are popped into an outstanding batch, but the request only
+    // leaves once the fake executor runs — so m3 is published into the un-flushed batch for the
+    // same key first, and is still there when the failure lands.
+    ApiFuture<String> publishFuture1 = sendTestMessageWithOrderingKey(publisher, "m1", "orderA");
+    ApiFuture<String> publishFuture2 = sendTestMessageWithOrderingKey(publisher, "m2", "orderA");
+    ApiFuture<String> publishFuture3 = sendTestMessageWithOrderingKey(publisher, "m3", "orderA");
+    assertFalse(publishFuture3.isDone());
+
+    fakeExecutor.advanceTime(Duration.ZERO);
+
+    try {
+      publishFuture1.get();
+      fail("This should fail.");
+    } catch (ExecutionException e) {
+    }
+    try {
+      publishFuture2.get();
+      fail("This should fail.");
+    } catch (ExecutionException e) {
+    }
+    try {
+      publishFuture3.get();
+      fail("This should fail.");
+    } catch (ExecutionException e) {
+      assertEquals(SequentialExecutorService.CallbackExecutor.CANCELLATION_EXCEPTION, e.getCause());
+    }
+
+    // Hangs here without the accounting fix: m3's increment was never returned.
+    shutdownTestPublisher(publisher);
+  }
+
   private ApiFuture<String> sendTestMessageWithOrderingKey(
       Publisher publisher, String data, String orderingKey) {
     return publisher.publish(

--- a/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/java-pubsub/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -643,13 +643,6 @@ public class PublisherImplTest {
     }
   }
 
-  /**
-   * When a batch for an ordering key fails, its failure callback also cancels the messages still
-   * accumulating in that key's un-flushed batch. Those messages incremented {@code messagesWaiter}
-   * when they were published and never become part of any {@code OutstandingBatch}, so they have to
-   * be returned to the waiter there — otherwise {@code pendingCount} can never reach zero again and
-   * {@code shutdown()}, which waits on it uninterruptibly and without a timeout, never returns.
-   */
   @Test(timeout = 60_000)
   public void testShutdownAfterOrderingKeyFailureWithMoreOfThatKeyStillBatched() throws Exception {
     Publisher publisher =
@@ -665,9 +658,8 @@ public class PublisherImplTest {
     // Queued before publishing, so the fake never blocks in publishResponses.take() (see #13394).
     testPublisherServiceImpl.addPublishError(new StatusException(Status.INVALID_ARGUMENT));
 
-    // m1 and m2 meet the threshold and are popped into an outstanding batch, but the request only
-    // leaves once the fake executor runs — so m3 is published into the un-flushed batch for the
-    // same key first, and is still there when the failure lands.
+    // m1 and m2 meet the threshold, but the request only leaves once the fake executor runs, so
+    // m3 lands in the un-flushed batch for the same key and is still there when the failure does.
     ApiFuture<String> publishFuture1 = sendTestMessageWithOrderingKey(publisher, "m1", "orderA");
     ApiFuture<String> publishFuture2 = sendTestMessageWithOrderingKey(publisher, "m2", "orderA");
     ApiFuture<String> publishFuture3 = sendTestMessageWithOrderingKey(publisher, "m3", "orderA");


### PR DESCRIPTION
Fixes #14001.

## The defect

`Publisher.publish` counts every accepted message into `messagesWaiter`. Both batch callbacks
decrement by the size of the batch that was *in flight*. But before that `finally`, the failure
callback also cancels the messages still accumulating in the un-flushed `MessagesBatch` for the
failed ordering key, and drops the batch:

```java
MessagesBatch messagesBatch = messagesBatches.get(outstandingBatch.orderingKey);
if (messagesBatch != null) {
  for (OutstandingPublish outstanding : messagesBatch.messages) {
    outstanding.publishResult.setException(
        SequentialExecutorService.CallbackExecutor.CANCELLATION_EXCEPTION);
  }
  messagesBatches.remove(outstandingBatch.orderingKey);
}
```

Each of those incremented the waiter when it was published, and none is part of any
`OutstandingBatch`, so nothing ever decrements for them. `pendingCount` stays at least equal to the
number cancelled, for the life of the publisher.

`Waiter.waitComplete()` ignores interruption and wakes only on an exact zero, and
`Publisher.shutdown()` calls it directly — so the calling thread parks permanently.
`awaitTermination(timeout, unit)` is the API that takes a bound, but it is documented to be called
*after* `shutdown()`, so it is never reached.

## The change

Count what the failure callback cancels and return it to the waiter alongside the batch's own size.
`MessagesBatch.getMessagesCount()` already exists, so the change is local to that callback.

## Verification

`PublisherImplTest.testShutdownAfterOrderingKeyFailureWithMoreOfThatKeyStillBatched` is new and
discriminating — measured both ways, not assumed:

- **without** the production change: times out, with the stack ending in
  `shutdownTestPublisher → Publisher.shutdown → Object.wait`, which is `messagesWaiter.waitComplete()`;
- **with** it: passes in 0.3 s.

The whole of `PublisherImplTest` passes (33 run, 2 pre-existing `@Ignore`s), and
`fmt-maven-plugin:check` reports no non-complying files.

The test queues the error before publishing rather than after, so `FakePublisherServiceImpl.publish`
never blocks in `publishResponses.take()` — the hazard behind #13394. It needs no response delay:
with the fake executor, the request only leaves once `advanceTime` runs, so the third message is
deterministically in the un-flushed batch when the failure lands.

## One thing worth a maintainer's opinion

`publish()` increments the waiter *after* releasing `messagesBatchLock`, so a message can be in a
`MessagesBatch` before it is counted. With this patch that can drive `pendingCount` transiently
negative — self-correcting, since the pending `+1` lands and the counter reaches zero, but it means
`waitComplete()` could return marginally early for a message that was just cancelled anyway.

Moving the increment inside the lock would make "batched" and "counted" one atomic state. The lock
order is already `messagesBatchLock` → `Waiter` monitor everywhere, so there is no inversion. I have
deliberately **not** done that here — it widens the change beyond the accounting bug, and the call is
yours.
