### PR TITLE
 refactor(gax): add constructor to HttpJsonStatusRuntimeException

### DIFF
--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCallImpl.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonClientCallImpl.java
@@ -212,7 +212,7 @@ final class HttpJsonClientCallImpl<RequestT, ResponseT>
           StatusCode.Code.DEADLINE_EXCEEDED.getHttpStatusCode(),
           "Deadline exceeded",
           new HttpJsonStatusRuntimeException(
-              StatusCode.Code.DEADLINE_EXCEEDED.getHttpStatusCode(), "Deadline exceeded", null),
+              StatusCode.Code.DEADLINE_EXCEEDED.getHttpStatusCode(), "Deadline exceeded"),
           true);
     }
 

--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusRuntimeException.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonStatusRuntimeException.java
@@ -42,6 +42,11 @@ public class HttpJsonStatusRuntimeException extends RuntimeException {
 
   private final int statusCode;
 
+  public HttpJsonStatusRuntimeException(int statusCode, String message) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+
   public HttpJsonStatusRuntimeException(int statusCode, String message, Throwable cause) {
     super(message, cause);
     this.statusCode = statusCode;


### PR DESCRIPTION
The exception class is NullMarked but needs to be constructed without a cause (once in the existing codebase with a null cause, with more expected with upcoming resumable upload support). Adding a separate constructor makes this cleaner and compatible with nullability checks.