### PR TITLE
ci: split enforcer into fast PR metadata check and release banDuplicateClasses check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,6 +401,21 @@ jobs:
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
   enforcer:
     needs: bulk-filter
+    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
+      with:
+        distribution: temurin
+        java-version: 11
+        cache: maven
+    - run: java -version
+    - run: mvn -B -ntp enforcer:enforce@enforce -T 1C
+  ban-duplicate-classes:
+    needs: bulk-filter
     if: |
       needs.bulk-filter.outputs.runnable == 'true' &&
       github.head_ref == 'release-please--branches--main' &&
@@ -421,7 +436,7 @@ jobs:
       env:
         JOB_TYPE: install
     - run: java -version
-    - run: mvn -B -ntp enforcer:enforce@enforce -T 1C
+    - run: mvn -B -ntp enforcer:enforce@enforce-banned-duplicate-classes -T 1C
   gapic-libraries-bom:
     needs: bulk-filter
     if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -401,7 +401,10 @@ jobs:
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
   enforcer:
     needs: bulk-filter
-    if: ${{ needs.bulk-filter.outputs.runnable == 'true' }}
+    if: |
+      needs.bulk-filter.outputs.runnable == 'true' &&
+      github.head_ref == 'release-please--branches--main' &&
+      !endsWith(github.event.pull_request.title, 'SNAPSHOT')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/google-auth-library-java/bom/pom.xml
+++ b/google-auth-library-java/bom/pom.xml
@@ -45,6 +45,10 @@
 
   <build>
     <plugins>
+      <!-- Temporary enforcer configuration override until a new version of google-cloud-shared-config is released to Maven Central.
+           Because this module inherits a released version of google-cloud-shared-config from Central (which includes banDuplicateClasses in its default enforce execution),
+           we override the enforce execution here to avoid running banDuplicateClasses on standard PRs where intra-repo SNAPSHOT JARs are unbuilt.
+           Remove this override once the parent version is bumped to the newly released google-cloud-shared-config. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/google-auth-library-java/bom/pom.xml
+++ b/google-auth-library-java/bom/pom.xml
@@ -42,4 +42,47 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules combine.self="override">
+                <requireMavenVersion>
+                  <version>[3.9.0,)</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8,)</version>
+                </requireJavaVersion>
+                <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-banned-duplicate-classes</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <banDuplicateClasses>
+                  <scopes>
+                    <scope>compile</scope>
+                    <scope>provided</scope>
+                  </scopes>
+                  <findAllDuplicates>true</findAllDuplicates>
+                  <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                </banDuplicateClasses>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/google-auth-library-java/bom/pom.xml
+++ b/google-auth-library-java/bom/pom.xml
@@ -58,7 +58,7 @@
             <configuration>
               <rules combine.self="override">
                 <requireMavenVersion>
-                  <version>[3.9.0,)</version>
+                  <version>[3.8.0,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[1.8,)</version>

--- a/google-auth-library-java/pom.xml
+++ b/google-auth-library-java/pom.xml
@@ -291,7 +291,7 @@
             <configuration>
               <rules combine.self="override">
                 <requireMavenVersion>
-                  <version>[3.9.0,)</version>
+                  <version>[3.8.0,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[1.8,)</version>

--- a/google-auth-library-java/pom.xml
+++ b/google-auth-library-java/pom.xml
@@ -278,6 +278,10 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <!-- Temporary enforcer configuration override until a new version of google-cloud-shared-config is released to Maven Central.
+           Because this module inherits a released version of google-cloud-shared-config from Central (which includes banDuplicateClasses in its default enforce execution),
+           we override the enforce execution here to avoid running banDuplicateClasses on standard PRs where intra-repo SNAPSHOT JARs are unbuilt.
+           Remove this override once the parent version is bumped to the newly released google-cloud-shared-config. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/google-auth-library-java/pom.xml
+++ b/google-auth-library-java/pom.xml
@@ -279,6 +279,44 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules combine.self="override">
+                <requireMavenVersion>
+                  <version>[3.9.0,)</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8,)</version>
+                </requireJavaVersion>
+                <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-banned-duplicate-classes</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <banDuplicateClasses>
+                  <scopes>
+                    <scope>compile</scope>
+                    <scope>provided</scope>
+                  </scopes>
+                  <findAllDuplicates>true</findAllDuplicates>
+                  <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                </banDuplicateClasses>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.14.0</version>
         <configuration>

--- a/grpc-gcp-java/pom.xml
+++ b/grpc-gcp-java/pom.xml
@@ -11,8 +11,8 @@
     first-party-dependencies, which is imported by google-cloud-shared-dependencies;
     importing shared dependency management from grpc-gcp would create a dependency
     management cycle. -->
-    <version>1.17.0</version>
-    <relativePath/>
+    <version>1.21.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-shared-config:current} -->
+    <relativePath>../java-shared-config/java-shared-config/pom.xml</relativePath>
   </parent>
 
   <groupId>com.google.cloud</groupId>
@@ -237,48 +237,6 @@
       </extension>
     </extensions>
     <plugins>
-      <!-- Temporary enforcer configuration override until a new version of google-cloud-shared-config is released to Maven Central.
-           Because this module inherits a released version of google-cloud-shared-config from Central (which includes banDuplicateClasses in its default enforce execution),
-           we override the enforce execution here to avoid running banDuplicateClasses on standard PRs where intra-repo SNAPSHOT JARs are unbuilt.
-           Remove this override once the parent version is bumped to the newly released google-cloud-shared-config. -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <rules combine.self="override">
-                <requireMavenVersion>
-                  <version>[3.9.0,)</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>[1.8,)</version>
-                </requireJavaVersion>
-                <requireUpperBoundDeps/>
-              </rules>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce-banned-duplicate-classes</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <banDuplicateClasses>
-                  <scopes>
-                    <scope>compile</scope>
-                    <scope>provided</scope>
-                  </scopes>
-                  <findAllDuplicates>true</findAllDuplicates>
-                  <ignoreWhenIdentical>true</ignoreWhenIdentical>
-                </banDuplicateClasses>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>

--- a/grpc-gcp-java/pom.xml
+++ b/grpc-gcp-java/pom.xml
@@ -237,6 +237,10 @@
       </extension>
     </extensions>
     <plugins>
+      <!-- Temporary enforcer configuration override until a new version of google-cloud-shared-config is released to Maven Central.
+           Because this module inherits a released version of google-cloud-shared-config from Central (which includes banDuplicateClasses in its default enforce execution),
+           we override the enforce execution here to avoid running banDuplicateClasses on standard PRs where intra-repo SNAPSHOT JARs are unbuilt.
+           Remove this override once the parent version is bumped to the newly released google-cloud-shared-config. -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/grpc-gcp-java/pom.xml
+++ b/grpc-gcp-java/pom.xml
@@ -238,6 +238,44 @@
     </extensions>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules combine.self="override">
+                <requireMavenVersion>
+                  <version>[3.9.0,)</version>
+                </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>[1.8,)</version>
+                </requireJavaVersion>
+                <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-banned-duplicate-classes</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <banDuplicateClasses>
+                  <scopes>
+                    <scope>compile</scope>
+                    <scope>provided</scope>
+                  </scopes>
+                  <findAllDuplicates>true</findAllDuplicates>
+                  <ignoreWhenIdentical>true</ignoreWhenIdentical>
+                </banDuplicateClasses>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.graalvm.buildtools</groupId>
         <artifactId>native-maven-plugin</artifactId>
         <version>${native-maven-plugin.version}</version>

--- a/java-samples/pom.xml
+++ b/java-samples/pom.xml
@@ -17,6 +17,10 @@
         <relativePath>../google-cloud-jar-parent/pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <enforcer.skip>true</enforcer.skip>
+    </properties>
+
     <modules>
         <module>native-image-sample</module>
     </modules>

--- a/java-shared-config/java-shared-config/pom.xml
+++ b/java-shared-config/java-shared-config/pom.xml
@@ -248,12 +248,22 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.0,)</version>
+                  <version>[3.9.0,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
-                  <version>[1.7,)</version>
+                  <version>[1.8,)</version>
                 </requireJavaVersion>
                 <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce-banned-duplicate-classes</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
                 <banDuplicateClasses>
                   <scopes>
                     <scope>compile</scope>

--- a/java-shared-config/java-shared-config/pom.xml
+++ b/java-shared-config/java-shared-config/pom.xml
@@ -248,7 +248,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.9.0,)</version>
+                  <version>[3.8.0,)</version>
                 </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[1.8,)</version>


### PR DESCRIPTION
## Summary

Separates the Maven Enforcer configuration into two distinct executions:

1. **`enforce` (Fast Metadata Checks)**: Checks `requireUpperBoundDeps`, `requireMavenVersion`, and `requireJavaVersion`. Runs on every PR directly in memory (~15s) without needing a full-repo build.
2. **`enforce-banned-duplicate-classes` (Bytecode Scanner)**: Checks `banDuplicateClasses`. Runs only on Release-Please (non-SNAPSHOT) PRs after compiling and installing all module JARs to disk.

---

### Key Changes

* **`java-shared-config/pom.xml`**:
  * Separated `<id>enforce</id>` into fast metadata rules (`requireUpperBoundDeps`, `requireMavenVersion: [3.8.0,)`, `requireJavaVersion: [1.8,)`).
  * Added `<id>enforce-banned-duplicate-classes</id>` execution containing the `<banDuplicateClasses>` rule.
* **`.github/workflows/ci.yaml`**:
  * `enforcer` job: Runs on every PR using `mvn -B -ntp enforcer:enforce@enforce -T 1C` (executes in ~15 seconds across all modules without pre-installing JARs).
  * `ban-duplicate-classes` job: Runs on Release-Please PRs (`release-please--branches--main` non-SNAPSHOT) with the full `JOB_TYPE: install` step followed by `mvn -B -ntp enforcer:enforce@enforce-banned-duplicate-classes -T 1C`.
* **`grpc-gcp-java`**:
  * Updated parent POM to inherit the local `google-cloud-shared-config:1.21.0-SNAPSHOT` parent via relative path and Release-Please tracking comment (`<!-- {x-version-update:google-cloud-shared-config:current} -->`), directly inheriting the split enforcer configuration.
* **`google-auth-library-java`**:
  * Added temporary enforcer configuration overrides with `<rules combine.self="override">` to prevent running the old `banDuplicateClasses` rule inherited from the remote `google-cloud-shared-config:1.17.0` release artifact.
  * *Note*: These overrides are temporary until the new version of `google-cloud-shared-config` is published to Maven Central, at which point the parent version will be bumped and the overrides removed.
* **`java-samples`**:
  * Added `<enforcer.skip>true</enforcer.skip>` to sample parent POM.

---

### Benefits

* **Fast PR Turnaround**: Developers get immediate feedback on dependency convergence (`requireUpperBoundDeps`) and tool versions in ~15 seconds rather than waiting 20+ minutes.
* **Full Classpath Safety**: Releases remain protected against duplicate class conflicts (JAR hell) via `banDuplicateClasses` before publishing.