### PR TITLE
fix(bigtable): remove heartbeat miss logging

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionImpl.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/internal/session/SessionImpl.java
@@ -538,8 +538,6 @@ public class SessionImpl implements Session, VRpcSessionApi {
       return;
     }
     if (clock.instant().isAfter(nextHeartbeat)) {
-      logger.warning(
-          String.format("Missed heartbeat for %s, forcing session close", info.getLogName()));
       forceClose(MISSED_HEARTBEAT_CLOSE_REQUEST);
       return;
     }


### PR DESCRIPTION
We already capture heartbeat closes in close reason. So this is visible from server side metrics. Logging warning could spam application logs. 