### PR TITLE
ci: add CI check for google-java-format version in sync

### DIFF
--- a/.github/workflows/formatter-version-check.yaml
+++ b/.github/workflows/formatter-version-check.yaml
@@ -18,8 +18,6 @@ permissions:
 name: Librarian - Formatter Version Check
 
 on:
-  schedule:
-    - cron: '30 3 * * *' # Run daily at 3:30 AM UTC
   workflow_dispatch: # Allow manual trigger
   pull_request:
 
@@ -43,11 +41,8 @@ jobs:
 
   check-formatter-version:
     needs: filter
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.filter.outputs.should_run == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.filter.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -86,19 +81,10 @@ jobs:
 
           if [ "${POM_VERSION}" != "${LIBRARIAN_VERSION}" ]; then
             echo "Mismatch: librarian.yaml has version '${LIBRARIAN_VERSION}', but java-shared-config/java-shared-config/pom.xml has version '${POM_VERSION}'"
-            exit 2
+            exit 1
           fi
 
           echo "Formatter versions are in sync!"
         env:
           POM_VERSION: ${{ steps.extract_pom_version.outputs.version }}
           LIBRARIAN_VERSION: ${{ steps.extract_librarian_version.outputs.version }}
-      - name: Create issue on failure
-        if: ${{ failure() && github.event_name == 'schedule' }}
-        uses: googleapis/librarian/.github/actions/create-issue-on-failure@35997441eafc2b02716804f9baba1e3f04f8a44f # v0.31.1
-        with:
-          title: "Formatter Version Mismatch: librarian.yaml and java-shared-config pom.xml out of sync"
-          body: |
-            The google-java-format version in `java-shared-config/java-shared-config/pom.xml` and `librarian.yaml` do not match. Please update them to match.
-
-            Please check the logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/formatter-version-check.yaml
+++ b/.github/workflows/formatter-version-check.yaml
@@ -32,10 +32,10 @@ jobs:
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
@@ -50,7 +50,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || needs.filter.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
       - name: Extract formatter version from pom.xml

--- a/.github/workflows/formatter-version-check.yaml
+++ b/.github/workflows/formatter-version-check.yaml
@@ -21,8 +21,13 @@ on:
   workflow_dispatch: # Allow manual trigger
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   filter:
+    name: Filter changed files
     runs-on: ubuntu-latest
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
@@ -40,6 +45,7 @@ jobs:
               - '.github/workflows/formatter-version-check.yaml'
 
   check-formatter-version:
+    name: Check Formatter Version
     needs: filter
     if: ${{ github.event_name == 'workflow_dispatch' || needs.filter.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
@@ -47,15 +53,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
-        with:
-          java-version: "17"
-          distribution: "temurin"
       - name: Extract formatter version from pom.xml
         id: extract_pom_version
         shell: bash
         run: |
-          version=$(mvn help:evaluate -Dexpression=google-java-format.version -q -DforceStdout -f java-shared-config/java-shared-config/pom.xml | tail -n 1 | tr -d '"')
+          version=$(awk -F'[<>]' '/google-java-format.version/{print $3; exit}' java-shared-config/java-shared-config/pom.xml | tr -d '"')
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Extract formatter version from librarian.yaml
         id: extract_librarian_version

--- a/.github/workflows/formatter-version-check.yaml
+++ b/.github/workflows/formatter-version-check.yaml
@@ -1,0 +1,103 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+permissions:
+  contents: read
+
+name: Librarian - Formatter Version Check
+
+on:
+  schedule:
+    - cron: '30 3 * * *' # Run daily at 3:30 AM UTC
+  workflow_dispatch: # Allow manual trigger
+  pull_request:
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        id: filter
+        with:
+          filters: |
+            should_run:
+              - 'librarian.yaml'
+              - 'java-shared-config/java-shared-config/pom.xml'
+              - '.github/workflows/formatter-version-check.yaml'
+
+  check-formatter-version:
+    needs: filter
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.filter.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      - name: Extract formatter version from pom.xml
+        id: extract_pom_version
+        shell: bash
+        run: |
+          version=$(mvn help:evaluate -Dexpression=google-java-format.version -q -DforceStdout -f java-shared-config/java-shared-config/pom.xml | tail -n 1 | tr -d '"')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Extract formatter version from librarian.yaml
+        id: extract_librarian_version
+        shell: bash
+        run: |
+          version=$(yq '.tools.maven[] | select(.name == "google-java-format") | .version' librarian.yaml | tr -d '"')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Verify formatter versions match
+        shell: bash
+        run: |
+          echo "Formatter version in pom.xml: ${POM_VERSION}"
+          echo "Formatter version in librarian.yaml: ${LIBRARIAN_VERSION}"
+
+          if [ -z "${POM_VERSION}" ]; then
+            echo "Error: Could not extract google-java-format.version from java-shared-config/java-shared-config/pom.xml"
+            exit 1
+          fi
+
+          if [ -z "${LIBRARIAN_VERSION}" ]; then
+            echo "Error: Could not extract google-java-format version from librarian.yaml"
+            exit 1
+          fi
+
+          if [ "${POM_VERSION}" != "${LIBRARIAN_VERSION}" ]; then
+            echo "Mismatch: librarian.yaml has version '${LIBRARIAN_VERSION}', but java-shared-config/java-shared-config/pom.xml has version '${POM_VERSION}'"
+            exit 2
+          fi
+
+          echo "Formatter versions are in sync!"
+        env:
+          POM_VERSION: ${{ steps.extract_pom_version.outputs.version }}
+          LIBRARIAN_VERSION: ${{ steps.extract_librarian_version.outputs.version }}
+      - name: Create issue on failure
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: googleapis/librarian/.github/actions/create-issue-on-failure@35997441eafc2b02716804f9baba1e3f04f8a44f # v0.31.1
+        with:
+          title: "Formatter Version Mismatch: librarian.yaml and java-shared-config pom.xml out of sync"
+          body: |
+            The google-java-format version in `java-shared-config/java-shared-config/pom.xml` and `librarian.yaml` do not match. Please update them to match.
+
+            Please check the logs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/formatter-version-check.yaml
+++ b/.github/workflows/formatter-version-check.yaml
@@ -46,6 +46,7 @@ jobs:
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || needs.filter.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -102,7 +102,7 @@ jobs:
         else
           echo "has_changes=true" >> $GITHUB_OUTPUT
         fi
-    - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+    - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       if: steps.detect_librarian.outputs.has_changes == 'true'
       with:
         java-version: "17"

--- a/.github/workflows/update_librarian_googleapis.yaml
+++ b/.github/workflows/update_librarian_googleapis.yaml
@@ -40,11 +40,13 @@ jobs:
     - name: Close Existing PR and Branch
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+        EVENT_NAME: ${{ github.event_name }}
+        REPOSITORY: ${{ github.repository }}
       run: |
         set -x
         current_branch="update-librarian-googleapis-main"
         
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
+        if [ "${EVENT_NAME}" = "pull_request" ]; then
           echo "PR Test: Skipping cleanup."
         else
           # Try to find an open pull request associated with the branch
@@ -57,9 +59,9 @@ jobs:
           
           # Delete the remote branch if it still exists (e.g. if no PR was open)
           echo "Checking if remote branch ${current_branch} exists..."
-          if gh api "repos/${{ github.repository }}/git/refs/heads/${current_branch}" --silent 2>/dev/null; then
+          if gh api "repos/${REPOSITORY}/git/refs/heads/${current_branch}" --silent 2>/dev/null; then
             echo "Deleting remote branch ${current_branch}..."
-            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${current_branch}" || {
+            gh api -X DELETE "repos/${REPOSITORY}/git/refs/heads/${current_branch}" || {
               echo "Error: Failed to delete remote branch ${current_branch}."
               exit 1
             }
@@ -131,6 +133,8 @@ jobs:
       if: steps.detect_librarian.outputs.has_changes == 'true'
       env:
         GH_TOKEN: ${{ secrets.CLOUD_JAVA_BOT_GITHUB_TOKEN }}
+        EVENT_NAME: ${{ github.event_name }}
+        REPOSITORY: ${{ github.repository }}
         PR_TITLE: "chore: update googleapis commitish to ${{ steps.commit.outputs.short_commit }}"
         PR_BODY: |
           Updated googleapis commitish in librarian.yaml to https://github.com/googleapis/googleapis/commit/${{ steps.commit.outputs.new_commit }}
@@ -139,7 +143,7 @@ jobs:
       run: |
         set -x
         
-        if [ "${{ github.event_name }}" = "pull_request" ]; then
+        if [ "${EVENT_NAME}" = "pull_request" ]; then
           echo "=== PR Test: DRY RUN MODE ACTIVE ==="
           echo "Would have checked out branch: update-librarian-googleapis-main"
           echo "Would have committed configs with title: $PR_TITLE"
@@ -174,7 +178,7 @@ jobs:
         fi
         
         # Push to remote (force push to overwrite any stale branch on remote)
-        git remote add remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${{ github.repository }}.git" || git remote set-url remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${{ github.repository }}.git"
+        git remote add remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${REPOSITORY}.git" || git remote set-url remote_repo https://cloud-java-bot:"${GH_TOKEN}@github.com/${REPOSITORY}.git"
         git fetch -q remote_repo
         git push -f remote_repo "${current_branch}"
         


### PR DESCRIPTION
Add a check that version specified in pom.xml and librarian.yaml are in sync. 
Sample action log: https://github.com/googleapis/google-cloud-java/actions/runs/31084351700/job/92560353612?pr=14007

Fixes https://github.com/googleapis/librarian/issues/7148