### PR TITLE
feat(bigtable): expose the row key, mutation count and serialized size on RowMutationEntry

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Mutation.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Mutation.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.data.v2.models;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
+import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.Mutation.AddToCell;
 import com.google.bigtable.v2.Mutation.DeleteFromColumn;
 import com.google.bigtable.v2.Mutation.DeleteFromFamily;
@@ -28,6 +29,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -60,6 +62,11 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
   private int numMutations;
   private long byteSize;
 
+  private transient int mutationCount;
+
+  /** Tag, length prefix and body of each mutation. Recomputed by readObject. */
+  private transient long mutationsSerializedSize;
+
   /** Creates new instance of Mutation object. */
   public static Mutation create() {
     return new Mutation(false);
@@ -86,6 +93,7 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
   public static Mutation fromProtoUnsafe(List<com.google.bigtable.v2.Mutation> protos) {
     Mutation mutation = new Mutation(true);
     mutation.mutations.addAll(protos);
+    mutation.countAllTowardsSerializedSize(protos);
     return mutation;
   }
 
@@ -99,6 +107,7 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
   public static Mutation fromProtoUnsafe(Iterable<com.google.bigtable.v2.Mutation> protos) {
     Mutation mutation = new Mutation(true);
     mutation.mutations.addAll(protos);
+    mutation.countAllTowardsSerializedSize(protos);
     return mutation;
   }
 
@@ -115,6 +124,7 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
   static Mutation fromProto(List<com.google.bigtable.v2.Mutation> protos) {
     Mutation mutation = new Mutation(false);
     mutation.mutations.addAll(protos);
+    mutation.countAllTowardsSerializedSize(protos);
     return mutation;
   }
 
@@ -129,6 +139,7 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
     ImmutableList<com.google.bigtable.v2.Mutation> deserialized =
         (ImmutableList<com.google.bigtable.v2.Mutation>) input.readObject();
     this.mutations = ImmutableList.<com.google.bigtable.v2.Mutation>builder().addAll(deserialized);
+    countAllTowardsSerializedSize(deserialized);
   }
 
   private void writeObject(ObjectOutputStream output) throws IOException {
@@ -335,8 +346,31 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
 
     numMutations++;
     byteSize += mutation.getSerializedSize();
+    countTowardsSerializedSize(mutation);
 
     mutations.add(mutation);
+  }
+
+  private void countTowardsSerializedSize(com.google.bigtable.v2.Mutation mutation) {
+    mutationCount++;
+    // Every request proto numbers this field below 16, so the tag is one byte in all of them.
+    mutationsSerializedSize +=
+        CodedOutputStream.computeMessageSize(
+            MutateRowsRequest.Entry.MUTATIONS_FIELD_NUMBER, mutation);
+  }
+
+  private void countAllTowardsSerializedSize(Iterable<com.google.bigtable.v2.Mutation> protos) {
+    for (com.google.bigtable.v2.Mutation proto : protos) {
+      countTowardsSerializedSize(proto);
+    }
+  }
+
+  int getMutationCount() {
+    return mutationCount;
+  }
+
+  long getMutationsSerializedSize() {
+    return mutationsSerializedSize;
   }
 
   private static ByteString wrapByteString(String str) {

--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntry.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntry.java
@@ -20,6 +20,7 @@ import com.google.api.core.InternalApi;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedOutputStream;
 import java.io.Serializable;
 import javax.annotation.Nonnull;
 
@@ -198,6 +199,26 @@ public class RowMutationEntry implements MutationApi<RowMutationEntry>, Serializ
       @Nonnull Value input) {
     mutation.mergeToCell(familyName, qualifier, timestamp, input);
     return this;
+  }
+
+  /** Returns the row key these mutations apply to. */
+  public ByteString getRowKey() {
+    return key;
+  }
+
+  /** Returns the number of mutations accumulated in this entry. */
+  public int getMutationCount() {
+    return mutation.getMutationCount();
+  }
+
+  /** Returns the serialized size of {@link #toProto()}, without building it. */
+  public long getSerializedSize() {
+    long size = mutation.getMutationsSerializedSize();
+    if (!key.isEmpty()) {
+      // An empty row key is not written at all, so it contributes no tag or length prefix.
+      size += CodedOutputStream.computeBytesSize(MutateRowsRequest.Entry.ROW_KEY_FIELD_NUMBER, key);
+    }
+    return size;
   }
 
   @InternalApi

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntryTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/RowMutationEntryTest.java
@@ -165,4 +165,114 @@ public class RowMutationEntryTest {
                 .setValue(ByteString.copyFrom(Longs.toByteArray(100_000L)))
                 .build());
   }
+
+  @Test
+  public void getRowKeyTest() {
+    ByteString rowKey = ByteString.copyFromUtf8("row-key");
+
+    assertThat(RowMutationEntry.create(rowKey).getRowKey()).isEqualTo(rowKey);
+    assertThat(RowMutationEntry.create("row-key").getRowKey()).isEqualTo(rowKey);
+    assertThat(RowMutationEntry.create(ByteString.EMPTY).getRowKey()).isEqualTo(ByteString.EMPTY);
+  }
+
+  @Test
+  public void getMutationCountTest() {
+    assertThat(RowMutationEntry.create("row-key").getMutationCount()).isEqualTo(0);
+    assertThat(
+            RowMutationEntry.create("row-key")
+                .setCell("fake-family", "q1", 10_000L, "v1")
+                .setCell("fake-family", "q2", 10_000L, "v2")
+                .deleteFamily("fake-family")
+                .deleteRow()
+                .getMutationCount())
+        .isEqualTo(4);
+  }
+
+  @Test
+  public void getSerializedSizeMatchesProtoTest() {
+    assertSizeMatchesProto(RowMutationEntry.create("row-key"));
+    assertSizeMatchesProto(RowMutationEntry.create(ByteString.EMPTY));
+    assertSizeMatchesProto(
+        RowMutationEntry.create("row-key").setCell("fake-family", "q", 10_000L, "v"));
+    assertSizeMatchesProto(
+        RowMutationEntry.create("row-key").setCell("fake-family", "q", 10_000L, repeat("v", 200)));
+    assertSizeMatchesProto(
+        RowMutationEntry.create(ByteString.copyFromUtf8(repeat("k", 5_000)))
+            .setCell("fake-family", "q", 10_000L, repeat("v", 70_000)));
+    assertSizeMatchesProto(
+        RowMutationEntry.create("row-key")
+            .setCell("fake-family", "q1", 10_000L, "v1")
+            .setCell("fake-family", "q2", 10_000L, 100_000L)
+            .deleteCells("fake-family", "q1")
+            .deleteFamily("fake-family")
+            .deleteRow());
+  }
+
+  @Test
+  public void getSerializedSizeMatchesProtoForManyMutationsTest() {
+    RowMutationEntry underTest = RowMutationEntry.create("row-key");
+    for (int i = 0; i < 300; i++) {
+      underTest.setCell("fake-family", "q" + i, 10_000L, "value-" + i);
+    }
+
+    assertThat(underTest.getMutationCount()).isEqualTo(300);
+    assertSizeMatchesProto(underTest);
+  }
+
+  @Test
+  public void getSerializedSizeFromMutationUnsafeTest() {
+    com.google.cloud.bigtable.data.v2.models.Mutation mutation =
+        com.google.cloud.bigtable.data.v2.models.Mutation.fromProtoUnsafe(
+            ImmutableList.of(
+                Mutation.newBuilder()
+                    .setSetCell(
+                        Mutation.SetCell.newBuilder()
+                            .setFamilyName("fake-family")
+                            .setColumnQualifier(ByteString.copyFromUtf8("q"))
+                            .setTimestampMicros(10_000L)
+                            .setValue(ByteString.copyFromUtf8(repeat("v", 500))))
+                    .build(),
+                Mutation.newBuilder()
+                    .setDeleteFromRow(Mutation.DeleteFromRow.getDefaultInstance())
+                    .build()));
+    RowMutationEntry underTest =
+        RowMutationEntry.createFromMutationUnsafe(ByteString.copyFromUtf8("row-key"), mutation);
+
+    assertThat(underTest.getMutationCount()).isEqualTo(2);
+    assertSizeMatchesProto(underTest);
+  }
+
+  @Test
+  public void getSerializedSizeSurvivesSerializationTest()
+      throws IOException, ClassNotFoundException {
+    RowMutationEntry underTest =
+        RowMutationEntry.create("row-key")
+            .setCell("fake-family", "q", 10_000L, repeat("v", 500))
+            .deleteFamily("fake-family");
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(bos);
+    oos.writeObject(underTest);
+    oos.close();
+    ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()));
+    RowMutationEntry actual = (RowMutationEntry) ois.readObject();
+
+    assertThat(actual.getRowKey()).isEqualTo(underTest.getRowKey());
+    assertThat(actual.getMutationCount()).isEqualTo(underTest.getMutationCount());
+    assertThat(actual.getSerializedSize()).isEqualTo(underTest.getSerializedSize());
+    assertSizeMatchesProto(actual);
+  }
+
+  private static void assertSizeMatchesProto(RowMutationEntry entry) {
+    assertThat(entry.getSerializedSize()).isEqualTo(entry.toProto().getSerializedSize());
+    assertThat(entry.getMutationCount()).isEqualTo(entry.toProto().getMutationsCount());
+  }
+
+  private static String repeat(String unit, int times) {
+    StringBuilder sb = new StringBuilder(unit.length() * times);
+    for (int i = 0; i < times; i++) {
+      sb.append(unit);
+    }
+    return sb.toString();
+  }
 }


### PR DESCRIPTION
Fixes #14018.

## The gap

`RowMutationEntry` exposes no accessor for its serialized size, its row key or its mutation count,
so a caller that needs any of them must call the `@InternalApi` `toProto()` and build a whole
`MutateRowsRequest.Entry` to read one number. Bounding in-flight memory by bytes is the motivating
case: a single row mutation may be megabytes, so bounding by entry count bounds nothing useful.

## The API

```java
public ByteString getRowKey();
public int getMutationCount();
public long getSerializedSize();   // == toProto().getSerializedSize(), without building it
```

## How the size is maintained

`Mutation.byteSize` could not simply be exposed: it sums each child mutation's own serialized size
and omits both the row-key field and the per-mutation tag and length prefixes. `Mutation` now
accumulates the *framed* size alongside it, in a new `mutationsSerializedSize`, and
`RowMutationEntry.getSerializedSize()` adds the row-key field to it. Reads are O(1) and allocate
nothing.

Three details, each of which the tests pin:

- **The empty row key.** Proto3 implicit presence means an empty `bytes` field is not written at
  all, so it contributes no tag and no length prefix either. I had this wrong first; the test that
  compares against `toProto().getSerializedSize()` is what caught it.
- **The factories that bypass `addMutation`.** `fromProtoUnsafe(List)`,
  `fromProtoUnsafe(Iterable)` and `fromProto(List)` add their protos to the list directly, so the
  new counter is accumulated there too. I have deliberately **not** touched `numMutations` or
  `byteSize` on those paths, even though they stay at zero there today — that would change when the
  `MAX_MUTATIONS` and `MAX_BYTE_SIZE` preconditions fire, which is a separate behavioural decision
  for you to make rather than something to slip into this PR.
- **Serialization.** The new fields are `transient` and recomputed in `readObject`, so an instance
  restored from a form written by an older version is correct rather than reporting zero. No
  `serialVersionUID` change and no wire-format change.

## Verification

`RowMutationEntryTest` gains six tests; the models package passes in full (228 tests). The size
tests are discriminating rather than characterizing — each asserts
`getSerializedSize() == toProto().getSerializedSize()` across the shapes that change the framing:
no mutations, an empty row key, a value long enough to need a multi-byte length prefix, a 5 KB row
key, all five mutation kinds, 300 mutations, the `createFromMutationUnsafe` path, and a
round-trip through Java serialization.

Verified by mutation, each mutant killed by the test that exists for it:

| Mutation | Result |
|---|---|
| drop the empty-row-key guard (always add the row-key framing) | `getSerializedSizeMatchesProtoTest` fails |
| `fromProtoUnsafe` no longer accumulates | `getSerializedSizeFromMutationUnsafeTest` fails |
| `readObject` no longer recomputes | `getSerializedSizeSurvivesSerializationTest` fails |

All restored afterwards. `google-java-format` reports the changed files compliant.

## What this does not do

It does not change `toProto()`, the wire format, or any existing behaviour — the new accessors are
additive. It also does not fix the client's own duplicate proto construction in
`MutateRowsBatchingDescriptor.createResource()`, which is a separate PR needing no API change.
