### PR TITLE
fix(bigtable): count mutations wrapped from protos towards the row limits

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Mutation.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/models/Mutation.java
@@ -87,7 +87,7 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
   @BetaApi
   public static Mutation fromProtoUnsafe(List<com.google.bigtable.v2.Mutation> protos) {
     Mutation mutation = new Mutation(true);
-    mutation.mutations.addAll(protos);
+    mutation.addAllFromProto(protos);
     return mutation;
   }
 
@@ -100,7 +100,7 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
   @BetaApi
   public static Mutation fromProtoUnsafe(Iterable<com.google.bigtable.v2.Mutation> protos) {
     Mutation mutation = new Mutation(true);
-    mutation.mutations.addAll(protos);
+    mutation.addAllFromProto(protos);
     return mutation;
   }
 
@@ -116,7 +116,7 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
    */
   static Mutation fromProto(List<com.google.bigtable.v2.Mutation> protos) {
     Mutation mutation = new Mutation(false);
-    mutation.mutations.addAll(protos);
+    mutation.addAllFromProto(protos);
     return mutation;
   }
 
@@ -346,10 +346,22 @@ public final class Mutation implements MutationApi<Mutation>, Serializable {
         byteSize + mutation.getSerializedSize() <= MAX_BYTE_SIZE,
         "Byte size of mutations is too large");
 
-    numMutations++;
-    byteSize += mutation.getSerializedSize();
+    countTowardsLimits(mutation);
 
     mutations.add(mutation);
+  }
+
+  private void countTowardsLimits(com.google.bigtable.v2.Mutation mutation) {
+    numMutations++;
+    byteSize += mutation.getSerializedSize();
+  }
+
+  private void addAllFromProto(Iterable<com.google.bigtable.v2.Mutation> protos) {
+    // One traversal: protos may be a non-repeatable Iterable.
+    for (com.google.bigtable.v2.Mutation proto : protos) {
+      mutations.add(proto);
+      countTowardsLimits(proto);
+    }
   }
 
   private static ByteString wrapByteString(String str) {

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/MutationTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/models/MutationTest.java
@@ -24,6 +24,7 @@ import com.google.bigtable.v2.Mutation.DeleteFromRow;
 import com.google.bigtable.v2.Mutation.MergeToCell;
 import com.google.bigtable.v2.Mutation.TimestampOrigin;
 import com.google.cloud.bigtable.data.v2.models.Range.TimestampRange;
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import java.io.ByteArrayInputStream;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.time.Instant;
+import java.util.Iterator;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -268,6 +270,105 @@ public class MutationTest {
     }
 
     assertThat(actualError).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void tooManyMutationsCountsWrappedProtosTest() {
+    Mutation mutation =
+        Mutation.fromProtoUnsafe(
+            ImmutableList.of(
+                com.google.bigtable.v2.Mutation.newBuilder()
+                    .setDeleteFromRow(com.google.bigtable.v2.Mutation.DeleteFromRow.newBuilder())
+                    .build()));
+
+    for (int i = 0; i < Mutation.MAX_MUTATIONS - 1; i++) {
+      mutation.setCell("f", "", "");
+    }
+
+    Exception actualError = null;
+    try {
+      mutation.setCell("f", "", "");
+    } catch (Exception e) {
+      actualError = e;
+    }
+
+    assertThat(actualError).isInstanceOf(IllegalStateException.class);
+    assertThat(mutation.getMutations()).hasSize(Mutation.MAX_MUTATIONS);
+  }
+
+  @Test
+  public void tooLargeRequestCountsWrappedProtosTest() {
+    Mutation mutation =
+        Mutation.fromProtoUnsafe(
+            ImmutableList.of(
+                com.google.bigtable.v2.Mutation.newBuilder()
+                    .setSetCell(
+                        com.google.bigtable.v2.Mutation.SetCell.newBuilder()
+                            .setFamilyName("f")
+                            .setValue(ByteString.copyFrom(new byte[Mutation.MAX_BYTE_SIZE / 2])))
+                    .build(),
+                com.google.bigtable.v2.Mutation.newBuilder()
+                    .setSetCell(
+                        com.google.bigtable.v2.Mutation.SetCell.newBuilder()
+                            .setFamilyName("f")
+                            .setValue(ByteString.copyFrom(new byte[Mutation.MAX_BYTE_SIZE / 2])))
+                    .build()));
+
+    Exception actualError = null;
+    try {
+      mutation.setCell("f", "", "");
+    } catch (Exception e) {
+      actualError = e;
+    }
+
+    assertThat(actualError).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void fromProtoUnsafeTraversesTheIterableOnceTest() {
+    Iterable<com.google.bigtable.v2.Mutation> oneShot =
+        oneShot(
+            com.google.bigtable.v2.Mutation.newBuilder()
+                .setDeleteFromRow(com.google.bigtable.v2.Mutation.DeleteFromRow.newBuilder())
+                .build(),
+            com.google.bigtable.v2.Mutation.newBuilder()
+                .setDeleteFromRow(com.google.bigtable.v2.Mutation.DeleteFromRow.newBuilder())
+                .build());
+
+    Mutation mutation = Mutation.fromProtoUnsafe(oneShot);
+
+    assertThat(mutation.getMutations()).hasSize(2);
+
+    for (int i = 0; i < Mutation.MAX_MUTATIONS - 2; i++) {
+      mutation.setCell("f", "", "");
+    }
+
+    Exception actualError = null;
+    try {
+      mutation.setCell("f", "", "");
+    } catch (Exception e) {
+      actualError = e;
+    }
+
+    assertThat(actualError).isInstanceOf(IllegalStateException.class);
+  }
+
+  /** An Iterable that refuses a second traversal. */
+  private static Iterable<com.google.bigtable.v2.Mutation> oneShot(
+      com.google.bigtable.v2.Mutation... protos) {
+    List<com.google.bigtable.v2.Mutation> source = ImmutableList.copyOf(protos);
+    return new Iterable<com.google.bigtable.v2.Mutation>() {
+      private boolean consumed;
+
+      @Override
+      public Iterator<com.google.bigtable.v2.Mutation> iterator() {
+        if (consumed) {
+          throw new IllegalStateException("Iterable traversed more than once");
+        }
+        consumed = true;
+        return source.iterator();
+      }
+    };
   }
 
   @Test


### PR DESCRIPTION
Fixes #14020.

## The defect

`Mutation.MAX_MUTATIONS` and `Mutation.MAX_BYTE_SIZE` are enforced in `addMutation`, against
counters only `addMutation` maintains. Three factories — `fromProtoUnsafe(List)`,
`fromProtoUnsafe(Iterable)` and `fromProto(List)` — add to the mutation list directly and leave
both counters at zero, so mutations wrapped from existing protos count towards neither limit.

Measured on 2.80.0, five mutations wrapped from protos and then `MAX_MUTATIONS` more added:

```text
MAX_MUTATIONS=100000
seeded=5 addedViaSetCell=100000 threw=null
actual mutations in list = 100005
```

The two limits then diverge, and only one of them is really lost:

- **Mutation count is backstopped** by `RowMutationEntry.toProto()` and `BulkMutation.add`, which
  re-check `getMutations().size()`. It surfaces — but late, from a different place, as an
  `IllegalArgumentException` at send time rather than an `IllegalStateException` from the `setCell`
  that crossed the line.
- **Byte size is not backstopped anywhere.** `MAX_BYTE_SIZE` appears only in `addMutation`, so a
  `Mutation` seeded from protos can exceed 200 MB with nothing client-side objecting.

## The change

Count wrapped protos in the three factories, so the counters describe the whole row rather than the
part that happened to arrive through `addMutation`.

Deliberately **not** a `checkState` in the factories themselves: that would make wrapping an
already-over-limit proto throw where it currently does not, which is a larger behaviour change than
restoring the guard requires. Counting never throws by itself; `addMutation` remains the only
place that checks.

## Behaviour change

This is the point worth a reviewer's attention rather than the code. A caller that wraps protos and
then adds more mutations will now get `IllegalStateException` from the `setCell` that crosses a
limit, where today it fails later (count) or not at all (bytes). I believe that is what the limits
are for — failing fast client-side instead of sending a request that cannot succeed — but it is a
visible change and I have no objection to it waiting for a release note or a major.

Nothing else moves: no new fields, no serialization change, no API change, and `readObject` needs
no adjustment because `numMutations` and `byteSize` are not transient.

## Verification

The full models package passes (224 tests). The two new tests are **discriminating, not
characterizing** — verified by removing the production change and re-running, which is the check I
care about here since the fix is a behaviour change and a test that passed either way would prove
nothing:

| State | Result |
|---|---|
| with the fix | 224 pass |
| production change reverted, tests kept | `tooManyMutationsCountsWrappedProtosTest` and `tooLargeRequestCountsWrappedProtosTest` fail (2 failures) |

`tooLargeRequestCountsWrappedProtosTest` allocates two 100 MB values to cross the 200 MB limit,
mirroring the footprint of the existing `tooLargeRequest`; it runs in the same class and needed no
heap beyond what that test already implies. `google-java-format` reports both changed files
compliant.

## Related

Independent of the other two findings in this area — the duplicate proto construction in
`MutateRowsBatchingDescriptor.createResource()`, and the missing serialized-size accessor on
`RowMutationEntry`. This PR touches the same three factories as the latter, so if both are taken
the second to merge needs a trivial rebase.
