### PR TITLE
fix(gax-httpjson): remove unsupported and deprecated PQC named groups

### DIFF
--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonConscryptUtils.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonConscryptUtils.java
@@ -48,7 +48,6 @@ public class HttpJsonConscryptUtils {
    *
    * <ol>
    *   <li><b>Standard ML-KEM algorithms</b>: Prioritized first for quantum resistance.
-   *   <li><b>Draft Kyber algorithms</b>: Retained as a fallback for legacy draft PQC deployments.
    *   <li><b>Classical curves</b>: Fallback for endpoints without PQC support.
    * </ol>
    *
@@ -59,17 +58,8 @@ public class HttpJsonConscryptUtils {
    * href="https://github.com/google/conscrypt/blob/2.6.0/CAPABILITIES.md">Conscrypt
    * CAPABILITIES.md</a>.
    */
-  public static final String[] DEFAULT_CONSCRYPT_NAMED_GROUPS =
-      new String[] {
-        "X25519MLKEM768",
-        "SecP256r1MLKEM768",
-        "MLKEM1024",
-        "MLKEM768",
-        "X25519Kyber768Draft00",
-        "X25519",
-        "secp256r1",
-        "secp384r1"
-      };
+  static final String[] DEFAULT_CONSCRYPT_NAMED_GROUPS =
+      new String[] {"X25519MLKEM768", "MLKEM1024", "X25519", "secp256r1", "secp384r1"};
 
   /**
    * Lazy initialization holder for Conscrypt {@link Provider}.

--- a/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonConscryptUtilsTest.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonConscryptUtilsTest.java
@@ -31,6 +31,7 @@ package com.google.api.gax.httpjson;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.client.http.javanet.NetHttpTransport;
 import java.security.Provider;
 import org.junit.jupiter.api.Test;
 
@@ -42,5 +43,21 @@ class HttpJsonConscryptUtilsTest {
     if (provider != null) {
       assertThat(provider.getName()).isEqualTo("Conscrypt");
     }
+  }
+
+  @Test
+  void testConfigureConscryptSecurityProvider() {
+    NetHttpTransport.Builder builder = new NetHttpTransport.Builder();
+    NetHttpTransport.Builder configured =
+        HttpJsonConscryptUtils.configureConscryptSecurityProvider(builder);
+    assertThat(configured).isSameInstanceAs(builder);
+  }
+
+  @Test
+  void testDefaultConscryptNamedGroups_containsExpectedGroups() {
+    assertThat(HttpJsonConscryptUtils.DEFAULT_CONSCRYPT_NAMED_GROUPS)
+        .asList()
+        .containsExactly("X25519MLKEM768", "MLKEM1024", "X25519", "secp256r1", "secp384r1")
+        .inOrder();
   }
 }


### PR DESCRIPTION
### Description
Removes unsupported and deprecated named groups (`X25519Kyber768Draft00`, `SecP256r1MLKEM768`, `MLKEM768`) from `DEFAULT_CONSCRYPT_NAMED_GROUPS` in `HttpJsonConscryptUtils.java`.

- `X25519Kyber768Draft00` was a pre-standardization draft Kyber-768 curve removed in newer BoringSSL versions (https://boringssl-review.googlesource.com/c/boringssl/+/99147). Conscrypt uses BoringSSL under the hood and  removing it from the default groups prevents native BoringSSL `SSL_set1_groups` lookup failures and `SSLHandshakeException: Error parsing groups`.
- `SecP256r1MLKEM768` and `MLKEM768` are unsupported named group strings unrecognized by Conscrypt (https://github.com/google/conscrypt/blob/master/CAPABILITIES.md#supported-named-groups). This is only used in Conscrypt and will not be used by the JDK TLS fallback.