### PR TITLE
fix: avoid NullPointerException in BigQuery.create() when the duplicated job cannot be re-fetched

### DIFF
--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -608,18 +608,20 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
             // If the Job ALREADY EXISTS, retrieve it.
             Job job = this.getJob(jobInfo.getJobId(), JobOption.fields(JobField.STATISTICS));
 
-            long jobCreationTime = job.getStatistics().getCreationTime();
-            long jobMinStaleTime = System.currentTimeMillis();
-            long jobMaxStaleTime =
-                java.time.Instant.ofEpochMilli(jobMinStaleTime)
-                    .minus(1, java.time.temporal.ChronoUnit.DAYS)
-                    .toEpochMilli();
+            if (job != null) {
+              long jobCreationTime = job.getStatistics().getCreationTime();
+              long jobMinStaleTime = System.currentTimeMillis();
+              long jobMaxStaleTime =
+                  java.time.Instant.ofEpochMilli(jobMinStaleTime)
+                      .minus(1, java.time.temporal.ChronoUnit.DAYS)
+                      .toEpochMilli();
 
-            // Only return the job if it has been created in the past 24 hours.
-            // This is assuming any job older than 24 hours is a valid duplicate JobID
-            // and not a false positive like b/290419183
-            if (jobCreationTime >= jobMaxStaleTime && jobCreationTime <= jobMinStaleTime) {
-              return job;
+              // Only return the job if it has been created in the past 24 hours.
+              // This is assuming any job older than 24 hours is a valid duplicate JobID
+              // and not a false positive like b/290419183
+              if (jobCreationTime >= jobMaxStaleTime && jobCreationTime <= jobMinStaleTime) {
+                return job;
+              }
             }
           }
         }

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -2145,6 +2145,37 @@ public class BigQueryImplTest {
   }
 
   @Test
+  void testCreateJobTryGetNotRandomJobNotFound() throws IOException {
+    Map<BigQueryRpc.Option, ?> withStatisticOption = optionMap(JobOption.fields(STATISTICS));
+    final String id = "testCreateJobTryGet-id";
+    String query = "SELECT * in FOO";
+
+    when(bigqueryRpcMock.createSkipExceptionTranslation(
+            jobCapture.capture(), eq(EMPTY_RPC_OPTIONS)))
+        .thenThrow(
+            new BigQueryException(
+                409,
+                "already exists, for some reason",
+                new RuntimeException("Already Exists: Job")));
+    when(bigqueryRpcMock.getJobSkipExceptionTranslation(
+            any(String.class), eq(id), eq((String) null), eq(withStatisticOption)))
+        .thenThrow(new BigQueryException(404, "Job not found"));
+
+    bigquery = options.getService();
+    BigQueryException exception =
+        Assertions.assertThrows(
+            BigQueryException.class,
+            () ->
+                ((BigQueryImpl) bigquery)
+                    .create(JobInfo.of(JobId.of(id), QueryJobConfiguration.of(query))));
+    assertEquals(409, exception.getCode());
+    assertEquals("already exists, for some reason", exception.getMessage());
+    verify(bigqueryRpcMock)
+        .getJobSkipExceptionTranslation(
+            any(String.class), eq(id), eq((String) null), eq(withStatisticOption));
+  }
+
+  @Test
   void testCreateJobWithProjectId() throws IOException {
     JobInfo jobInfo =
         JobInfo.newBuilder(QUERY_JOB_CONFIGURATION.setProjectId(OTHER_PROJECT))


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #14025 ☕️

`BigQuery.create(JobInfo)`'s duplicate-job-id handler dereferences the `getJob(...)` re-fetch
unconditionally, but `getJob` returns null when the job cannot be seen — most commonly a job
outside the US multi-region looked up through a `JobId` that carries no location (the `jobs.get`
of a location-less `JobId` resolves against the US multi-region only). googleapis/java-bigquery#3035
narrowed the re-fetch to `fields(STATISTICS)` but did not guard the null return, and its test
covers the found-job path only, so googleapis/java-bigquery#3034's NPE still reproduces.

This guards the re-fetch and falls through to the original `Already Exists` exception, exactly as
the random-id branch a few lines below already does with its `if (job == null)` check. Verified
against BigQuery (a `us-central1` dataset): the `NullPointerException` becomes the original
`BigQueryException: Already Exists: Job <project>:<location>.<id>`, whose message names the job's
actual location. The added test mirrors `testCreateJobTryGetNotRandom` with the re-fetch answering
not-found, and fails with the NPE when run without the fix.
