### PR TITLE
build: centralize quick-build profile in java-shared-config

### DIFF
--- a/google-cloud-pom-parent/pom.xml
+++ b/google-cloud-pom-parent/pom.xml
@@ -62,23 +62,6 @@
 
   <profiles>
     <profile>
-      <!-- skips all plugins that would have been activated by the Maven lifecycle -->
-      <id>quick-build</id>
-      <properties>
-        <checkstyle.skip>true</checkstyle.skip>
-        <enforcer.skip>true</enforcer.skip>
-        <jacoco.skip>true</jacoco.skip>
-        <clirr.skip>true</clirr.skip>
-        <spotbugs.skip>true</spotbugs.skip>
-        <pmd.skip>true</pmd.skip>
-        <animal.sniffer.skip>true</animal.sniffer.skip>
-        <fmt.skip>true</fmt.skip>
-        <flatten.skip>true</flatten.skip>
-        <mdep.analyze.skip>true</mdep.analyze.skip>
-        <shade.skip>true</shade.skip>
-      </properties>
-    </profile>
-    <profile>
       <!-- Only run checkstyle plugin on Java 11+ (checkstyle artifact only supports Java 11+) -->
       <id>checkstyle-tests</id>
       <activation>

--- a/java-shared-config/java-shared-config/pom.xml
+++ b/java-shared-config/java-shared-config/pom.xml
@@ -29,6 +29,9 @@
     <auto-value.version>1.11.0</auto-value.version>
     <docRoot>/java/docs/reference/</docRoot>
     <google-java-format.version>1.25.2</google-java-format.version>
+    <!-- maven-shade-plugin does not define a built-in user property for its skip parameter;
+         shade.skip is declared here and mapped in shaded modules to allow quick-build to toggle it off. -->
+    <shade.skip>false</shade.skip>
   </properties>
 
   <build>
@@ -482,6 +485,23 @@
           </snapshots>
         </repository>
       </repositories>
+    </profile>
+    <profile>
+      <!-- skips all plugins that would have been activated by the Maven lifecycle -->
+      <id>quick-build</id>
+      <properties>
+        <checkstyle.skip>true</checkstyle.skip>
+        <enforcer.skip>true</enforcer.skip>
+        <jacoco.skip>true</jacoco.skip>
+        <clirr.skip>true</clirr.skip>
+        <spotbugs.skip>true</spotbugs.skip>
+        <pmd.skip>true</pmd.skip>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+        <fmt.skip>true</fmt.skip>
+        <flatten.skip>true</flatten.skip>
+        <mdep.analyze.skip>true</mdep.analyze.skip>
+        <shade.skip>true</shade.skip>
+      </properties>
     </profile>
     <profile>
       <!-- Only run checkstyle plugin on Java 11+ (checkstyle artifact only supports Java 11+) -->

--- a/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
+++ b/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
@@ -82,23 +82,6 @@
 
   <profiles>
     <profile>
-      <!-- skips all plugins that would have been activated by the Maven lifecycle -->
-      <id>quick-build</id>
-      <properties>
-        <checkstyle.skip>true</checkstyle.skip>
-        <enforcer.skip>true</enforcer.skip>
-        <jacoco.skip>true</jacoco.skip>
-        <clirr.skip>true</clirr.skip>
-        <spotbugs.skip>true</spotbugs.skip>
-        <pmd.skip>true</pmd.skip>
-        <animal.sniffer.skip>true</animal.sniffer.skip>
-        <fmt.skip>true</fmt.skip>
-        <flatten.skip>true</flatten.skip>
-        <mdep.analyze.skip>true</mdep.analyze.skip>
-      </properties>
-    </profile>
-
-    <profile>
       <!-- Only run checkstyle plugin on Java 11+ (checkstyle artifact only supports Java 11+) -->
       <id>checkstyle-tests</id>
       <activation>


### PR DESCRIPTION
Move the quick-build profile to shared-configs so that it can be used for all modules in the monorepo. Should be properly inherited by all the modules as it's the top level config for everything in the monorepo.