### PR TITLE
fix(spanner): Add credential check for built-in metrics enabling

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/SpannerOptions.java
@@ -2729,7 +2729,7 @@ public class SpannerOptions extends ServiceOptions<Spanner, SpannerOptions> {
     // records each instrument once per GrpcOpenTelemetry instance, so wiring two instances onto one
     // channel does not double-count attempt/operation metrics (verified by
     // GrpcMetricsDualWireTest).
-    if (isEnableBuiltInMetrics()) {
+    if (isEnableBuiltInMetrics() && !usesNoCredentials()) {
       this.builtInMetricsProvider.enableGrpcMetrics(
           channelProviderBuilder,
           this.getProjectId(),


### PR DESCRIPTION

Issue: The original logic for checking whether to enable built-in metrics (enableBuiltInMetrics) lacked a credential check. This caused telemetry data to still be sent when using the Spanner emulator, which does not require credentials.

Solution: In the enableRPCMetrics method, update the condition to isEnableBuiltInMetrics() && !usesNoCredentials(), so that metric collection is properly skipped when a credential-free environment (such as the emulator) is detected.

[issues 12277: Disable native metrics in connection](https://github.com/googleapis/google-cloud-java/issues/12277)

[issues 13038: Do not print exceptions from metric export failures by default](https://github.com/googleapis/google-cloud-java/issues/13038)