### PR TITLE
feat(gax): implement startUploadCallable for resumable uploads

### DIFF
--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClient.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClient.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.resumable.ResumableUploadClient;
+import com.google.api.gax.resumable.ResumableUploadSession;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.base.Preconditions;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Implementation of {@link ResumableUploadClient} using HTTP/JSON transport.
+ *
+ * <p>Executes the low-level HTTP wire calls for managing resumable upload sessions.
+ *
+ * @param <RequestT> request type for starting an upload
+ * @param <ResponseT> response type of the upload method
+ */
+@NullMarked
+@BetaApi
+@InternalApi
+public final class HttpJsonResumableUploadClient<RequestT, ResponseT>
+    implements ResumableUploadClient<RequestT, ResponseT> {
+
+  private final UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable;
+
+  public static <RequestT, ResponseT> HttpJsonResumableUploadClient<RequestT, ResponseT> create(
+      ClientContext clientContext, ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor) {
+    return new HttpJsonResumableUploadClient<>(clientContext, methodDescriptor);
+  }
+
+  private HttpJsonResumableUploadClient(
+      ClientContext clientContext, ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor) {
+    Preconditions.checkNotNull(clientContext);
+    Preconditions.checkNotNull(methodDescriptor);
+
+    ApiMethodDescriptor<RequestT, String> startUploadDescriptor =
+        ApiMethodDescriptor.<RequestT, String>newBuilder()
+            .setFullMethodName(methodDescriptor.getFullMethodName())
+            .setHttpMethod(HttpMethods.POST)
+            .setType(ApiMethodDescriptor.MethodType.UNARY)
+            .setRequestFormatter(methodDescriptor.getRequestFormatter())
+            .setResponseParser(ResumableUploadResponseParser.create())
+            .build();
+    this.startUploadCallable =
+        ResumableUploadStartCallable.create(clientContext, startUploadDescriptor);
+  }
+
+  @Override
+  public UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable() {
+    return startUploadCallable;
+  }
+}

--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadHttpJsonFuture.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadHttpJsonFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -27,29 +27,37 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package com.google.api.gax.httpjson;
 
+import com.google.api.core.AbstractApiFuture;
+import com.google.api.core.ApiFuture;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /**
- * HTTP status code in RuntimeException form, for propagating status code information via
- * exceptions.
+ * An {@link ApiFuture} that cancels the underlying {@link HttpJsonClientCall} upon cancellation to
+ * prevent connection leaks.
  */
 @NullMarked
-public class HttpJsonStatusRuntimeException extends RuntimeException {
-  private static final long serialVersionUID = -5390915748330242256L;
+class ResumableUploadHttpJsonFuture<T> extends AbstractApiFuture<T> {
 
-  private final int statusCode;
+  private final HttpJsonClientCall<?, ?> call;
 
-  public HttpJsonStatusRuntimeException(
-      int statusCode, @Nullable String message, @Nullable Throwable cause) {
-    super(message, cause);
-    this.statusCode = statusCode;
+  ResumableUploadHttpJsonFuture(HttpJsonClientCall<?, ?> call) {
+    this.call = call;
   }
 
-  public int getStatusCode() {
-    return statusCode;
+  @Override
+  protected void interruptTask() {
+    call.cancel("Call was cancelled", null);
+  }
+
+  @Override
+  public boolean set(T value) {
+    return super.set(value);
+  }
+
+  @Override
+  public boolean setException(Throwable throwable) {
+    return super.setException(throwable);
   }
 }

--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadStartCallable.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadStartCallable.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.resumable.ResumableUploadSession;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/** A {@link UnaryCallable} that initiates a resumable upload session. */
+@NullMarked
+class ResumableUploadStartCallable<RequestT>
+    extends UnaryCallable<RequestT, ResumableUploadSession> {
+
+  private static final String UPLOAD_PROTOCOL_HEADER = "X-Goog-Upload-Protocol";
+  private static final String UPLOAD_COMMAND_HEADER = "X-Goog-Upload-Command";
+  private static final String UPLOAD_URL_HEADER = "X-Goog-Upload-URL";
+  private static final String UPLOAD_GRANULARITY_HEADER = "X-Goog-Upload-Chunk-Granularity";
+
+  private static final Map<String, List<String>> START_UPLOAD_HEADERS =
+      ImmutableMap.of(
+          UPLOAD_PROTOCOL_HEADER, ImmutableList.of("resumable"),
+          UPLOAD_COMMAND_HEADER, ImmutableList.of("start"));
+
+  private final ApiMethodDescriptor<RequestT, String> descriptor;
+  private final ClientContext clientContext;
+
+  private ResumableUploadStartCallable(
+      ClientContext clientContext, ApiMethodDescriptor<RequestT, String> descriptor) {
+    this.clientContext = Preconditions.checkNotNull(clientContext);
+    this.descriptor = Preconditions.checkNotNull(descriptor);
+  }
+
+  @Override
+  public ApiFuture<ResumableUploadSession> futureCall(
+      RequestT request, @Nullable ApiCallContext inputContext) {
+    Preconditions.checkNotNull(request);
+    HttpJsonCallContext context =
+        (HttpJsonCallContext)
+            HttpJsonCallContext.createDefault()
+                .nullToSelf(clientContext.getDefaultCallContext())
+                .merge(inputContext)
+                .withExtraHeaders(START_UPLOAD_HEADERS);
+
+    HttpJsonClientCall<RequestT, String> clientCall =
+        HttpJsonClientCalls.newCall(descriptor, context);
+
+    ResumableUploadHttpJsonFuture<ResumableUploadSession> future =
+        new ResumableUploadHttpJsonFuture<>(clientCall);
+    HttpJsonClientCalls.startUnaryCall(
+        clientCall, request, context, new StartUploadResponseListener(future));
+
+    return future;
+  }
+
+  static <RequestT> UnaryCallable<RequestT, ResumableUploadSession> create(
+      ClientContext clientContext, ApiMethodDescriptor<RequestT, String> descriptor) {
+    UnaryCallable<RequestT, ResumableUploadSession> rawCallable =
+        new ResumableUploadStartCallable<>(clientContext, descriptor);
+    UnaryCallable<RequestT, ResumableUploadSession> callable =
+        new HttpJsonExceptionCallable<>(
+            rawCallable,
+            // Wire calls do not retry directly; retries are managed by ResumableUploadCallable.
+            Collections.emptySet());
+    return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  /** A listener that parses HTTP response headers to produce a {@link ResumableUploadSession}. */
+  private static class StartUploadResponseListener extends HttpJsonClientCall.Listener<String> {
+    private final ResumableUploadHttpJsonFuture<ResumableUploadSession> future;
+    private long chunkGranularity = 1L;
+    @Nullable private String uploadUrl;
+    @Nullable private Throwable headerParsingException;
+
+    private StartUploadResponseListener(
+        ResumableUploadHttpJsonFuture<ResumableUploadSession> future) {
+      this.future = future;
+    }
+
+    @Override
+    public void onHeaders(HttpJsonMetadata responseHeaders) {
+      Map<String, Object> headers = responseHeaders.getHeaders();
+
+      String url = HttpHeadersUtils.getSingleHeader(headers, UPLOAD_URL_HEADER);
+      if (!Strings.isNullOrEmpty(url)) {
+        this.uploadUrl = url;
+      }
+
+      String granularityStr = HttpHeadersUtils.getSingleHeader(headers, UPLOAD_GRANULARITY_HEADER);
+      if (Strings.isNullOrEmpty(granularityStr)) {
+        return;
+      }
+
+      try {
+        long parsed = Long.parseLong(granularityStr);
+        if (parsed <= 0) {
+          this.headerParsingException =
+              ApiExceptionFactory.createException(
+                  "Start upload response contained non-positive chunk granularity header: "
+                      + granularityStr,
+                  /* cause= */ null,
+                  HttpJsonStatusCode.of(StatusCode.Code.INTERNAL),
+                  /* retryable= */ false);
+        } else {
+          this.chunkGranularity = parsed;
+        }
+      } catch (NumberFormatException e) {
+        this.headerParsingException =
+            ApiExceptionFactory.createException(
+                "Start upload response contained invalid chunk granularity header: "
+                    + granularityStr,
+                e,
+                HttpJsonStatusCode.of(StatusCode.Code.INTERNAL),
+                /* retryable= */ false);
+      }
+    }
+
+    @Override
+    public void onMessage(@Nullable String message) {
+      // Response body is not needed for startUpload; session URL is in headers.
+    }
+
+    @Override
+    public void onClose(int statusCode, HttpJsonMetadata trailers) {
+      try {
+        if (statusCode >= 200 && statusCode < 300) {
+          if (headerParsingException != null) {
+            future.setException(headerParsingException);
+            return;
+          }
+          if (!Strings.isNullOrEmpty(uploadUrl)) {
+            future.set(
+                ResumableUploadSession.newBuilder()
+                    .setUploadUrl(uploadUrl)
+                    .setChunkGranularity(chunkGranularity)
+                    .build());
+          } else {
+            future.setException(
+                ApiExceptionFactory.createException(
+                    "Start upload response did not contain upload session URL header",
+                    /* cause= */ null,
+                    HttpJsonStatusCode.of(StatusCode.Code.INTERNAL),
+                    /* retryable= */ false));
+          }
+        } else {
+          Throwable cause = trailers.getException();
+          future.setException(
+              cause != null
+                  ? cause
+                  : new HttpJsonStatusRuntimeException(
+                      statusCode, "Failed to start upload with status code: " + statusCode, null));
+        }
+      } catch (Throwable t) {
+        future.setException(t);
+      }
+    }
+  }
+}

--- a/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClientTest.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClientTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.resumable.ResumableUploadSession;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.InternalException;
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.common.base.Strings;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@InternalApi
+class HttpJsonResumableUploadClientTest {
+
+  private static final String TEST_UPLOAD_URL =
+      "https://test.googleapis.com/upload/session/test-session-id";
+
+  private static ExecutorService executorService;
+
+  @BeforeAll
+  static void setUp() {
+    executorService = Executors.newFixedThreadPool(2);
+  }
+
+  @AfterAll
+  static void tearDown() {
+    executorService.shutdownNow();
+  }
+
+  @Test
+  void startUpload_validHeaders_returnsSession() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-URL", TEST_UPLOAD_URL);
+    httpResponse.addHeader("X-Goog-Upload-Chunk-Granularity", "262144");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    TestRequest request = new TestRequest("upload/v1/resources");
+
+    ResumableUploadSession session = client.startUploadCallable().call(request);
+
+    assertThat(session.getUploadUrl()).isEqualTo(TEST_UPLOAD_URL);
+    assertThat(session.getChunkGranularity()).isEqualTo(262144L);
+  }
+
+  @Test
+  void startUpload_caseInsensitiveHeaders_returnsSession() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader(
+        "x-goog-upload-url", "https://test.googleapis.com/upload/session/case-insensitive");
+    httpResponse.addHeader("x-goog-upload-chunk-granularity", "524288");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    TestRequest request = new TestRequest("upload/v1/resources");
+
+    ResumableUploadSession session = client.startUploadCallable().call(request);
+
+    assertThat(session.getUploadUrl())
+        .isEqualTo("https://test.googleapis.com/upload/session/case-insensitive");
+    assertThat(session.getChunkGranularity()).isEqualTo(524288L);
+  }
+
+  @Test
+  void startUpload_malformedChunkGranularityHeader_throwsException() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-URL", TEST_UPLOAD_URL);
+    httpResponse.addHeader("X-Goog-Upload-Chunk-Granularity", "not-a-number");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    TestRequest request = new TestRequest("upload/v1/resources");
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.startUploadCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(InternalException.class);
+    assertThat(exception.getCause().getCause()).isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  void startUpload_nonPositiveChunkGranularityHeader_throwsException() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-URL", TEST_UPLOAD_URL);
+    httpResponse.addHeader("X-Goog-Upload-Chunk-Granularity", "-256");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    TestRequest request = new TestRequest("upload/v1/resources");
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.startUploadCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(InternalException.class);
+    assertThat(exception.getCause())
+        .hasMessageThat()
+        .contains("Start upload response contained non-positive chunk granularity header: -256");
+  }
+
+  @Test
+  void startUpload_missingSessionUrlHeader_throwsException() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Chunk-Granularity", "262144");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    TestRequest request = new TestRequest("upload/v1/resources");
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.startUploadCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(InternalException.class);
+    assertThat(exception.getCause())
+        .hasMessageThat()
+        .contains("Start upload response did not contain upload session URL header");
+  }
+
+  @Test
+  void startUpload_withPayloadAndQueryParams_sendsCorrectRequest() {
+    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+    response.setStatusCode(200);
+    response.addHeader("X-Goog-Upload-URL", TEST_UPLOAD_URL);
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(response);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+
+    Map<String, List<String>> queryParams =
+        Collections.singletonMap("uploadType", Collections.singletonList("resumable"));
+    TestRequest request =
+        new TestRequest("upload/v1/resources", "{\"name\":\"my-resource.txt\"}", queryParams);
+
+    client.startUploadCallable().call(request);
+
+    assertThat(transport.capturedUrl)
+        .isEqualTo("https://test.googleapis.com/upload/v1/resources?uploadType=resumable");
+    assertThat(transport.capturedContent).isEqualTo("{\"name\":\"my-resource.txt\"}");
+    assertThat(transport.capturedHeaders.get("x-goog-upload-protocol"))
+        .containsExactly("resumable");
+    assertThat(transport.capturedHeaders.get("x-goog-upload-command")).containsExactly("start");
+  }
+
+  @Test
+  void startUpload_serverReturnsError_throwsApiException() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(404);
+    httpResponse.setContent("{\"error\":{\"message\":\"Resource not found\"}}");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    TestRequest request = new TestRequest("upload/v1/nonexistent");
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.startUploadCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(NotFoundException.class);
+    NotFoundException notFoundException = (NotFoundException) exception.getCause();
+    assertThat(notFoundException.getStatusCode().getCode()).isEqualTo(StatusCode.Code.NOT_FOUND);
+  }
+
+  @Test
+  void startUpload_withCustomExtraHeaders_preservesHeaders() {
+    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+    response.setStatusCode(200);
+    response.addHeader("X-Goog-Upload-URL", TEST_UPLOAD_URL);
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(response);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+
+    TestRequest request = new TestRequest("upload/v1/resources");
+    Map<String, List<String>> customHeaders =
+        Collections.singletonMap("X-Custom-Header", Collections.singletonList("CustomValue"));
+
+    ApiCallContext callContext =
+        HttpJsonCallContext.createDefault().withExtraHeaders(customHeaders);
+
+    client.startUploadCallable().call(request, callContext);
+
+    assertThat(transport.capturedHeaders.get("x-custom-header")).containsExactly("CustomValue");
+  }
+
+  private static HttpJsonResumableUploadClient<TestRequest, String> createClient(
+      HttpTransport transport) {
+    ManagedHttpJsonChannel channel =
+        ManagedHttpJsonChannel.newBuilder()
+            .setEndpoint("test.googleapis.com")
+            .setExecutor(executorService)
+            .setHttpTransport(transport)
+            .build();
+
+    ClientContext clientContext =
+        ClientContext.newBuilder()
+            .setTransportChannel(HttpJsonTransportChannel.create(channel))
+            .setDefaultCallContext(HttpJsonCallContext.createDefault().withChannel(channel))
+            .build();
+
+    return HttpJsonResumableUploadClient.create(clientContext, TEST_METHOD_DESCRIPTOR);
+  }
+
+  private static HttpJsonResumableUploadClient<TestRequest, String> createClient(
+      MockLowLevelHttpResponse response) {
+    return createClient(new MockHttpTransport.Builder().setLowLevelHttpResponse(response).build());
+  }
+
+  /** A mock transport that captures request URL, headers, and body for verification. */
+  private static class CapturingHttpTransport extends MockHttpTransport {
+    private final MockLowLevelHttpResponse response;
+    final Map<String, List<String>> capturedHeaders = new HashMap<>();
+    @Nullable String capturedUrl;
+    @Nullable String capturedContent;
+
+    CapturingHttpTransport(MockLowLevelHttpResponse response) {
+      this.response = response;
+    }
+
+    @Override
+    public LowLevelHttpRequest buildRequest(String method, String url) {
+      this.capturedUrl = url;
+      return new MockLowLevelHttpRequest() {
+        @Override
+        public LowLevelHttpResponse execute() throws IOException {
+          capturedHeaders.putAll(getHeaders());
+          capturedContent = getContentAsString();
+          return response;
+        }
+      };
+    }
+  }
+
+  private static final ApiMethodDescriptor<TestRequest, String> TEST_METHOD_DESCRIPTOR =
+      ApiMethodDescriptor.<TestRequest, String>newBuilder()
+          .setFullMethodName("ResumableUpload/StartUpload")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              new HttpRequestFormatter<TestRequest>() {
+                @Override
+                public Map<String, List<String>> getQueryParamNames(TestRequest request) {
+                  return request.queryParams;
+                }
+
+                @Override
+                public String getRequestBody(TestRequest request) {
+                  return Strings.nullToEmpty(request.jsonPayload);
+                }
+
+                @Override
+                public String getPath(TestRequest request) {
+                  return request.path;
+                }
+
+                @Override
+                public PathTemplate getPathTemplate() {
+                  return PathTemplate.create("**");
+                }
+              })
+          .setResponseParser(ResumableUploadResponseParser.create())
+          .build();
+
+  private static class TestRequest {
+    final String path;
+    @Nullable final String jsonPayload;
+    final Map<String, List<String>> queryParams;
+
+    TestRequest(String path) {
+      this(path, null, Collections.emptyMap());
+    }
+
+    TestRequest(String path, @Nullable String jsonPayload, Map<String, List<String>> queryParams) {
+      this.path = path;
+      this.jsonPayload = jsonPayload;
+      this.queryParams = queryParams;
+    }
+  }
+}


### PR DESCRIPTION
The implementation uses a custom `HttpJsonClientCall.Listener` to extract `X-Goog-Upload-URL` and `X-Goog-Upload-Chunk-Granularity` headers to be returned in a `ResumableUploadSession`.