### PR TITLE
ci: add retries and timeout to xmllint installation steps

### DIFF
--- a/.github/workflows/java-shared-config-downstream-dependencies.yaml
+++ b/.github/workflows/java-shared-config-downstream-dependencies.yaml
@@ -48,8 +48,15 @@ jobs:
         java-version: ${{matrix.java}}
         cache: maven
     - run: java -version
-    - run: sudo apt-get update -y
-    - run: sudo apt-get install libxml2-utils
+    - name: Install xmllint
+      timeout-minutes: 5
+      run: |
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        for i in {1..3}; do
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+          break || sleep 5
+        done
     - name: Install java-shared-dependencies and common dependencies
       run: |
         .kokoro/build.sh
@@ -88,8 +95,15 @@ jobs:
         java-version: 11
         cache: maven
     - run: java -version
-    - run: sudo apt-get update -y
-    - run: sudo apt-get install libxml2-utils
+    - name: Install xmllint
+      timeout-minutes: 5
+      run: |
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        for i in {1..3}; do
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+          break || sleep 5
+        done
     - name: Install java-shared-dependencies and common dependencies
       run: |
         .kokoro/build.sh

--- a/.github/workflows/java-shared-config-downstream-dependencies.yaml
+++ b/.github/workflows/java-shared-config-downstream-dependencies.yaml
@@ -51,7 +51,8 @@ jobs:
     - name: Install xmllint
       timeout-minutes: 5
       run: |
-        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+        # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
         for i in {1..3}; do
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
@@ -98,7 +99,8 @@ jobs:
     - name: Install xmllint
       timeout-minutes: 5
       run: |
-        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+        # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
         for i in {1..3}; do
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \

--- a/.github/workflows/java-shared-config-downstream-maven-plugins.yaml
+++ b/.github/workflows/java-shared-config-downstream-maven-plugins.yaml
@@ -72,7 +72,8 @@ jobs:
     - name: Install xmllint
       timeout-minutes: 5
       run: |
-        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+        # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
         for i in {1..3}; do
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
@@ -106,7 +107,8 @@ jobs:
     - name: Install xmllint
       timeout-minutes: 5
       run: |
-        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+        # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
         for i in {1..3}; do
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
@@ -168,7 +170,8 @@ jobs:
     - name: Install xmllint
       timeout-minutes: 5
       run: |
-        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+        # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
         for i in {1..3}; do
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \

--- a/.github/workflows/java-shared-config-downstream-maven-plugins.yaml
+++ b/.github/workflows/java-shared-config-downstream-maven-plugins.yaml
@@ -69,8 +69,15 @@ jobs:
         java-version: ${{matrix.java}}
         cache: maven
     - run: java -version
-    - run: sudo apt-get update -y
-    - run: sudo apt-get install libxml2-utils
+    - name: Install xmllint
+      timeout-minutes: 5
+      run: |
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        for i in {1..3}; do
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+          break || sleep 5
+        done
     - run: .kokoro/client-library-check.sh ${{matrix.repo}} ${{matrix.job-type}}
   lint:
     needs: filter
@@ -96,8 +103,15 @@ jobs:
         java-version: ${{matrix.java}}
         cache: maven
     - run: java -version
-    - run: sudo apt-get update -y
-    - run: sudo apt-get install libxml2-utils
+    - name: Install xmllint
+      timeout-minutes: 5
+      run: |
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        for i in {1..3}; do
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+          break || sleep 5
+        done
     - name: Install java-shared-dependencies and common dependencies
       run: |
         .kokoro/build.sh
@@ -151,8 +165,15 @@ jobs:
         java-version: 17
         cache: maven
     - run: java -version
-    - run: sudo apt-get update -y
-    - run: sudo apt-get install libxml2-utils
+    - name: Install xmllint
+      timeout-minutes: 5
+      run: |
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        for i in {1..3}; do
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+          break || sleep 5
+        done
     - name: Install java-shared-dependencies and common dependencies
       run: |
         .kokoro/build.sh

--- a/.github/workflows/sdk-platform-java-downstream.yaml
+++ b/.github/workflows/sdk-platform-java-downstream.yaml
@@ -54,7 +54,8 @@ jobs:
       - name: Install xmllint
         timeout-minutes: 5
         run: |
-          # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+          # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+          # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
           for i in {1..3}; do
             sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
             sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
@@ -84,7 +85,8 @@ jobs:
       - name: Install xmllint
         timeout-minutes: 5
         run: |
-          # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+          # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+          # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
           for i in {1..3}; do
             sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
             sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \

--- a/.github/workflows/sdk-platform-java-downstream.yaml
+++ b/.github/workflows/sdk-platform-java-downstream.yaml
@@ -52,9 +52,14 @@ jobs:
           cache: maven
       - run: mvn -version
       - name: Install xmllint
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get -y install libxml2-utils
+          # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+          for i in {1..3}; do
+            sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+            sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+            break || sleep 5
+          done
       - name: Test helper scripts
         run: .kokoro/common_test.sh
       - name: Perform downstream compatibility testing
@@ -77,9 +82,14 @@ jobs:
           cache: maven
       - run: mvn -version
       - name: Install xmllint
+        timeout-minutes: 5
         run: |
-          sudo apt-get update
-          sudo apt-get -y install libxml2-utils
+          # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+          for i in {1..3}; do
+            sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+            sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+            break || sleep 5
+          done
       - name: Perform downstream compatibility testing
         run: .kokoro/downstream-compatibility-spring.sh
   required:

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -45,7 +45,8 @@ jobs:
     - name: Install xmllint
       timeout-minutes: 5
       run: |
-        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout.
+        # Retries protect against transient network glitches, mirror timeouts, and apt lock contention on runner startup.
         for i in {1..3}; do
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
           sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -42,8 +42,15 @@ jobs:
       github.repository_owner == 'googleapis' && github.head_ref == 'release-please--branches--main' &&
       !endsWith(github.event.pull_request.title, 'SNAPSHOT')
     steps:
-    - run: sudo apt-get update -y
-    - run: sudo apt-get install libxml2-utils
+    - name: Install xmllint
+      timeout-minutes: 5
+      run: |
+        # Retry apt-get update and install up to 3 times with a 15-second per-request timeout
+        for i in {1..3}; do
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 update && \
+          sudo apt-get -o Acquire::http::Timeout="15" -o Acquire::Retries=3 -y install libxml2-utils && \
+          break || sleep 5
+        done
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         persist-credentials: false


### PR DESCRIPTION
Looks like there is no timeout configured so it just runs forever
<img width="2736" height="1036" alt="image" src="https://github.com/user-attachments/assets/1c5db117-e9fa-4f0f-bb4b-8d6b7593df7e" />

From https://github.com/googleapis/google-cloud-java/actions/runs/32165713748/job/95805191802?pr=14106
