### PR TITLE
feat(gax): implement uploadChunkCallable for resumable uploads

### DIFF
--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClient.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClient.java
@@ -32,6 +32,8 @@ package com.google.api.gax.httpjson;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
+import com.google.api.gax.resumable.ChunkUploadRequest;
+import com.google.api.gax.resumable.ChunkUploadResponse;
 import com.google.api.gax.resumable.ResumableUploadClient;
 import com.google.api.gax.resumable.ResumableUploadSession;
 import com.google.api.gax.rpc.ClientContext;
@@ -54,6 +56,8 @@ public final class HttpJsonResumableUploadClient<RequestT, ResponseT>
     implements ResumableUploadClient<RequestT, ResponseT> {
 
   private final UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable;
+  private final UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>>
+      uploadChunkCallable;
 
   public static <RequestT, ResponseT> HttpJsonResumableUploadClient<RequestT, ResponseT> create(
       ClientContext clientContext, ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor) {
@@ -64,6 +68,8 @@ public final class HttpJsonResumableUploadClient<RequestT, ResponseT>
       ClientContext clientContext, ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor) {
     Preconditions.checkNotNull(clientContext);
     Preconditions.checkNotNull(methodDescriptor);
+    HttpResponseParser<ResponseT> responseParser =
+        Preconditions.checkNotNull(methodDescriptor.getResponseParser());
 
     ApiMethodDescriptor<RequestT, String> startUploadDescriptor =
         ApiMethodDescriptor.<RequestT, String>newBuilder()
@@ -75,10 +81,16 @@ public final class HttpJsonResumableUploadClient<RequestT, ResponseT>
             .build();
     this.startUploadCallable =
         ResumableUploadStartCallable.create(clientContext, startUploadDescriptor);
+    this.uploadChunkCallable = ResumableUploadChunkCallable.create(clientContext, responseParser);
   }
 
   @Override
   public UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable() {
     return startUploadCallable;
+  }
+
+  @Override
+  public UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> uploadChunkCallable() {
+    return uploadChunkCallable;
   }
 }

--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadChunkCallable.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadChunkCallable.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.resumable.ChunkUploadRequest;
+import com.google.api.gax.resumable.ChunkUploadResponse;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/** A {@link UnaryCallable} that transmits individual chunks in a resumable upload session. */
+@NullMarked
+class ResumableUploadChunkCallable<ResponseT>
+    extends UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> {
+
+  private static final String UPLOAD_COMMAND_HEADER = "X-Goog-Upload-Command";
+  private static final String UPLOAD_OFFSET_HEADER = "X-Goog-Upload-Offset";
+  private static final String UPLOAD_STATUS_HEADER = "X-Goog-Upload-Status";
+  private static final String STATUS_FINAL = "final";
+
+  private static final String COMMAND_UPLOAD = "upload";
+  private static final String COMMAND_FINALIZE = "finalize";
+  private static final String COMMAND_UPLOAD_FINALIZE = "upload, finalize";
+
+  private static final PathTemplate PATH_TEMPLATE = PathTemplate.create("**");
+
+  private static final ApiMethodDescriptor<ChunkUploadRequest, String> UPLOAD_CHUNK_DESCRIPTOR =
+      ApiMethodDescriptor.<ChunkUploadRequest, String>newBuilder()
+          .setFullMethodName("ResumableUpload/UploadChunk")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              new ResumableUploadChunkRequestFormatter<ChunkUploadRequest>() {
+                @Override
+                public Map<String, List<String>> getQueryParamNames(ChunkUploadRequest request) {
+                  return Collections.emptyMap();
+                }
+
+                @Override
+                public byte[] getBinaryRequestBody(ChunkUploadRequest request) {
+                  return request.getPayload();
+                }
+
+                @Override
+                public String getPath(ChunkUploadRequest request) {
+                  return request.getUploadUrl();
+                }
+
+                @Override
+                public PathTemplate getPathTemplate() {
+                  return PATH_TEMPLATE;
+                }
+              })
+          .setResponseParser(ResumableUploadResponseParser.create())
+          .build();
+
+  private final ClientContext clientContext;
+  private final HttpResponseParser<ResponseT> responseParser;
+
+  private ResumableUploadChunkCallable(
+      ClientContext clientContext, HttpResponseParser<ResponseT> responseParser) {
+    this.clientContext = Preconditions.checkNotNull(clientContext);
+    this.responseParser = Preconditions.checkNotNull(responseParser);
+  }
+
+  @Override
+  public ApiFuture<ChunkUploadResponse<ResponseT>> futureCall(
+      ChunkUploadRequest request, @Nullable ApiCallContext inputContext) {
+    Preconditions.checkNotNull(request);
+    boolean isPayloadEmpty = request.getPayload().length == 0;
+    String command;
+    if (request.isFinal()) {
+      command = !isPayloadEmpty ? COMMAND_UPLOAD_FINALIZE : COMMAND_FINALIZE;
+    } else {
+      command = COMMAND_UPLOAD;
+    }
+    ImmutableMap.Builder<String, List<String>> chunkHeadersBuilder =
+        ImmutableMap.<String, List<String>>builder()
+            .put(UPLOAD_COMMAND_HEADER, ImmutableList.of(command));
+    if (!COMMAND_FINALIZE.equals(command)) {
+      chunkHeadersBuilder.put(
+          UPLOAD_OFFSET_HEADER, ImmutableList.of(String.valueOf(request.getOffset())));
+    }
+    Map<String, List<String>> chunkHeaders = chunkHeadersBuilder.build();
+
+    HttpJsonCallContext context =
+        (HttpJsonCallContext)
+            HttpJsonCallContext.createDefault()
+                .nullToSelf(clientContext.getDefaultCallContext())
+                .merge(inputContext)
+                .withExtraHeaders(chunkHeaders);
+
+    HttpJsonClientCall<ChunkUploadRequest, String> clientCall =
+        HttpJsonClientCalls.newCall(UPLOAD_CHUNK_DESCRIPTOR, context);
+
+    ResumableUploadHttpJsonFuture<ChunkUploadResponse<ResponseT>> future =
+        new ResumableUploadHttpJsonFuture<>(clientCall);
+    HttpJsonClientCalls.startUnaryCall(
+        clientCall, request, context, new ChunkUploadResponseListener<>(future, responseParser));
+
+    return future;
+  }
+
+  static <ResponseT> UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> create(
+      ClientContext clientContext, HttpResponseParser<ResponseT> responseParser) {
+    UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> rawCallable =
+        new ResumableUploadChunkCallable<>(clientContext, responseParser);
+    UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> callable =
+        new HttpJsonExceptionCallable<>(
+            rawCallable,
+            // Wire calls do not retry directly; retries are managed by ResumableUploadCallable.
+            Collections.emptySet());
+    return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  /**
+   * A listener that processes chunk upload response headers and bodies to produce the {@link
+   * ChunkUploadResponse}.
+   */
+  private static class ChunkUploadResponseListener<ResponseT>
+      extends HttpJsonClientCall.Listener<String> {
+
+    private final ResumableUploadHttpJsonFuture<ChunkUploadResponse<ResponseT>> future;
+    private final HttpResponseParser<ResponseT> responseParser;
+    @Nullable private String uploadStatus = null;
+    private String responseBody = "";
+
+    private ChunkUploadResponseListener(
+        ResumableUploadHttpJsonFuture<ChunkUploadResponse<ResponseT>> future,
+        HttpResponseParser<ResponseT> responseParser) {
+      this.future = future;
+      this.responseParser = responseParser;
+    }
+
+    @Override
+    public void onHeaders(HttpJsonMetadata responseHeaders) {
+      Map<String, Object> headers = responseHeaders.getHeaders();
+      this.uploadStatus = HttpHeadersUtils.getSingleHeader(headers, UPLOAD_STATUS_HEADER);
+    }
+
+    @Override
+    public void onMessage(@Nullable String message) {
+      if (message != null) {
+        this.responseBody = message;
+      }
+    }
+
+    @Override
+    public void onClose(int statusCode, HttpJsonMetadata trailers) {
+      try {
+        if (statusCode >= 200 && statusCode < 300) {
+          if (uploadStatus == null) {
+            future.setException(
+                ApiExceptionFactory.createException(
+                    "Upload chunk response did not contain valid "
+                        + UPLOAD_STATUS_HEADER
+                        + " header",
+                    /* cause= */ null,
+                    HttpJsonStatusCode.of(StatusCode.Code.INTERNAL),
+                    /* retryable= */ false));
+            return;
+          }
+          boolean isComplete = STATUS_FINAL.equalsIgnoreCase(uploadStatus);
+          ChunkUploadResponse.Builder<ResponseT> chunkResponseBuilder =
+              ChunkUploadResponse.<ResponseT>newBuilder().setComplete(isComplete);
+          if (isComplete) {
+            InputStream stream =
+                new ByteArrayInputStream(responseBody.getBytes(StandardCharsets.UTF_8));
+            chunkResponseBuilder.setResponse(responseParser.parse(stream));
+          }
+          future.set(chunkResponseBuilder.build());
+        } else {
+          Throwable cause = trailers.getException();
+          future.setException(
+              cause != null
+                  ? cause
+                  : new HttpJsonStatusRuntimeException(
+                      statusCode, "Failed to upload chunk with status code: " + statusCode, null));
+        }
+      } catch (Throwable t) {
+        future.setException(t);
+      }
+    }
+  }
+}

--- a/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClientTest.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClientTest.java
@@ -40,8 +40,12 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.core.InternalApi;
+import com.google.api.gax.resumable.ChunkUploadRequest;
+import com.google.api.gax.resumable.ChunkUploadResponse;
 import com.google.api.gax.resumable.ResumableUploadSession;
+import com.google.api.gax.rpc.AbortedException;
 import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.InternalException;
 import com.google.api.gax.rpc.NotFoundException;
@@ -49,6 +53,7 @@ import com.google.api.gax.rpc.StatusCode;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.common.base.Strings;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -231,6 +236,192 @@ class HttpJsonResumableUploadClientTest {
     client.startUploadCallable().call(request, callContext);
 
     assertThat(transport.capturedHeaders.get("x-custom-header")).containsExactly("CustomValue");
+  }
+
+  @Test
+  void uploadChunk_intermediateChunk_sendsUploadCommandAndReturnsActiveStatus() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Status", "active");
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(httpResponse);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+
+    byte[] payload = new byte[262144];
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl(TEST_UPLOAD_URL)
+            .setPayload(payload)
+            .setOffset(0L)
+            .setFinal(false)
+            .build();
+
+    ChunkUploadResponse<String> response = client.uploadChunkCallable().call(request);
+
+    assertThat(response.isComplete()).isFalse();
+    assertThat(response.getResponse()).isNull();
+
+    assertThat(transport.capturedUrl).isEqualTo(TEST_UPLOAD_URL);
+    assertThat(transport.capturedHeaders.get("x-goog-upload-command")).containsExactly("upload");
+    assertThat(transport.capturedHeaders.get("x-goog-upload-offset")).containsExactly("0");
+  }
+
+  @Test
+  void uploadChunk_finalChunk_sendsUploadFinalizeAndReturnsResponseBody() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Status", "final");
+    httpResponse.setContent("{\"name\":\"uploaded-file.txt\",\"size\":524288}");
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(httpResponse);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+
+    byte[] payload = new byte[262144];
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl(TEST_UPLOAD_URL)
+            .setPayload(payload)
+            .setOffset(262144L)
+            .setFinal(true)
+            .build();
+
+    ChunkUploadResponse<String> response = client.uploadChunkCallable().call(request);
+
+    assertThat(response.isComplete()).isTrue();
+    assertThat(response.getResponse())
+        .isEqualTo("{\"name\":\"uploaded-file.txt\",\"size\":524288}");
+
+    assertThat(transport.capturedHeaders.get("x-goog-upload-command"))
+        .containsExactly("upload, finalize");
+    assertThat(transport.capturedHeaders.get("x-goog-upload-offset")).containsExactly("262144");
+  }
+
+  @Test
+  void uploadChunk_emptyPayloadFinal_sendsFinalizeCommandAndReturnsResponseBody() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Status", "final");
+    httpResponse.setContent("{\"name\":\"uploaded-file.txt\",\"size\":1048576}");
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(httpResponse);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl(TEST_UPLOAD_URL)
+            .setPayload(new byte[0])
+            .setOffset(1048576L)
+            .setFinal(true)
+            .build();
+
+    ChunkUploadResponse<String> response = client.uploadChunkCallable().call(request);
+
+    assertThat(response.isComplete()).isTrue();
+    assertThat(response.getResponse())
+        .isEqualTo("{\"name\":\"uploaded-file.txt\",\"size\":1048576}");
+
+    assertThat(transport.capturedHeaders.get("x-goog-upload-command")).containsExactly("finalize");
+    assertThat(transport.capturedHeaders).doesNotContainKey("x-goog-upload-offset");
+  }
+
+  @Test
+  void uploadChunk_withCustomExtraHeaders_preservesHeaders() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Status", "active");
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(httpResponse);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl(TEST_UPLOAD_URL)
+            .setPayload("data".getBytes(StandardCharsets.UTF_8))
+            .setOffset(0L)
+            .build();
+
+    Map<String, List<String>> customHeaders =
+        Collections.singletonMap(
+            "X-Custom-Chunk-Header", Collections.singletonList("CustomChunkValue"));
+
+    ApiCallContext callContext =
+        HttpJsonCallContext.createDefault().withExtraHeaders(customHeaders);
+
+    client.uploadChunkCallable().call(request, callContext);
+
+    assertThat(transport.capturedHeaders.get("x-custom-chunk-header"))
+        .containsExactly("CustomChunkValue");
+  }
+
+  @Test
+  void uploadChunk_serverReturnsConflictOrError_throwsException() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(409);
+    httpResponse.setContent("{\"error\":{\"message\":\"Invalid offset\"}}");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl(TEST_UPLOAD_URL)
+            .setPayload("data".getBytes(StandardCharsets.UTF_8))
+            .setOffset(100L)
+            .build();
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.uploadChunkCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(AbortedException.class);
+    AbortedException abortedException = (AbortedException) exception.getCause();
+    assertThat(abortedException.getStatusCode().getCode()).isEqualTo(StatusCode.Code.ABORTED);
+  }
+
+  @Test
+  void uploadChunk_missingUploadStatusHeader_throwsInternalException() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl(TEST_UPLOAD_URL)
+            .setPayload("data".getBytes(StandardCharsets.UTF_8))
+            .setOffset(0L)
+            .build();
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.uploadChunkCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(InternalException.class);
+    assertThat(exception.getCause())
+        .hasMessageThat()
+        .contains("Upload chunk response did not contain valid X-Goog-Upload-Status header");
+  }
+
+  @Test
+  void uploadChunk_serverReturnsFinalStatusOnNon200_marksExceptionNonRetryable() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(503);
+    httpResponse.addHeader("X-Goog-Upload-Status", "final");
+    httpResponse.setContent("{\"error\":{\"message\":\"Upload rejected by backend\"}}");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl(TEST_UPLOAD_URL)
+            .setPayload("data".getBytes(StandardCharsets.UTF_8))
+            .setOffset(0L)
+            .build();
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.uploadChunkCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(ApiException.class);
+    ApiException apiException = (ApiException) exception.getCause();
+    assertThat(apiException.isRetryable()).isFalse();
+    assertThat(apiException.getStatusCode().getCode()).isEqualTo(StatusCode.Code.UNAVAILABLE);
   }
 
   private static HttpJsonResumableUploadClient<TestRequest, String> createClient(

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ChunkUploadRequest.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ChunkUploadRequest.java
@@ -34,43 +34,42 @@ import com.google.api.core.InternalApi;
 import com.google.auto.value.AutoValue;
 import org.jspecify.annotations.NullMarked;
 
-/** Represents the session metadata returned after starting a resumable upload. */
+/** Request value object for uploading a chunk to an active resumable upload session. */
 @NullMarked
 @BetaApi
 @InternalApi
 @AutoValue
-public abstract class ResumableUploadSession {
+public abstract class ChunkUploadRequest {
 
-  private static final long DEFAULT_CHUNK_GRANULARITY = 1L;
-
-  /** Returns the server-provided URL to which data uploads are directed. */
+  /** The upload session URL returned during session initialization. */
   public abstract String getUploadUrl();
 
-  /**
-   * Returns the server-mandated chunk granularity in bytes.
-   *
-   * <p>When specified by the server (via {@code X-Goog-Upload-Chunk-Granularity}), intermediate
-   * upload chunks must have a size and offset that are an exact multiple of this value (the final
-   * chunk may be smaller). If not specified by the server, this defaults to 1 byte, indicating no
-   * alignment or granularity requirements apply.
-   *
-   * @return the chunk granularity in bytes
-   */
-  public abstract long getChunkGranularity();
+  /** The binary chunk payload to upload. */
+  @SuppressWarnings("mutable")
+  public abstract byte[] getPayload();
+
+  /** The byte offset of this chunk in the overall stream. */
+  public abstract long getOffset();
+
+  /** Whether this is the final chunk in the stream. */
+  public abstract boolean isFinal();
 
   public abstract Builder toBuilder();
 
   public static Builder newBuilder() {
-    return new AutoValue_ResumableUploadSession.Builder()
-        .setChunkGranularity(DEFAULT_CHUNK_GRANULARITY);
+    return new AutoValue_ChunkUploadRequest.Builder().setFinal(false);
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setUploadUrl(String uploadUrl);
 
-    public abstract Builder setChunkGranularity(long chunkGranularity);
+    public abstract Builder setPayload(byte[] payload);
 
-    public abstract ResumableUploadSession build();
+    public abstract Builder setOffset(long offset);
+
+    public abstract Builder setFinal(boolean isFinal);
+
+    public abstract ChunkUploadRequest build();
   }
 }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ChunkUploadResponse.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ChunkUploadResponse.java
@@ -33,44 +33,48 @@ import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.auto.value.AutoValue;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
-/** Represents the session metadata returned after starting a resumable upload. */
+/**
+ * Response value object representing the outcome of a chunk upload.
+ *
+ * @param <ResponseT> response type of the upload operation
+ */
 @NullMarked
 @BetaApi
 @InternalApi
 @AutoValue
-public abstract class ResumableUploadSession {
+public abstract class ChunkUploadResponse<ResponseT> {
 
-  private static final long DEFAULT_CHUNK_GRANULARITY = 1L;
-
-  /** Returns the server-provided URL to which data uploads are directed. */
-  public abstract String getUploadUrl();
+  /** Whether the overall resumable upload stream has finalized and completed on the server. */
+  public abstract boolean isComplete();
 
   /**
-   * Returns the server-mandated chunk granularity in bytes.
-   *
-   * <p>When specified by the server (via {@code X-Goog-Upload-Chunk-Granularity}), intermediate
-   * upload chunks must have a size and offset that are an exact multiple of this value (the final
-   * chunk may be smaller). If not specified by the server, this defaults to 1 byte, indicating no
-   * alignment or granularity requirements apply.
-   *
-   * @return the chunk granularity in bytes
+   * The response object returned by the server upon final completion (e.g. metadata of the uploaded
+   * resource), or {@code null} if the upload is still in progress.
    */
-  public abstract long getChunkGranularity();
+  public abstract @Nullable ResponseT getResponse();
 
-  public abstract Builder toBuilder();
+  public abstract Builder<ResponseT> toBuilder();
 
-  public static Builder newBuilder() {
-    return new AutoValue_ResumableUploadSession.Builder()
-        .setChunkGranularity(DEFAULT_CHUNK_GRANULARITY);
+  public static <ResponseT> Builder<ResponseT> newBuilder() {
+    return new AutoValue_ChunkUploadResponse.Builder<ResponseT>().setComplete(false);
+  }
+
+  public static <ResponseT> ChunkUploadResponse<ResponseT> create(
+      boolean isComplete, @Nullable ResponseT response) {
+    return new AutoValue_ChunkUploadResponse.Builder<ResponseT>()
+        .setComplete(isComplete)
+        .setResponse(response)
+        .build();
   }
 
   @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder setUploadUrl(String uploadUrl);
+  public abstract static class Builder<ResponseT> {
+    public abstract Builder<ResponseT> setComplete(boolean isComplete);
 
-    public abstract Builder setChunkGranularity(long chunkGranularity);
+    public abstract Builder<ResponseT> setResponse(@Nullable ResponseT response);
 
-    public abstract ResumableUploadSession build();
+    public abstract ChunkUploadResponse<ResponseT> build();
   }
 }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ResumableUploadClient.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ResumableUploadClient.java
@@ -29,6 +29,7 @@
  */
 package com.google.api.gax.resumable;
 
+import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.rpc.UnaryCallable;
 import org.jspecify.annotations.NullMarked;
@@ -40,9 +41,13 @@ import org.jspecify.annotations.NullMarked;
  * @param <ResponseT> response type of the upload operation
  */
 @NullMarked
+@BetaApi
 @InternalApi
 public interface ResumableUploadClient<RequestT, ResponseT> {
 
   /** Returns a {@link UnaryCallable} to initiate a resumable upload session. */
   UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable();
+
+  /** Returns a {@link UnaryCallable} to transmit an individual chunk. */
+  UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> uploadChunkCallable();
 }

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/resumable/ChunkUploadRequestTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/resumable/ChunkUploadRequestTest.java
@@ -29,48 +29,38 @@
  */
 package com.google.api.gax.resumable;
 
-import com.google.api.core.BetaApi;
-import com.google.api.core.InternalApi;
-import com.google.auto.value.AutoValue;
-import org.jspecify.annotations.NullMarked;
+import static com.google.common.truth.Truth.assertThat;
 
-/** Represents the session metadata returned after starting a resumable upload. */
-@NullMarked
-@BetaApi
-@InternalApi
-@AutoValue
-public abstract class ResumableUploadSession {
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
 
-  private static final long DEFAULT_CHUNK_GRANULARITY = 1L;
+class ChunkUploadRequestTest {
 
-  /** Returns the server-provided URL to which data uploads are directed. */
-  public abstract String getUploadUrl();
+  @Test
+  void builder_defaultIsFinalFalse() {
+    byte[] payload = "test-payload".getBytes(StandardCharsets.UTF_8);
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl("https://upload.example.com/session/1")
+            .setPayload(payload)
+            .setOffset(0L)
+            .build();
 
-  /**
-   * Returns the server-mandated chunk granularity in bytes.
-   *
-   * <p>When specified by the server (via {@code X-Goog-Upload-Chunk-Granularity}), intermediate
-   * upload chunks must have a size and offset that are an exact multiple of this value (the final
-   * chunk may be smaller). If not specified by the server, this defaults to 1 byte, indicating no
-   * alignment or granularity requirements apply.
-   *
-   * @return the chunk granularity in bytes
-   */
-  public abstract long getChunkGranularity();
-
-  public abstract Builder toBuilder();
-
-  public static Builder newBuilder() {
-    return new AutoValue_ResumableUploadSession.Builder()
-        .setChunkGranularity(DEFAULT_CHUNK_GRANULARITY);
+    assertThat(request.isFinal()).isFalse();
+    assertThat(request.getPayload()).isEqualTo(payload);
   }
 
-  @AutoValue.Builder
-  public abstract static class Builder {
-    public abstract Builder setUploadUrl(String uploadUrl);
+  @Test
+  void builder_explicitIsFinalTrue_preservesValue() {
+    ChunkUploadRequest request =
+        ChunkUploadRequest.newBuilder()
+            .setUploadUrl("https://upload.example.com/session/1")
+            .setPayload(new byte[0])
+            .setOffset(1024L)
+            .setFinal(true)
+            .build();
 
-    public abstract Builder setChunkGranularity(long chunkGranularity);
-
-    public abstract ResumableUploadSession build();
+    assertThat(request.isFinal()).isTrue();
+    assertThat(request.getPayload()).isEmpty();
   }
 }


### PR DESCRIPTION
This handles sending binary chunks and finalize commands over HTTP/JSON, extracting offset and status from response headers/codes.
