### PR TITLE
deps(gax-httpjson): upgrade conscrypt-openjdk-uber to 2.6.2

### DIFF
--- a/.kokoro/java-storage-expected-flattened-dependencies.txt
+++ b/.kokoro/java-storage-expected-flattened-dependencies.txt
@@ -80,7 +80,7 @@ org.apache.httpcomponents:httpcore:jar:4.4.16:compile
 org.checkerframework:checker-qual:jar:3.49.0:compile
 org.codehaus.mojo:animal-sniffer-annotations:jar:1.27:compile
 org.codehaus.woodstox:stax2-api:jar:4.2.2:compile
-org.conscrypt:conscrypt-openjdk-uber:jar:2.6.0:compile
+org.conscrypt:conscrypt-openjdk-uber:jar:2.6.2:compile
 org.jspecify:jspecify:jar:1.0.0:compile
 org.slf4j:slf4j-api:jar:2.0.16:compile
 org.threeten:threetenbp:jar:1.7.0:compile

--- a/java-cloud-bom/README.md
+++ b/java-cloud-bom/README.md
@@ -49,7 +49,7 @@ This is the table of modules included in the latest libraries-bom release:
 | Artifact ID | Library Type | Google Cloud Library Reference | Google Cloud Product Reference | 
 | --------- | ------------ | ------------ | ------------ |
 | api-common | Runtime | [2.66.0](https://cloud.google.com/java/docs/reference/api-common/latest/overview) | N/A |
-| conscrypt-openjdk-uber | Product | [2.6.0](https://cloud.google.com/java/docs/reference/conscrypt-openjdk-uber/latest/overview) | N/A |
+| conscrypt-openjdk-uber | Product | [2.6.2](https://cloud.google.com/java/docs/reference/conscrypt-openjdk-uber/latest/overview) | N/A |
 | gax | Runtime | [2.83.0](https://cloud.google.com/java/docs/reference/gax/latest/overview) | N/A |
 | google-analytics-admin | Product | [0.105.0](https://cloud.google.com/java/docs/reference/google-analytics-admin/latest/overview) | [Analytics Admin](https://developers.google.com/analytics) |
 | google-analytics-data | Product | [0.106.0](https://cloud.google.com/java/docs/reference/google-analytics-data/latest/overview) | [Analytics Data](https://developers.google.com/analytics/trusted-testing/analytics-data) |

--- a/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITPostQuantumCryptography.java
+++ b/java-showcase/gapic-showcase/src/test/java/com/google/showcase/v1beta1/it/ITPostQuantumCryptography.java
@@ -152,7 +152,7 @@ class ITPostQuantumCryptography {
       // Go's crypto/tls library only recognizes standard Curve IDs (e.g. X25519MLKEM768 and
       // X25519), which is not a 1:1 mapping with the full list of named groups that Conscrypt
       // supports (see
-      // https://github.com/google/conscrypt/blob/2.6.0/CAPABILITIES.md#supported-named-groups).
+      // https://github.com/google/conscrypt/blob/2.6.2/CAPABILITIES.md#supported-named-groups).
       // Draft/standalone groups like X25519Kyber768Draft00 and MLKEM1024 are formatted as
       // "Unknown-Curve-25497" and "Unknown-Curve-514" by the Showcase server.
       List<String> supportedGroups =

--- a/sdk-platform-java/dependencies.txt
+++ b/sdk-platform-java/dependencies.txt
@@ -21,7 +21,7 @@ com.google.j2objc:j2objc-annotations,j2objc-annotations=3.1
 org.threeten:threetenbp,threetenbp=1.7.3
 org.slf4j:slf4j-api,slf4j=2.0.18
 org.jspecify:jspecify,jspecify=1.0.0
-org.conscrypt:conscrypt-openjdk-uber,conscrypt=2.6.1
+org.conscrypt:conscrypt-openjdk-uber,conscrypt=2.6.2
 
 # 1P Shared-Deps
 # These dependencies are declared: https://github.com/googleapis/google-cloud-java/blob/main/sdk-platform-java/java-shared-dependencies/first-party-dependencies/pom.xml

--- a/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
+++ b/sdk-platform-java/gapic-generator-java-pom-parent/pom.xml
@@ -41,7 +41,7 @@
     <mockito.version>4.11.0</mockito.version>
     <awaitility.version>4.3.0</awaitility.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <conscrypt.version>2.6.0</conscrypt.version>
+    <conscrypt.version>2.6.2</conscrypt.version>
     <!--  skipping clirr check for protobuf 4.x upgrade -->
     <clirr.skip>true</clirr.skip>
     <ignoreNonCompile>true</ignoreNonCompile><!-- maven-dependency-plugin:analyze to skip test scope dependencies -->

--- a/sdk-platform-java/gax-java/dependencies.properties
+++ b/sdk-platform-java/gax-java/dependencies.properties
@@ -79,7 +79,7 @@ maven.javax_annotation_javax_annotation_api=javax.annotation:javax.annotation-ap
 maven.org_graalvm_sdk=org.graalvm.sdk:nativeimage:24.1.2
 maven.org_slf4j_slf4j_api=org.slf4j:slf4j-api:2.0.16
 maven.com_google_protobuf_protobuf_java_util=com.google.protobuf:protobuf-java-util:3.25.5
-maven.org_conscrypt_conscrypt_openjdk_uber=org.conscrypt:conscrypt-openjdk-uber:2.6.0
+maven.org_conscrypt_conscrypt_openjdk_uber=org.conscrypt:conscrypt-openjdk-uber:2.6.2
 
 # Testing maven artifacts
 maven.org_jspecify_jspecify=org.jspecify:jspecify:1.0.0

--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonConscryptUtils.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonConscryptUtils.java
@@ -55,7 +55,7 @@ public class HttpJsonConscryptUtils {
    * ClientHello extension in preference order. The server selects the first group it supports.
    *
    * <p>For details on Conscrypt's supported TLS algorithms, see <a
-   * href="https://github.com/google/conscrypt/blob/2.6.0/CAPABILITIES.md">Conscrypt
+   * href="https://github.com/google/conscrypt/blob/2.6.2/CAPABILITIES.md">Conscrypt
    * CAPABILITIES.md</a>.
    */
   static final String[] DEFAULT_CONSCRYPT_NAMED_GROUPS =


### PR DESCRIPTION
## Description
Upgrade `org.conscrypt:conscrypt-openjdk-uber` from `2.6.0` to `2.6.2`.

Conscrypt 2.6.2 compiles native binaries against an older glibc baseline, improving compatibility across older Linux environments and test frameworks like Robolectric (see https://github.com/robolectric/robolectric/issues/11362).

Error:
```
Exception: java.lang.UnsatisfiedLinkError: /tmp/libconscrypt_openjdk_jni-linux-x86_6417845320266820000.so: /lib64/libc.so.6: version `GLIBC_2.35' not found (required by /tmp/libconscrypt_openjdk_jni-linux-x86_6417845320266820000.so)
```

## Changes
- Bump `conscrypt.version` to `2.6.2` in `sdk-platform-java/gapic-generator-java-pom-parent/pom.xml`
- Update Conscrypt version to `2.6.2` in `sdk-platform-java/gax-java/dependencies.properties`
- Update Conscrypt version to `2.6.2` in `sdk-platform-java/dependencies.txt`
- Update expected downstream version in `.kokoro/java-storage-expected-flattened-dependencies.txt`
- Update version reference in `java-cloud-bom/README.md`
- Update Conscrypt capabilities doc links in `HttpJsonConscryptUtils.java` and `ITPostQuantumCryptography.java`