### PR TITLE
feat(firestore): add DML stages (Insert, Upsert) and atomic execution option to Java SDK pipelines

### DIFF
--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Pipeline.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Pipeline.java
@@ -47,6 +47,7 @@ import com.google.cloud.firestore.pipeline.stages.Delete;
 import com.google.cloud.firestore.pipeline.stages.Distinct;
 import com.google.cloud.firestore.pipeline.stages.FindNearest;
 import com.google.cloud.firestore.pipeline.stages.FindNearestOptions;
+import com.google.cloud.firestore.pipeline.stages.Insert;
 import com.google.cloud.firestore.pipeline.stages.Limit;
 import com.google.cloud.firestore.pipeline.stages.Offset;
 import com.google.cloud.firestore.pipeline.stages.PipelineExecuteOptions;
@@ -63,6 +64,7 @@ import com.google.cloud.firestore.pipeline.stages.Union;
 import com.google.cloud.firestore.pipeline.stages.Unnest;
 import com.google.cloud.firestore.pipeline.stages.UnnestOptions;
 import com.google.cloud.firestore.pipeline.stages.Update;
+import com.google.cloud.firestore.pipeline.stages.Upsert;
 import com.google.cloud.firestore.pipeline.stages.Where;
 import com.google.cloud.firestore.telemetry.MetricsUtil.MetricsContext;
 import com.google.cloud.firestore.telemetry.TelemetryConstants;
@@ -76,6 +78,7 @@ import com.google.firestore.v1.Document;
 import com.google.firestore.v1.ExecutePipelineRequest;
 import com.google.firestore.v1.ExecutePipelineResponse;
 import com.google.firestore.v1.StructuredPipeline;
+import com.google.firestore.v1.TransactionOptions;
 import com.google.firestore.v1.Value;
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
@@ -1306,6 +1309,21 @@ public final class Pipeline {
     return append(update);
   }
 
+  @BetaApi
+  public Pipeline insert(Insert insert) {
+    return append(insert);
+  }
+
+  @BetaApi
+  public Pipeline upsert(Upsert upsert) {
+    return append(upsert);
+  }
+
+  @BetaApi
+  public Pipeline upsert(Selectable... transformedFields) {
+    return append(new Upsert(transformedFields));
+  }
+
   /**
    * Performs an insert operation using documents from previous stages. Adds a generic stage to the
    * pipeline.
@@ -1509,15 +1527,13 @@ public final class Pipeline {
     }
   }
 
-  void executeInternal(
+  ExecutePipelineRequest toExecutePipelineRequest(
       @Nonnull PipelineExecuteOptions options,
       @Nullable final ByteString transactionId,
-      @Nullable com.google.protobuf.Timestamp readTime,
-      PipelineResultObserver observer,
-      MetricsContext metricsContext) {
+      @Nullable com.google.protobuf.Timestamp readTime) {
     ExecutePipelineRequest.Builder request =
         ExecutePipelineRequest.newBuilder()
-            .setDatabase(rpcContext.getDatabaseName())
+            .setDatabase(rpcContext != null ? rpcContext.getDatabaseName() : "")
             .setStructuredPipeline(
                 StructuredPipeline.newBuilder()
                     .setPipeline(toProto())
@@ -1526,14 +1542,31 @@ public final class Pipeline {
 
     if (transactionId != null) {
       request.setTransaction(transactionId);
+    } else if (options.isAtomic()) {
+      request.setNewTransaction(
+          TransactionOptions.newBuilder()
+              .setReadWrite(TransactionOptions.ReadWrite.getDefaultInstance())
+              .build());
+      request.setAutoCommitTransaction(true);
     }
 
     if (readTime != null) {
       request.setReadTime(readTime);
     }
 
+    return request.build();
+  }
+
+  void executeInternal(
+      @Nonnull PipelineExecuteOptions options,
+      @Nullable final ByteString transactionId,
+      @Nullable com.google.protobuf.Timestamp readTime,
+      PipelineResultObserver observer,
+      MetricsContext metricsContext) {
+    ExecutePipelineRequest request = toExecutePipelineRequest(options, transactionId, readTime);
+
     pipelineInternalStream(
-        request.build(),
+        request,
         new PipelineResultObserver() {
           @Override
           public void onCompleted() {

--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Pipeline.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/Pipeline.java
@@ -1320,8 +1320,8 @@ public final class Pipeline {
   }
 
   @BetaApi
-  public Pipeline upsert(Selectable... transformedFields) {
-    return append(new Upsert(transformedFields));
+  public Pipeline upsert(Selectable... additionalFields) {
+    return append(new Upsert(additionalFields));
   }
 
   /**

--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Insert.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Insert.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore.pipeline.stages;
+
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.cloud.firestore.PipelineUtils;
+import com.google.cloud.firestore.pipeline.expressions.Expression;
+import com.google.common.collect.ImmutableMap;
+import com.google.firestore.v1.Value;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+@InternalApi
+public final class Insert extends Stage {
+
+  @Nullable private final String collectionPath;
+  @Nullable private final Expression documentIdExpr;
+
+  private Insert(
+      @Nullable String collectionPath,
+      @Nullable Expression documentIdExpr,
+      InternalOptions options) {
+    super("insert", buildOptions(collectionPath, documentIdExpr, options));
+    this.collectionPath = collectionPath;
+    this.documentIdExpr = documentIdExpr;
+  }
+
+  @BetaApi
+  public Insert() {
+    this(null, null, InternalOptions.EMPTY);
+  }
+
+  @BetaApi
+  public Insert withCollection(String collectionPath) {
+    return new Insert(collectionPath, this.documentIdExpr, this.options);
+  }
+
+  @BetaApi
+  public Insert withDocumentId(Expression documentIdExpr) {
+    return new Insert(this.collectionPath, documentIdExpr, this.options);
+  }
+
+  private static InternalOptions buildOptions(
+      @Nullable String collectionPath,
+      @Nullable Expression documentIdExpr,
+      InternalOptions baseOptions) {
+    Map<String, Value> optsMap = new HashMap<>(baseOptions.options);
+    if (collectionPath != null) {
+      String path = collectionPath.startsWith("/") ? collectionPath : "/" + collectionPath;
+      optsMap.put("collection", Value.newBuilder().setReferenceValue(path).build());
+    }
+    if (documentIdExpr != null) {
+      optsMap.put("document_id", PipelineUtils.encodeValue(documentIdExpr));
+    }
+    return new InternalOptions(ImmutableMap.copyOf(optsMap));
+  }
+
+  @Override
+  Iterable<Value> toStageArgs() {
+    return new ArrayList<>();
+  }
+}

--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Insert.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Insert.java
@@ -31,15 +31,15 @@ import javax.annotation.Nullable;
 public final class Insert extends Stage {
 
   @Nullable private final String collectionPath;
-  @Nullable private final Expression documentIdExpr;
+  @Nullable private final Expression documentIdExpression;
 
   private Insert(
       @Nullable String collectionPath,
-      @Nullable Expression documentIdExpr,
+      @Nullable Expression documentIdExpression,
       InternalOptions options) {
-    super("insert", buildOptions(collectionPath, documentIdExpr, options));
+    super("insert", buildOptions(collectionPath, documentIdExpression, options));
     this.collectionPath = collectionPath;
-    this.documentIdExpr = documentIdExpr;
+    this.documentIdExpression = documentIdExpression;
   }
 
   @BetaApi
@@ -49,25 +49,30 @@ public final class Insert extends Stage {
 
   @BetaApi
   public Insert withCollection(String collectionPath) {
-    return new Insert(collectionPath, this.documentIdExpr, this.options);
+    return new Insert(collectionPath, this.documentIdExpression, this.options);
   }
 
   @BetaApi
-  public Insert withDocumentId(Expression documentIdExpr) {
-    return new Insert(this.collectionPath, documentIdExpr, this.options);
+  public Insert withDocumentIdExpression(Expression documentIdExpression) {
+    return new Insert(this.collectionPath, documentIdExpression, this.options);
+  }
+
+  @BetaApi
+  public Insert withDocumentId(Expression documentIdExpression) {
+    return withDocumentIdExpression(documentIdExpression);
   }
 
   private static InternalOptions buildOptions(
       @Nullable String collectionPath,
-      @Nullable Expression documentIdExpr,
+      @Nullable Expression documentIdExpression,
       InternalOptions baseOptions) {
     Map<String, Value> optsMap = new HashMap<>(baseOptions.options);
     if (collectionPath != null) {
       String path = collectionPath.startsWith("/") ? collectionPath : "/" + collectionPath;
       optsMap.put("collection", Value.newBuilder().setReferenceValue(path).build());
     }
-    if (documentIdExpr != null) {
-      optsMap.put("document_id", PipelineUtils.encodeValue(documentIdExpr));
+    if (documentIdExpression != null) {
+      optsMap.put("document_id", PipelineUtils.encodeValue(documentIdExpression));
     }
     return new InternalOptions(ImmutableMap.copyOf(optsMap));
   }

--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/PipelineExecuteOptions.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/PipelineExecuteOptions.java
@@ -38,4 +38,13 @@ public final class PipelineExecuteOptions extends AbstractOptions<PipelineExecut
   public PipelineExecuteOptions withIndexMode(String indexMode) {
     return with("index_mode", indexMode);
   }
+
+  public PipelineExecuteOptions withAtomic(boolean atomic) {
+    return with("atomic", atomic);
+  }
+
+  public boolean isAtomic() {
+    return options.options.containsKey("atomic")
+        && options.options.get("atomic").getBooleanValue();
+  }
 }

--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Upsert.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Upsert.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.firestore.pipeline.stages;
+
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.cloud.firestore.PipelineUtils;
+import com.google.cloud.firestore.pipeline.expressions.Expression;
+import com.google.cloud.firestore.pipeline.expressions.Selectable;
+import com.google.common.collect.ImmutableMap;
+import com.google.firestore.v1.Value;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+@InternalApi
+public final class Upsert extends Stage {
+
+  @Nullable private final Selectable[] transformedFields;
+  @Nullable private final String collectionPath;
+  @Nullable private final Expression documentIdExpr;
+
+  private Upsert(
+      @Nullable Selectable[] transformedFields,
+      @Nullable String collectionPath,
+      @Nullable Expression documentIdExpr,
+      InternalOptions options) {
+    super("upsert", buildOptions(collectionPath, documentIdExpr, options));
+    this.transformedFields = transformedFields;
+    this.collectionPath = collectionPath;
+    this.documentIdExpr = documentIdExpr;
+  }
+
+  @BetaApi
+  public Upsert() {
+    this(null, null, null, InternalOptions.EMPTY);
+  }
+
+  @BetaApi
+  public Upsert(Selectable... transformedFields) {
+    this(transformedFields, null, null, InternalOptions.EMPTY);
+  }
+
+  @BetaApi
+  public Upsert withCollection(String collectionPath) {
+    return new Upsert(this.transformedFields, collectionPath, this.documentIdExpr, this.options);
+  }
+
+  @BetaApi
+  public Upsert withDocumentId(Expression documentIdExpr) {
+    return new Upsert(this.transformedFields, this.collectionPath, documentIdExpr, this.options);
+  }
+
+  private static InternalOptions buildOptions(
+      @Nullable String collectionPath,
+      @Nullable Expression documentIdExpr,
+      InternalOptions baseOptions) {
+    Map<String, Value> optsMap = new HashMap<>(baseOptions.options);
+    if (collectionPath != null) {
+      String path = collectionPath.startsWith("/") ? collectionPath : "/" + collectionPath;
+      optsMap.put("collection", Value.newBuilder().setReferenceValue(path).build());
+    }
+    if (documentIdExpr != null) {
+      optsMap.put("document_id", PipelineUtils.encodeValue(documentIdExpr));
+    }
+    return new InternalOptions(ImmutableMap.copyOf(optsMap));
+  }
+
+  @Override
+  Iterable<Value> toStageArgs() {
+    List<Value> args = new ArrayList<>();
+    if (transformedFields != null && transformedFields.length > 0) {
+      Map<String, Expression> map = PipelineUtils.selectablesToMap(transformedFields);
+      Map<String, Value> encodedMap = new HashMap<>();
+      for (Map.Entry<String, Expression> entry : map.entrySet()) {
+        encodedMap.put(entry.getKey(), PipelineUtils.encodeValue(entry.getValue()));
+      }
+      args.add(PipelineUtils.encodeValue(encodedMap));
+    }
+    return args;
+  }
+}

--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Upsert.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Upsert.java
@@ -21,6 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.firestore.PipelineUtils;
 import com.google.cloud.firestore.pipeline.expressions.Expression;
 import com.google.cloud.firestore.pipeline.expressions.Selectable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.firestore.v1.Value;
 import java.util.ArrayList;
@@ -32,39 +33,73 @@ import javax.annotation.Nullable;
 @InternalApi
 public final class Upsert extends Stage {
 
-  @Nullable private final Selectable[] transformedFields;
+  @Nullable private final ImmutableList<Selectable> additionalFields;
   @Nullable private final String collectionPath;
   @Nullable private final Expression documentIdExpression;
 
   private Upsert(
-      @Nullable Selectable[] transformedFields,
+      @Nullable ImmutableList<Selectable> additionalFields,
       @Nullable String collectionPath,
       @Nullable Expression documentIdExpression,
       InternalOptions options) {
     super("upsert", buildOptions(collectionPath, documentIdExpression, options));
-    this.transformedFields = transformedFields;
+    this.additionalFields = additionalFields;
     this.collectionPath = collectionPath;
     this.documentIdExpression = documentIdExpression;
   }
 
   @BetaApi
   public Upsert() {
-    this(null, null, null, InternalOptions.EMPTY);
+    this((ImmutableList<Selectable>) null, null, null, InternalOptions.EMPTY);
   }
 
   @BetaApi
-  public Upsert(Selectable... transformedFields) {
-    this(transformedFields, null, null, InternalOptions.EMPTY);
+  public Upsert(Selectable... additionalFields) {
+    this(
+        additionalFields != null ? ImmutableList.copyOf(additionalFields) : null,
+        null,
+        null,
+        InternalOptions.EMPTY);
+  }
+
+  @BetaApi
+  public Upsert withAdditionalFields(Selectable... additionalFields) {
+    return new Upsert(
+        ImmutableList.copyOf(additionalFields),
+        this.collectionPath,
+        this.documentIdExpression,
+        this.options);
+  }
+
+  @BetaApi
+  public Upsert withAdditionalFields(List<Selectable> additionalFields) {
+    return new Upsert(
+        ImmutableList.copyOf(additionalFields),
+        this.collectionPath,
+        this.documentIdExpression,
+        this.options);
+  }
+
+  @BetaApi
+  public Upsert withTransformedFields(Selectable... transformedFields) {
+    return withAdditionalFields(transformedFields);
+  }
+
+  @BetaApi
+  public Upsert withTransformedFields(List<Selectable> transformedFields) {
+    return withAdditionalFields(transformedFields);
   }
 
   @BetaApi
   public Upsert withCollection(String collectionPath) {
-    return new Upsert(this.transformedFields, collectionPath, this.documentIdExpression, this.options);
+    return new Upsert(
+        this.additionalFields, collectionPath, this.documentIdExpression, this.options);
   }
 
   @BetaApi
   public Upsert withDocumentIdExpression(Expression documentIdExpression) {
-    return new Upsert(this.transformedFields, this.collectionPath, documentIdExpression, this.options);
+    return new Upsert(
+        this.additionalFields, this.collectionPath, documentIdExpression, this.options);
   }
 
   @BetaApi
@@ -90,8 +125,9 @@ public final class Upsert extends Stage {
   @Override
   Iterable<Value> toStageArgs() {
     List<Value> args = new ArrayList<>();
-    if (transformedFields != null && transformedFields.length > 0) {
-      Map<String, Expression> map = PipelineUtils.selectablesToMap(transformedFields);
+    if (additionalFields != null && !additionalFields.isEmpty()) {
+      Map<String, Expression> map =
+          PipelineUtils.selectablesToMap(additionalFields.toArray(new Selectable[0]));
       Map<String, Value> encodedMap = new HashMap<>();
       for (Map.Entry<String, Expression> entry : map.entrySet()) {
         encodedMap.put(entry.getKey(), PipelineUtils.encodeValue(entry.getValue()));

--- a/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Upsert.java
+++ b/java-firestore/google-cloud-firestore/src/main/java/com/google/cloud/firestore/pipeline/stages/Upsert.java
@@ -34,17 +34,17 @@ public final class Upsert extends Stage {
 
   @Nullable private final Selectable[] transformedFields;
   @Nullable private final String collectionPath;
-  @Nullable private final Expression documentIdExpr;
+  @Nullable private final Expression documentIdExpression;
 
   private Upsert(
       @Nullable Selectable[] transformedFields,
       @Nullable String collectionPath,
-      @Nullable Expression documentIdExpr,
+      @Nullable Expression documentIdExpression,
       InternalOptions options) {
-    super("upsert", buildOptions(collectionPath, documentIdExpr, options));
+    super("upsert", buildOptions(collectionPath, documentIdExpression, options));
     this.transformedFields = transformedFields;
     this.collectionPath = collectionPath;
-    this.documentIdExpr = documentIdExpr;
+    this.documentIdExpression = documentIdExpression;
   }
 
   @BetaApi
@@ -59,25 +59,30 @@ public final class Upsert extends Stage {
 
   @BetaApi
   public Upsert withCollection(String collectionPath) {
-    return new Upsert(this.transformedFields, collectionPath, this.documentIdExpr, this.options);
+    return new Upsert(this.transformedFields, collectionPath, this.documentIdExpression, this.options);
   }
 
   @BetaApi
-  public Upsert withDocumentId(Expression documentIdExpr) {
-    return new Upsert(this.transformedFields, this.collectionPath, documentIdExpr, this.options);
+  public Upsert withDocumentIdExpression(Expression documentIdExpression) {
+    return new Upsert(this.transformedFields, this.collectionPath, documentIdExpression, this.options);
+  }
+
+  @BetaApi
+  public Upsert withDocumentId(Expression documentIdExpression) {
+    return withDocumentIdExpression(documentIdExpression);
   }
 
   private static InternalOptions buildOptions(
       @Nullable String collectionPath,
-      @Nullable Expression documentIdExpr,
+      @Nullable Expression documentIdExpression,
       InternalOptions baseOptions) {
     Map<String, Value> optsMap = new HashMap<>(baseOptions.options);
     if (collectionPath != null) {
       String path = collectionPath.startsWith("/") ? collectionPath : "/" + collectionPath;
       optsMap.put("collection", Value.newBuilder().setReferenceValue(path).build());
     }
-    if (documentIdExpr != null) {
-      optsMap.put("document_id", PipelineUtils.encodeValue(documentIdExpr));
+    if (documentIdExpression != null) {
+      optsMap.put("document_id", PipelineUtils.encodeValue(documentIdExpression));
     }
     return new InternalOptions(ImmutableMap.copyOf(optsMap));
   }

--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PipelineProtoTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PipelineProtoTest.java
@@ -20,7 +20,9 @@ import static com.google.cloud.firestore.pipeline.expressions.Expression.constan
 import static com.google.cloud.firestore.pipeline.expressions.Expression.field;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.firestore.pipeline.stages.PipelineExecuteOptions;
 import com.google.cloud.firestore.pipeline.stages.Search;
+import com.google.firestore.v1.ExecutePipelineRequest;
 import com.google.firestore.v1.Pipeline.Stage;
 import com.google.firestore.v1.Value;
 import org.junit.Test;
@@ -102,5 +104,140 @@ public class PipelineProtoTest {
     // add_fields
     Value addFields = optionsMap.get("add_fields");
     assertThat(addFields.getMapValue().getFieldsMap().get("bar").getBooleanValue()).isTrue();
+  }
+
+  @Test
+  public void testInsertStageProtoEncoding() {
+    FirestoreOptions options =
+        FirestoreOptions.newBuilder()
+            .setProjectId("new-project")
+            .setDatabaseId("(default)")
+            .build();
+    Firestore firestore = options.getService();
+
+    java.util.Map<String, Object> data = new java.util.HashMap<>();
+    data.put("title", "Test Book");
+
+    Pipeline pipeline =
+        firestore
+            .pipeline()
+            .literals(data)
+            .insert(
+                new com.google.cloud.firestore.pipeline.stages.Insert()
+                    .withCollection("books")
+                    .withDocumentId(constant("book1")));
+
+    com.google.firestore.v1.Pipeline protoPipeline = pipeline.toProto();
+    assertThat(protoPipeline.getStagesCount()).isEqualTo(2);
+
+    Stage insertStage = protoPipeline.getStages(1);
+    assertThat(insertStage.getName()).isEqualTo("insert");
+    assertThat(insertStage.getArgsCount()).isEqualTo(0);
+
+    java.util.Map<String, Value> optionsMap = insertStage.getOptionsMap();
+    assertThat(optionsMap.get("collection").getReferenceValue()).isEqualTo("/books");
+    assertThat(optionsMap.get("document_id").getStringValue()).isEqualTo("book1");
+  }
+
+  @Test
+  public void testUpsertStageProtoEncoding() {
+    FirestoreOptions options =
+        FirestoreOptions.newBuilder()
+            .setProjectId("new-project")
+            .setDatabaseId("(default)")
+            .build();
+    Firestore firestore = options.getService();
+
+    java.util.Map<String, Object> data = new java.util.HashMap<>();
+    data.put("title", "Upsert Book");
+    data.put("count", 1);
+
+    Pipeline pipeline =
+        firestore
+            .pipeline()
+            .literals(data)
+            .upsert(
+                new com.google.cloud.firestore.pipeline.stages.Upsert(
+                        com.google.cloud.firestore.pipeline.expressions.Expression.add(
+                                field("count"), constant(1))
+                            .as("count"))
+                    .withCollection("books")
+                    .withDocumentId(constant("book1")));
+
+    com.google.firestore.v1.Pipeline protoPipeline = pipeline.toProto();
+    assertThat(protoPipeline.getStagesCount()).isEqualTo(2);
+
+    Stage upsertStage = protoPipeline.getStages(1);
+    assertThat(upsertStage.getName()).isEqualTo("upsert");
+    assertThat(upsertStage.getArgsCount()).isEqualTo(1);
+    assertThat(upsertStage.getArgs(0).getMapValue().getFieldsMap()).containsKey("count");
+
+    java.util.Map<String, Value> optionsMap = upsertStage.getOptionsMap();
+    assertThat(optionsMap.get("collection").getReferenceValue()).isEqualTo("/books");
+    assertThat(optionsMap.get("document_id").getStringValue()).isEqualTo("book1");
+  }
+
+  @Test
+  public void testAtomicExecutionOptionsConfigureNewTransactionAndAutoCommitTransaction() {
+    FirestoreOptions options =
+        FirestoreOptions.newBuilder()
+            .setProjectId("new-project")
+            .setDatabaseId("(default)")
+            .build();
+    Firestore firestore = options.getService();
+
+    java.util.Map<String, Object> data = new java.util.HashMap<>();
+    data.put("title", "Atomic Book");
+
+    Pipeline pipeline =
+        firestore
+            .pipeline()
+            .literals(data)
+            .insert(
+                new com.google.cloud.firestore.pipeline.stages.Insert()
+                    .withCollection("books")
+                    .withDocumentId(constant("book1")));
+
+    PipelineExecuteOptions executeOptions = new PipelineExecuteOptions().withAtomic(true);
+    ExecutePipelineRequest request =
+        pipeline.toExecutePipelineRequest(executeOptions, null, null);
+
+    assertThat(request.hasNewTransaction()).isTrue();
+    assertThat(request.getNewTransaction().hasReadWrite()).isTrue();
+    assertThat(request.getAutoCommitTransaction()).isTrue();
+  }
+
+  @Test
+  public void testNonAtomicExecutionOptionsDoNotConfigureNewTransactionOrAutoCommitTransaction() {
+    FirestoreOptions options =
+        FirestoreOptions.newBuilder()
+            .setProjectId("new-project")
+            .setDatabaseId("(default)")
+            .build();
+    Firestore firestore = options.getService();
+
+    java.util.Map<String, Object> data = new java.util.HashMap<>();
+    data.put("title", "Non-Atomic Book");
+
+    Pipeline pipeline =
+        firestore
+            .pipeline()
+            .literals(data)
+            .insert(
+                new com.google.cloud.firestore.pipeline.stages.Insert()
+                    .withCollection("books")
+                    .withDocumentId(constant("book1")));
+
+    PipelineExecuteOptions executeOptionsDisabled = new PipelineExecuteOptions().withAtomic(false);
+    ExecutePipelineRequest requestDisabled =
+        pipeline.toExecutePipelineRequest(executeOptionsDisabled, null, null);
+    assertThat(requestDisabled.hasNewTransaction()).isFalse();
+    assertThat(requestDisabled.getAutoCommitTransaction()).isFalse();
+
+    PipelineExecuteOptions executeOptionsDefault = new PipelineExecuteOptions();
+    ExecutePipelineRequest requestDefault =
+        pipeline.toExecutePipelineRequest(executeOptionsDefault, null, null);
+    assertThat(requestDefault.hasNewTransaction()).isFalse();
+    assertThat(requestDefault.getAutoCommitTransaction()).isFalse();
   }
 }

--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PipelineProtoTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PipelineProtoTest.java
@@ -125,7 +125,7 @@ public class PipelineProtoTest {
             .insert(
                 new com.google.cloud.firestore.pipeline.stages.Insert()
                     .withCollection("books")
-                    .withDocumentId(constant("book1")));
+                    .withDocumentIdExpression(constant("book1")));
 
     com.google.firestore.v1.Pipeline protoPipeline = pipeline.toProto();
     assertThat(protoPipeline.getStagesCount()).isEqualTo(2);
@@ -137,6 +137,19 @@ public class PipelineProtoTest {
     java.util.Map<String, Value> optionsMap = insertStage.getOptionsMap();
     assertThat(optionsMap.get("collection").getReferenceValue()).isEqualTo("/books");
     assertThat(optionsMap.get("document_id").getStringValue()).isEqualTo("book1");
+
+    // Test backward compatibility with withDocumentId
+    Pipeline pipelineDeprecated =
+        firestore
+            .pipeline()
+            .literals(data)
+            .insert(
+                new com.google.cloud.firestore.pipeline.stages.Insert()
+                    .withCollection("books")
+                    .withDocumentId(constant("book1")));
+    Stage insertStageDeprecated = pipelineDeprecated.toProto().getStages(1);
+    assertThat(insertStageDeprecated.getOptionsMap().get("document_id").getStringValue())
+        .isEqualTo("book1");
   }
 
   @Test
@@ -162,7 +175,7 @@ public class PipelineProtoTest {
                                 field("count"), constant(1))
                             .as("count"))
                     .withCollection("books")
-                    .withDocumentId(constant("book1")));
+                    .withDocumentIdExpression(constant("book1")));
 
     com.google.firestore.v1.Pipeline protoPipeline = pipeline.toProto();
     assertThat(protoPipeline.getStagesCount()).isEqualTo(2);
@@ -175,6 +188,22 @@ public class PipelineProtoTest {
     java.util.Map<String, Value> optionsMap = upsertStage.getOptionsMap();
     assertThat(optionsMap.get("collection").getReferenceValue()).isEqualTo("/books");
     assertThat(optionsMap.get("document_id").getStringValue()).isEqualTo("book1");
+
+    // Test backward compatibility with withDocumentId
+    Pipeline pipelineDeprecated =
+        firestore
+            .pipeline()
+            .literals(data)
+            .upsert(
+                new com.google.cloud.firestore.pipeline.stages.Upsert(
+                        com.google.cloud.firestore.pipeline.expressions.Expression.add(
+                                field("count"), constant(1))
+                            .as("count"))
+                    .withCollection("books")
+                    .withDocumentId(constant("book1")));
+    Stage upsertStageDeprecated = pipelineDeprecated.toProto().getStages(1);
+    assertThat(upsertStageDeprecated.getOptionsMap().get("document_id").getStringValue())
+        .isEqualTo("book1");
   }
 
   @Test
@@ -196,7 +225,7 @@ public class PipelineProtoTest {
             .insert(
                 new com.google.cloud.firestore.pipeline.stages.Insert()
                     .withCollection("books")
-                    .withDocumentId(constant("book1")));
+                    .withDocumentIdExpression(constant("book1")));
 
     PipelineExecuteOptions executeOptions = new PipelineExecuteOptions().withAtomic(true);
     ExecutePipelineRequest request =
@@ -226,7 +255,7 @@ public class PipelineProtoTest {
             .insert(
                 new com.google.cloud.firestore.pipeline.stages.Insert()
                     .withCollection("books")
-                    .withDocumentId(constant("book1")));
+                    .withDocumentIdExpression(constant("book1")));
 
     PipelineExecuteOptions executeOptionsDisabled = new PipelineExecuteOptions().withAtomic(false);
     ExecutePipelineRequest requestDisabled =

--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PipelineProtoTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/PipelineProtoTest.java
@@ -170,7 +170,8 @@ public class PipelineProtoTest {
             .pipeline()
             .literals(data)
             .upsert(
-                new com.google.cloud.firestore.pipeline.stages.Upsert(
+                new com.google.cloud.firestore.pipeline.stages.Upsert()
+                    .withAdditionalFields(
                         com.google.cloud.firestore.pipeline.expressions.Expression.add(
                                 field("count"), constant(1))
                             .as("count"))
@@ -188,6 +189,40 @@ public class PipelineProtoTest {
     java.util.Map<String, Value> optionsMap = upsertStage.getOptionsMap();
     assertThat(optionsMap.get("collection").getReferenceValue()).isEqualTo("/books");
     assertThat(optionsMap.get("document_id").getStringValue()).isEqualTo("book1");
+
+    // Test withAdditionalFields with List
+    Pipeline pipelineWithList =
+        firestore
+            .pipeline()
+            .literals(data)
+            .upsert(
+                new com.google.cloud.firestore.pipeline.stages.Upsert()
+                    .withAdditionalFields(
+                        java.util.Collections.singletonList(
+                            com.google.cloud.firestore.pipeline.expressions.Expression.add(
+                                    field("count"), constant(1))
+                                .as("count")))
+                    .withCollection("books")
+                    .withDocumentIdExpression(constant("book1")));
+    Stage upsertStageWithList = pipelineWithList.toProto().getStages(1);
+    assertThat(upsertStageWithList.getArgs(0).getMapValue().getFieldsMap()).containsKey("count");
+
+    // Test backward compatibility with withTransformedFields
+    Pipeline pipelineWithTransformedFields =
+        firestore
+            .pipeline()
+            .literals(data)
+            .upsert(
+                new com.google.cloud.firestore.pipeline.stages.Upsert()
+                    .withTransformedFields(
+                        com.google.cloud.firestore.pipeline.expressions.Expression.add(
+                                field("count"), constant(1))
+                            .as("count"))
+                    .withCollection("books")
+                    .withDocumentIdExpression(constant("book1")));
+    Stage upsertStageWithTransformedFields = pipelineWithTransformedFields.toProto().getStages(1);
+    assertThat(upsertStageWithTransformedFields.getArgs(0).getMapValue().getFieldsMap())
+        .containsKey("count");
 
     // Test backward compatibility with withDocumentId
     Pipeline pipelineDeprecated =

--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineTest.java
@@ -136,11 +136,13 @@ import com.google.cloud.firestore.pipeline.stages.CollectionOptions;
 import com.google.cloud.firestore.pipeline.stages.ExplainOptions;
 import com.google.cloud.firestore.pipeline.stages.FindNearest;
 import com.google.cloud.firestore.pipeline.stages.FindNearestOptions;
+import com.google.cloud.firestore.pipeline.stages.Insert;
 import com.google.cloud.firestore.pipeline.stages.PipelineExecuteOptions;
 import com.google.cloud.firestore.pipeline.stages.RawOptions;
 import com.google.cloud.firestore.pipeline.stages.RawStage;
 import com.google.cloud.firestore.pipeline.stages.Sample;
 import com.google.cloud.firestore.pipeline.stages.UnnestOptions;
+import com.google.cloud.firestore.pipeline.stages.Upsert;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -4736,5 +4738,103 @@ public class ITPipelineTest extends ITBaseTest {
     assertThat(results).hasSize(1);
     assertThat(results.get(0).getData().get("base")).isEqualTo(10L);
     assertThat(results.get(0).getData().get("doubled")).isEqualTo(20L);
+  }
+
+  @Test
+  public void testInsertStage() throws Exception {
+    CollectionReference dmlCol = firestore.collection(LocalFirestoreHelper.autoId());
+    java.util.Map<String, Object> data = new java.util.HashMap<>();
+    data.put("title", "New Book");
+    data.put("author", "Author 1");
+
+    List<PipelineResult> results =
+        firestore
+            .pipeline()
+            .literals(data)
+            .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentId(constant("newBook_insert_1")))
+            .execute()
+            .get()
+            .getResults();
+
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getData().get("documents_modified")).isEqualTo(1L);
+
+    DocumentSnapshot snap = dmlCol.document("newBook_insert_1").get().get();
+    assertThat(snap.exists()).isTrue();
+    assertThat(snap.get("title")).isEqualTo("New Book");
+  }
+
+  @Test
+  public void testUpsertStageWithTransforms() throws Exception {
+    CollectionReference dmlCol = firestore.collection(LocalFirestoreHelper.autoId());
+    java.util.Map<String, Object> data = new java.util.HashMap<>();
+    data.put("title", "Upserted Book");
+    data.put("count", 1);
+
+    List<PipelineResult> results =
+        firestore
+            .pipeline()
+            .literals(data)
+            .upsert(
+                new Upsert(add(field("count"), constant(1)).as("count"))
+                    .withCollection(dmlCol.getPath())
+                    .withDocumentId(constant("upsertBook_1")))
+            .execute(new PipelineExecuteOptions().withAtomic(true))
+            .get()
+            .getResults();
+
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getData().get("documents_modified")).isEqualTo(1L);
+
+    DocumentSnapshot snap = dmlCol.document("upsertBook_1").get().get();
+    assertThat(snap.exists()).isTrue();
+    assertThat(snap.get("title")).isEqualTo("Upserted Book");
+  }
+
+  @Test
+  public void testDMLWithAtomicOption() throws Exception {
+    CollectionReference dmlCol = firestore.collection(LocalFirestoreHelper.autoId());
+    java.util.Map<String, Object> data = new java.util.HashMap<>();
+    data.put("title", "Atomic Book");
+
+    List<PipelineResult> results =
+        firestore
+            .pipeline()
+            .literals(data)
+            .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentId(constant("atomicBook_1")))
+            .execute(new PipelineExecuteOptions().withAtomic(true))
+            .get()
+            .getResults();
+
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getData().get("documents_modified")).isEqualTo(1L);
+
+    DocumentSnapshot snap = dmlCol.document("atomicBook_1").get().get();
+    assertThat(snap.exists()).isTrue();
+  }
+
+  @Test
+  public void testInsertUpsertStagesInsideTransaction() throws Exception {
+    CollectionReference dmlCol = firestore.collection(LocalFirestoreHelper.autoId());
+    firestore
+        .runTransaction(
+            transaction -> {
+              java.util.Map<String, Object> data = new java.util.HashMap<>();
+              data.put("title", "Tx Book");
+              Pipeline insertPpl =
+                  firestore
+                      .pipeline()
+                      .literals(data)
+                      .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentId(constant("txBook_1")));
+              List<PipelineResult> res = transaction.execute(insertPpl).get().getResults();
+              assertThat(res).hasSize(1);
+              assertThat(res.get(0).getData().get("documents_modified")).isEqualTo(1L);
+              return null;
+            })
+        .get();
+
+    DocumentSnapshot snap = dmlCol.document("txBook_1").get().get();
+    assertThat(snap.exists()).isTrue();
+    assertThat(snap.get("title")).isEqualTo("Tx Book");
   }
 }

--- a/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineTest.java
+++ b/java-firestore/google-cloud-firestore/src/test/java/com/google/cloud/firestore/it/ITPipelineTest.java
@@ -4751,7 +4751,7 @@ public class ITPipelineTest extends ITBaseTest {
         firestore
             .pipeline()
             .literals(data)
-            .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentId(constant("newBook_insert_1")))
+            .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentIdExpression(constant("newBook_insert_1")))
             .execute()
             .get()
             .getResults();
@@ -4778,7 +4778,7 @@ public class ITPipelineTest extends ITBaseTest {
             .upsert(
                 new Upsert(add(field("count"), constant(1)).as("count"))
                     .withCollection(dmlCol.getPath())
-                    .withDocumentId(constant("upsertBook_1")))
+                    .withDocumentIdExpression(constant("upsertBook_1")))
             .execute(new PipelineExecuteOptions().withAtomic(true))
             .get()
             .getResults();
@@ -4801,7 +4801,7 @@ public class ITPipelineTest extends ITBaseTest {
         firestore
             .pipeline()
             .literals(data)
-            .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentId(constant("atomicBook_1")))
+            .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentIdExpression(constant("atomicBook_1")))
             .execute(new PipelineExecuteOptions().withAtomic(true))
             .get()
             .getResults();
@@ -4825,7 +4825,7 @@ public class ITPipelineTest extends ITBaseTest {
                   firestore
                       .pipeline()
                       .literals(data)
-                      .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentId(constant("txBook_1")));
+                      .insert(new Insert().withCollection(dmlCol.getPath()).withDocumentIdExpression(constant("txBook_1")));
               List<PipelineResult> res = transaction.execute(insertPpl).get().getResults();
               assertThat(res).hasSize(1);
               assertThat(res.get(0).getData().get("documents_modified")).isEqualTo(1L);


### PR DESCRIPTION
### Summary
Adds DML stages (`Insert`, `Upsert`) and the atomic execution option to the Java SDK (`java-firestore`) Firestore Pipelines subsystem to achieve parity with Node and Web SDKs.

### Key Changes
- **`Insert.java`**: Added new stage class for `insert` operation with `collection` reference and `document_id` expression options.
- **`Upsert.java`**: Added new stage class for `upsert` operation with transformation expressions argument, `collection` reference, and `document_id` expression options.
- **`PipelineExecuteOptions.java`**: Added `withAtomic(boolean atomic)` option.
- **`Pipeline.java`**:
  - Added `insert(...)` and `upsert(...)` builder methods.
  - Configured `executeInternal` to populate `newTransaction` (`readWrite`) and `autoCommitTransaction = true` on `ExecutePipelineRequest` when `atomic` is enabled.
- **Unit & System Integration Tests**:
  - Added unit test suite in `PipelineProtoTest.java` verifying proto generation for `Insert` and `Upsert` stages.
  - Added system integration tests in `ITPipelineTest.java` covering `insert`, `upsert` with transforms, `atomic` option, and transaction runner execution (`transaction.execute(pipeline)`).

### Buganizer Ticket
Fixes http://b/545136773 (under umbrella http://b/500350942)