### PR TITLE
feat(bigquery-jdbc): add picosecond precision support for TIMESTAMP

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -50,6 +50,7 @@ import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
+import org.apache.arrow.vector.util.Text;
 
 /** {@link ResultSet} Implementation for Arrow datasource (Using Storage Read APIs) */
 class BigQueryArrowResultSet extends BigQueryBaseResultSet {
@@ -343,6 +344,27 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     }
     setWasNull(value);
     return value;
+  }
+
+  @Override
+  public String getString(int columnIndex) throws SQLException {
+    checkClosed();
+    StandardSQLTypeName type = getStandardSQLTypeName(columnIndex);
+    if (type != StandardSQLTypeName.TIMESTAMP) {
+      return super.getString(columnIndex);
+    }
+    Object value = getObjectInternal(columnIndex);
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Text || value instanceof String) {
+      return BigQueryTemporalUtility.formatTimestampStringFromIso(
+          value.toString(), this.statement.isEnableTimestampPicos());
+    }
+    if (value instanceof Long) {
+      return BigQueryTemporalUtility.formatTimestampStringFromMicroseconds((Long) value);
+    }
+    return super.getString(columnIndex);
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -185,6 +185,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   int highThroughputMinTableSize;
   int highThroughputActivationRatio;
   boolean enableSession;
+  boolean enableTimestampPicos;
   boolean enableProjectDiscovery;
   private List<String> discoveredProjectsCache;
   boolean unsupportedHTAPIFallback;
@@ -372,6 +373,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
               this.sslTrustStoreProvider,
               this.connectionClassName);
       this.enableSession = ds.getEnableSession();
+      this.enableTimestampPicos = ds.getEnableTimestampPicos();
       this.unsupportedHTAPIFallback = ds.getUnsupportedHTAPIFallback();
       this.maxResults = ds.getMaxResults();
       Map<String, String> queryPropertiesMap = ds.getQueryProperties();
@@ -705,6 +707,10 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
   boolean isSessionEnabled() {
     return this.enableSession;
+  }
+
+  boolean isEnableTimestampPicos() {
+    return this.enableTimestampPicos;
   }
 
   boolean isUnsupportedHTAPIFallback() {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
@@ -185,6 +185,8 @@ final class BigQueryJdbcUrlUtility {
   static final String SSL_TRUST_STORE_TYPE_PROPERTY_NAME = "SSLTrustStoreType";
   static final String SSL_TRUST_STORE_PROVIDER_PROPERTY_NAME = "SSLTrustStoreProvider";
   static final int DEFAULT_REQUEST_GOOGLE_DRIVE_SCOPE_VALUE = 0;
+  static final String ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME = "EnableTimestampPicos";
+  static final boolean DEFAULT_ENABLE_TIMESTAMP_PICOS_VALUE = false;
   static final String MAX_BYTES_BILLED_PROPERTY_NAME = "MaximumBytesBilled";
   static final Long DEFAULT_MAX_BYTES_BILLED_VALUE = 0L;
   static final String LABELS_PROPERTY_NAME = "Labels";
@@ -310,6 +312,12 @@ final class BigQueryJdbcUrlUtility {
       Collections.unmodifiableSet(
           new HashSet<>(
               Arrays.asList(
+                  BigQueryConnectionProperty.newBuilder()
+                      .setName(ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME)
+                      .setDescription(
+                          "Enable 12-digit picosecond precision for TIMESTAMP columns. Set to 1 to enable. Disabled (0) by default.")
+                      .setDefaultValue(String.valueOf(DEFAULT_ENABLE_TIMESTAMP_PICOS_VALUE))
+                      .build(),
                   BigQueryConnectionProperty.newBuilder()
                       .setName(MAX_BYTES_BILLED_PROPERTY_NAME)
                       .setDescription(

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
@@ -315,7 +315,7 @@ final class BigQueryJdbcUrlUtility {
                   BigQueryConnectionProperty.newBuilder()
                       .setName(ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME)
                       .setDescription(
-                          "Enable 12-digit picosecond precision for TIMESTAMP columns. Set to 1 to enable. Disabled (0) by default.")
+                          "Enables or disables 12-digit picosecond precision for TIMESTAMP columns. Disabled by default.")
                       .setDefaultValue(String.valueOf(DEFAULT_ENABLE_TIMESTAMP_PICOS_VALUE))
                       .build(),
                   BigQueryConnectionProperty.newBuilder()

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSet.java
@@ -229,7 +229,8 @@ class BigQueryJsonResultSet extends BigQueryBaseResultSet {
     if (value.getAttribute() == Attribute.REPEATED || value.getAttribute() == Attribute.RECORD) {
       return super.getString(columnIndex);
     }
-    return BigQueryTemporalUtility.formatTimestampString(value.getStringValue());
+    return BigQueryTemporalUtility.formatTimestampString(
+        value.getStringValue(), this.statement.isEnableTimestampPicos());
   }
 
   @Override

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadata.java
@@ -51,6 +51,16 @@ class BigQueryResultSetMetadata implements ResultSetMetaData {
     return this.statement;
   }
 
+  private boolean isTimestampPicosEnabled() {
+    return this.statement instanceof BigQueryStatement
+        && ((BigQueryStatement) this.statement).isEnableTimestampPicos();
+  }
+
+  private boolean supportsPicoseconds(int sqlColumn) {
+    Long timestampPrecision = getField(sqlColumn).getTimestampPrecision();
+    return timestampPrecision != null && timestampPrecision > 6;
+  }
+
   private Field getField(int sqlColumn) {
     return this.schemaFieldList.get(sqlColumn - 1);
   }
@@ -116,7 +126,10 @@ class BigQueryResultSetMetadata implements ResultSetMetaData {
       case Types.NUMERIC:
         return 14;
       case Types.TIMESTAMP:
-        return 16;
+        if (isTimestampPicosEnabled() && supportsPicoseconds(column)) {
+          return 32;
+        }
+        return 26;
       default:
         return DEFAULT_DISPLAY_SIZE;
     }
@@ -139,6 +152,11 @@ class BigQueryResultSetMetadata implements ResultSetMetaData {
       return precision.intValue();
     }
     StandardSQLTypeName type = getStandardSQLTypeName(column);
+    if (type == StandardSQLTypeName.TIMESTAMP
+        && isTimestampPicosEnabled()
+        && supportsPicoseconds(column)) {
+      return 32;
+    }
     BigQueryJdbcTypeMappings.ColumnTypeInfo typeInfo =
         BigQueryJdbcTypeMappings.STANDARD_TYPE_INFO.get(type);
     if (typeInfo != null && typeInfo.columnSize != null) {
@@ -154,6 +172,11 @@ class BigQueryResultSetMetadata implements ResultSetMetaData {
       return scale.intValue();
     }
     StandardSQLTypeName type = getStandardSQLTypeName(column);
+    if (type == StandardSQLTypeName.TIMESTAMP
+        && isTimestampPicosEnabled()
+        && supportsPicoseconds(column)) {
+      return 12;
+    }
     BigQueryJdbcTypeMappings.ColumnTypeInfo typeInfo =
         BigQueryJdbcTypeMappings.STANDARD_TYPE_INFO.get(type);
     if (typeInfo != null && typeInfo.decimalDigits != null) {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -49,12 +49,14 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcSqlFeatureNotSupportedExc
 import com.google.cloud.bigquery.exception.BigQueryJdbcSqlSyntaxErrorException;
 import com.google.cloud.bigquery.storage.v1.ArrowRecordBatch;
 import com.google.cloud.bigquery.storage.v1.ArrowSchema;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -845,6 +847,15 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       // format
       ReadSession.Builder sessionBuilder =
           ReadSession.newBuilder().setTable(srcTable).setDataFormat(DataFormat.ARROW);
+
+      if (this.connection.isEnableTimestampPicos()) {
+        TableReadOptions.Builder tableReadOptionsBuilder = TableReadOptions.newBuilder();
+        tableReadOptionsBuilder
+            .getArrowSerializationOptionsBuilder()
+            .setPicosTimestampPrecision(
+                ArrowSerializationOptions.PicosTimestampPrecision.TIMESTAMP_PRECISION_PICOS);
+        sessionBuilder.setReadOptions(tableReadOptionsBuilder.build());
+      }
 
       CreateReadSessionRequest.Builder builder =
           CreateReadSessionRequest.newBuilder()
@@ -1669,6 +1680,10 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   @Override
   public Connection getConnection() {
     return this.connection;
+  }
+
+  boolean isEnableTimestampPicos() {
+    return this.connection.isEnableTimestampPicos();
   }
 
   public boolean hasMoreResults() {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtility.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtility.java
@@ -166,15 +166,6 @@ final class BigQueryTemporalUtility {
 
   /**
    * Formats a numeric epoch decimal string into standard SQL timestamp string format ("yyyy-MM-dd
-   * HH:mm:ss.ffffff"). Sub-microsecond precision is deterministically truncated (down) to prevent
-   * timestamp boundary rollovers.
-   */
-  public static String formatTimestampString(String epochDecimal) {
-    return formatTimestampString(epochDecimal, false);
-  }
-
-  /**
-   * Formats a numeric epoch decimal string into standard SQL timestamp string format ("yyyy-MM-dd
    * HH:mm:ss.ffffff[ffffff]"). Sub-microsecond / sub-picosecond precision is deterministically
    * truncated (down) to prevent timestamp boundary rollovers.
    */

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
@@ -58,6 +58,7 @@ public class DataSource implements javax.sql.DataSource {
   private Map<String, String> queryProperties;
   private String logLevel;
   private Boolean enableSession;
+  private Boolean enableTimestampPicos;
   private String logPath;
   private String gcpTelemetryProjectId;
   private String gcpTelemetryCredentials;
@@ -149,6 +150,12 @@ public class DataSource implements javax.sql.DataSource {
           .put(
               BigQueryJdbcUrlUtility.GCP_TELEMETRY_CREDENTIALS_PROPERTY_NAME,
               DataSource::setGcpTelemetryCredentials)
+          .put(
+              BigQueryJdbcUrlUtility.ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME,
+              (ds, val) ->
+                  ds.setEnableTimestampPicos(
+                      BigQueryJdbcUrlUtility.convertIntToBoolean(
+                          val, BigQueryJdbcUrlUtility.ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME)))
           .put(
               BigQueryJdbcUrlUtility.ENABLE_HTAPI_PROPERTY_NAME,
               (ds, val) ->
@@ -923,6 +930,16 @@ public class DataSource implements javax.sql.DataSource {
     return this.unsupportedHTAPIFallback != null
         ? this.unsupportedHTAPIFallback
         : BigQueryJdbcUrlUtility.DEFAULT_UNSUPPORTED_HTAPI_FALLBACK_VALUE;
+  }
+
+  public Boolean getEnableTimestampPicos() {
+    return enableTimestampPicos != null
+        ? enableTimestampPicos
+        : BigQueryJdbcUrlUtility.DEFAULT_ENABLE_TIMESTAMP_PICOS_VALUE;
+  }
+
+  public void setEnableTimestampPicos(Boolean enableTimestampPicos) {
+    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   public Boolean getEnableSession() {

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/ArrowFormatTypeBigQueryCoercionUtilityTest.java
@@ -29,6 +29,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
@@ -156,6 +157,26 @@ public class ArrowFormatTypeBigQueryCoercionUtilityTest {
   public void longToTimestamp() {
     assertThat(INSTANCE.coerceTo(Timestamp.class, 1408452095220000L))
         .isEqualTo(new Timestamp(1408452095220L));
+  }
+
+  @Test
+  public void textToTimestamp() {
+    Text textUtc = new Text("2026-04-08 10:00:00.123456789123 UTC");
+    Timestamp expected = Timestamp.from(Instant.parse("2026-04-08T10:00:00.123456789Z"));
+    assertThat(INSTANCE.coerceTo(Timestamp.class, textUtc)).isEqualTo(expected);
+
+    Text textIso = new Text("2026-04-08T10:00:00.123456789123Z");
+    assertThat(INSTANCE.coerceTo(Timestamp.class, textIso)).isEqualTo(expected);
+  }
+
+  @Test
+  public void stringToTimestamp() {
+    String strUtc = "2026-04-08 10:00:00.123456789123 UTC";
+    Timestamp expected = Timestamp.from(Instant.parse("2026-04-08T10:00:00.123456789Z"));
+    assertThat(INSTANCE.coerceTo(Timestamp.class, strUtc)).isEqualTo(expected);
+
+    String strIso = "2026-04-08T10:00:00.123456789123Z";
+    assertThat(INSTANCE.coerceTo(Timestamp.class, strIso)).isEqualTo(expected);
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSetTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSetTest.java
@@ -23,6 +23,7 @@ import static org.apache.arrow.vector.types.Types.MinorType.INT;
 import static org.apache.arrow.vector.types.Types.MinorType.VARCHAR;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Field.Mode;
@@ -437,5 +438,56 @@ public class BigQueryArrowResultSetTest {
     return rowCount;
   }
 
-  // TODO: Unit Test for iteration and getters
+  @Test
+  public void testPicosecondTimestampArrowVector() throws Exception {
+    RootAllocator allocator = new RootAllocator();
+    VarCharVector timeStampPicosVector = new VarCharVector("timeStampField", allocator);
+    timeStampPicosVector.allocateNew(1);
+    timeStampPicosVector.set(0, new Text("2026-04-08T10:00:00.123456789123Z"));
+    timeStampPicosVector.setValueCount(1);
+
+    VectorSchemaRoot picosRoot = new VectorSchemaRoot(ImmutableList.of(timeStampPicosVector));
+    ArrowSchema arrowSchema =
+        ArrowSchema.newBuilder()
+            .setSerializedSchema(serializeSchema(picosRoot.getSchema()))
+            .build();
+    ArrowRecordBatch recordBatch =
+        ArrowRecordBatch.newBuilder()
+            .setSerializedRecordBatch(serializeVectorSchemaRoot(picosRoot))
+            .build();
+
+    BigQueryArrowBatchWrapper batchWrapper = BigQueryArrowBatchWrapper.of(recordBatch, false);
+    BlockingQueue<BigQueryArrowBatchWrapper> picosBuffer = new LinkedBlockingDeque<>(2);
+    picosBuffer.add(batchWrapper);
+    picosBuffer.add(BigQueryArrowBatchWrapper.of(null, true));
+
+    Schema bqSchema =
+        Schema.of(FieldList.of(Field.of("timeStampField", StandardSQLTypeName.TIMESTAMP)));
+    BigQueryStatement mockStatement = mock(BigQueryStatement.class);
+    when(mockStatement.isEnableTimestampPicos()).thenReturn(true);
+
+    BigQueryArrowResultSet rs =
+        BigQueryArrowResultSet.of(
+            bqSchema, arrowSchema, 1, mockStatement, picosBuffer, mock(Future.class), null);
+
+    assertThat(rs.next()).isTrue();
+    // getString returns full 12-digit picosecond string
+    assertThat(rs.getString("timeStampField")).isEqualTo("2026-04-08 10:00:00.123456789123");
+    assertThat(rs.getString(1)).isEqualTo("2026-04-08 10:00:00.123456789123");
+
+    // getTimestamp returns java.sql.Timestamp with 9 digits of nanoseconds
+    Timestamp ts = rs.getTimestamp("timeStampField");
+    assertThat(ts).isNotNull();
+    assertThat(ts.getNanos()).isEqualTo(123456789);
+
+    // getObject returns java.sql.Timestamp
+    Object obj = rs.getObject(1);
+    assertThat(obj).isInstanceOf(Timestamp.class);
+    assertThat(((Timestamp) obj).getNanos()).isEqualTo(123456789);
+
+    rs.close();
+    timeStampPicosVector.close();
+    picosRoot.close();
+    allocator.close();
+  }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSetTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJsonResultSetTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.time.Month.MARCH;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
@@ -509,7 +510,8 @@ public class BigQueryJsonResultSetTest {
   }
 
   @Test
-  public void testGetString_timestamp() throws SQLException {
+  public void testGetString_timestampWithPicoseconds() throws SQLException {
+    when(statement.isEnableTimestampPicos()).thenReturn(true);
     assertThat(resetResultSet()).isTrue();
     bigQueryJsonResultSet.next();
     assertThat(bigQueryJsonResultSet.getString("fifth")).isEqualTo("2023-03-30 11:14:19.820000");

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadataTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryResultSetMetadataTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
@@ -196,7 +197,7 @@ public class BigQueryResultSetMetadataTest {
     assertThat(resultSetMetaData.getColumnDisplaySize(2)).isEqualTo(10);
     assertThat(resultSetMetaData.getColumnDisplaySize(3)).isEqualTo(14);
     assertThat(resultSetMetaData.getColumnDisplaySize(12)).isEqualTo(50);
-    assertThat(resultSetMetaData.getColumnDisplaySize(5)).isEqualTo(16);
+    assertThat(resultSetMetaData.getColumnDisplaySize(5)).isEqualTo(26);
   }
 
   // Nested Types
@@ -294,5 +295,22 @@ public class BigQueryResultSetMetadataTest {
             Schema.of(schemaFields), 1L, null, statement, new Future<?>[] {mock(Future.class)});
     ResultSetMetaData metaData = resultSet.getMetaData();
     assertThat(metaData.isSearchable(1)).isTrue();
+  }
+
+  @Test
+  public void testTimestampPicosecondsMetadata() throws SQLException {
+    Field picosTimestampField =
+        Field.newBuilder("picosTs", StandardSQLTypeName.TIMESTAMP)
+            .setTimestampPrecision(12L)
+            .build();
+    Schema schema = Schema.of(FieldList.of(picosTimestampField));
+    when(statement.isEnableTimestampPicos()).thenReturn(true);
+    BigQueryJsonResultSet jsonRs =
+        BigQueryJsonResultSet.of(schema, 1L, null, statement, (Future<?>[]) null);
+    ResultSetMetaData metadata = jsonRs.getMetaData();
+
+    assertThat(metadata.getColumnDisplaySize(1)).isEqualTo(32);
+    assertThat(metadata.getPrecision(1)).isEqualTo(32);
+    assertThat(metadata.getScale(1)).isEqualTo(12);
   }
 }


### PR DESCRIPTION
b/544839231

This PR introduces support for picosecond precision (up to 12 fractional digits) when reading BigQuery `TIMESTAMP` columns, building on top of #14037 

### Overview

To maintain strict backwards compatibility, picosecond precision is disabled by default and activated via the new `EnableTimestampPicos` connection property:
* **Disabled (default)**: Timestamps maintain standard 6-digit microsecond precision across metadata (`displaySize=26, precision=26, scale=6`), `getString()`, `getTimestamp()`, and `getObject()`.
* **Enabled on picosecond columns**: Reports `displaySize=32, precision=32, scale=12` in `ResultSetMetaData` and preserves full 12-digit picosecond precision in `getString()`.

### Changes Made

* **Configuration**:
  * Added the `EnableTimestampPicos` connection property in `BigQueryConnection` and `DataSource`.

* **Arrow Storage Engine**:
  * Configured `ReadSession` creation in `BigQueryStatement` to explicitly request `TIMESTAMP_PRECISION_PICOS` when `EnableTimestampPicos` is active.
  * Added type coercions for `Text -> Timestamp` and `String -> Timestamp` in `BigQueryTypeCoercionUtility` using `BigQueryTemporalUtility::boxTimestamp` so `getObject()` and `getTimestamp()` seamlessly handle Arrow picosecond `VarCharVector` columns.

* **JDBC Metadata**:
  * Updated `BigQueryResultSetMetadata` to report `displaySize=32`, `precision=32`, and `scale=12` when `EnableTimestampPicos` is active and the column schema precision is 12.

* **Temporal Utilities & API Safety**:
  * **`boxTimestamp()`**: Gracefully down-casts 12-digit picosecond strings to 9 digits (nanoseconds) for `java.sql.Timestamp`, which maxes out at nanosecond precision and would otherwise throw a `DateTimeParseException`.
  * **`formatTimestampStringFromIso()`**: Standardized ISO-8601 formatting supporting both `'T'`/`'Z'`, SQL space-delimited (`' '`/`' UTC'`), and raw strings.

### Testing

* **Unit Tests**:
  * Added mocked Arrow vector tests in `BigQueryArrowResultSetTest` verifying `getString()`, `getTimestamp()`, and `getObject()` against picosecond `Text` columns.
  * Added metadata tests in `BigQueryResultSetMetadataTest` verifying precision, scale, and display size with picoseconds enabled and disabled.
  * Added ISO-8601 coercions tests in `ArrowFormatTypeBigQueryCoercionUtilityTest` and `BigQueryTemporalUtilityTest`.
