### PR TITLE
fix(samples): align native profile junit and surefire versions with shared config

### DIFF
--- a/java-samples/native-image-sample/pom.xml
+++ b/java-samples/native-image-sample/pom.xml
@@ -83,7 +83,6 @@
 
     <profiles>
         <!-- Native Profile-->
-        <!-- TODO(10840): Use maven properties to track versions once https://github.com/googleapis/java-shared-config/pull/824 is merged. -->
         <profile>
             <id>native</id>
 
@@ -91,12 +90,12 @@
                 <dependency>
                     <groupId>org.opentest4j</groupId>
                     <artifactId>opentest4j</artifactId>
-                    <version>1.3.0</version>
+                    <version>${opentest4j.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.junit.vintage</groupId>
                     <artifactId>junit-vintage-engine</artifactId>
-                    <version>5.14.4</version>
+                    <version>${junit-vintage-engine.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -106,12 +105,12 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.2.5</version>
+                        <version>${surefire.version}</version>
                         <dependencies>
                             <dependency>
                                 <groupId>org.junit.vintage</groupId>
                                 <artifactId>junit-vintage-engine</artifactId>
-                                <version>5.14.4</version>
+                                <version>${junit-vintage-engine.version}</version>
                             </dependency>
                         </dependencies>
                         <configuration>


### PR DESCRIPTION
## Description
In `java-samples/native-image-sample/pom.xml`, the `<id>native</id>` profile hardcoded `junit-vintage-engine` version `5.14.4` and `maven-surefire-plugin` version `3.2.5`. Version `5.14.4` caused JUnit Platform classloader incompatibility errors (`ClassNotFoundException: org.junit.platform.commons.support.scanning.ClassFilter`), resulting in `TestEngine with ID 'junit-vintage' failed to discover tests` during surefire test execution in native runs.

This change:
- Replaces the hardcoded versions with inherited properties defined in `native-image-shared-config`:
  - `${junit-vintage-engine.version}`
  - `${surefire.version}`
  - `${opentest4j.version}`
- Removes the completed `TODO(10840)` comment.