### PR TITLE
feat(bigquery): expose `StatementType` and query execution stats on `TableResult`

### DIFF
--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -41,6 +41,7 @@ import com.google.cloud.RetryOption;
 import com.google.cloud.Tuple;
 import com.google.cloud.bigquery.BigQueryRetryHelper.BigQueryRetryHelperException;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
 import com.google.cloud.bigquery.spi.v2.BigQueryRpc;
 import com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc;
 import com.google.common.annotations.VisibleForTesting;
@@ -2095,6 +2096,15 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
       return job;
     }
 
+    StatementType statementType =
+        results.getStatementType() != null
+            ? StatementType.valueOf(results.getStatementType())
+            : null;
+    Long totalBytesBilled = results.getTotalBytesBilled();
+    Long totalBytesProcessed = results.getTotalBytesProcessed();
+    Long totalSlotMs = results.getTotalSlotMs();
+    Long numDmlAffectedRows = results.getNumDmlAffectedRows();
+
     if (results.getPageToken() != null) {
       JobId jobId = JobId.fromPb(results.getJobReference());
       String cursor = results.getPageToken();
@@ -2114,6 +2124,11 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           .setQueryId(results.getQueryId())
           .setJobCreationReason(JobCreationReason.fromPb(results.getJobCreationReason()))
           .setRowsInPage(results.getRows() != null ? (long) results.getRows().size() : 0L)
+          .setStatementType(statementType)
+          .setTotalBytesBilled(totalBytesBilled)
+          .setTotalBytesProcessed(totalBytesProcessed)
+          .setTotalSlotMs(totalSlotMs)
+          .setNumDmlAffectedRows(numDmlAffectedRows)
           .build();
     }
     // only 1 page of result
@@ -2134,6 +2149,11 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
         .setQueryId(results.getQueryId())
         .setJobCreationReason(JobCreationReason.fromPb(results.getJobCreationReason()))
         .setRowsInPage(results.getRows() != null ? (long) results.getRows().size() : 0L)
+        .setStatementType(statementType)
+        .setTotalBytesBilled(totalBytesBilled)
+        .setTotalBytesProcessed(totalBytesProcessed)
+        .setTotalSlotMs(totalSlotMs)
+        .setNumDmlAffectedRows(numDmlAffectedRows)
         .build();
   }
 

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/BigQueryImpl.java
@@ -42,6 +42,7 @@ import com.google.cloud.Tuple;
 import com.google.cloud.bigquery.BigQueryRetryHelper.BigQueryRetryHelperException;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
+import com.google.cloud.bigquery.JobStatistics.SessionInfo;
 import com.google.cloud.bigquery.spi.v2.BigQueryRpc;
 import com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc;
 import com.google.common.annotations.VisibleForTesting;
@@ -2104,6 +2105,8 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
     Long totalBytesProcessed = results.getTotalBytesProcessed();
     Long totalSlotMs = results.getTotalSlotMs();
     Long numDmlAffectedRows = results.getNumDmlAffectedRows();
+    SessionInfo sessionInfo =
+        results.getSessionInfo() != null ? SessionInfo.fromPb(results.getSessionInfo()) : null;
 
     if (results.getPageToken() != null) {
       JobId jobId = JobId.fromPb(results.getJobReference());
@@ -2129,6 +2132,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
           .setTotalBytesProcessed(totalBytesProcessed)
           .setTotalSlotMs(totalSlotMs)
           .setNumDmlAffectedRows(numDmlAffectedRows)
+          .setSessionInfo(sessionInfo)
           .build();
     }
     // only 1 page of result
@@ -2154,6 +2158,7 @@ final class BigQueryImpl extends BaseService<BigQueryOptions> implements BigQuer
         .setTotalBytesProcessed(totalBytesProcessed)
         .setTotalSlotMs(totalSlotMs)
         .setNumDmlAffectedRows(numDmlAffectedRows)
+        .setSessionInfo(sessionInfo)
         .build();
   }
 

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
@@ -28,6 +28,8 @@ import com.google.cloud.bigquery.BigQuery.JobOption;
 import com.google.cloud.bigquery.BigQuery.QueryResultsOption;
 import com.google.cloud.bigquery.BigQuery.TableDataListOption;
 import com.google.cloud.bigquery.JobConfiguration.Type;
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics;
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -414,6 +416,16 @@ public class Job extends JobInfo {
                 : ImmutableList.copyOf(job.getStatus().getExecutionErrors()));
       }
 
+      QueryStatistics stats =
+          job.getStatistics() instanceof QueryStatistics
+              ? (QueryStatistics) job.getStatistics()
+              : null;
+      StatementType statementType = stats != null ? stats.getStatementType() : null;
+      Long totalBytesBilled = stats != null ? stats.getTotalBytesBilled() : null;
+      Long totalBytesProcessed = stats != null ? stats.getTotalBytesProcessed() : null;
+      Long totalSlotMs = stats != null ? stats.getTotalSlotMs() : null;
+      Long numDmlAffectedRows = stats != null ? stats.getNumDmlAffectedRows() : null;
+
       // If there are no rows in the result, this may have been a DDL query.
       // Listing table data might fail, such as with CREATE VIEW queries.
       // Avoid a tabledata.list API request by returning an empty TableResult.
@@ -425,6 +437,11 @@ public class Job extends JobInfo {
                 .setTotalRows(0L)
                 .setPageNoSchema(new PageImpl<FieldValueList>(null, "", null))
                 .setRowsInPage(0L)
+                .setStatementType(statementType)
+                .setTotalBytesBilled(totalBytesBilled)
+                .setTotalBytesProcessed(totalBytesProcessed)
+                .setTotalSlotMs(totalSlotMs)
+                .setNumDmlAffectedRows(numDmlAffectedRows)
                 .build();
         return emptyTableResult;
       }
@@ -436,7 +453,15 @@ public class Job extends JobInfo {
       TableResult tableResult =
           bigquery.listTableData(
               table, response.getSchema(), listOptions.toArray(new TableDataListOption[0]));
-      TableResult tableResultWithJobId = tableResult.toBuilder().setJobId(job.getJobId()).build();
+      TableResult tableResultWithJobId =
+          tableResult.toBuilder()
+              .setJobId(job.getJobId())
+              .setStatementType(statementType)
+              .setTotalBytesBilled(totalBytesBilled)
+              .setTotalBytesProcessed(totalBytesProcessed)
+              .setTotalSlotMs(totalSlotMs)
+              .setNumDmlAffectedRows(numDmlAffectedRows)
+              .build();
       return tableResultWithJobId;
     } finally {
       if (getQueryResults != null) {

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/Job.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigquery.BigQuery.TableDataListOption;
 import com.google.cloud.bigquery.JobConfiguration.Type;
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics;
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
+import com.google.cloud.bigquery.JobStatistics.SessionInfo;
 import com.google.common.collect.ImmutableList;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -425,6 +426,7 @@ public class Job extends JobInfo {
       Long totalBytesProcessed = stats != null ? stats.getTotalBytesProcessed() : null;
       Long totalSlotMs = stats != null ? stats.getTotalSlotMs() : null;
       Long numDmlAffectedRows = stats != null ? stats.getNumDmlAffectedRows() : null;
+      SessionInfo sessionInfo = stats != null ? stats.getSessionInfo() : null;
 
       // If there are no rows in the result, this may have been a DDL query.
       // Listing table data might fail, such as with CREATE VIEW queries.
@@ -442,6 +444,7 @@ public class Job extends JobInfo {
                 .setTotalBytesProcessed(totalBytesProcessed)
                 .setTotalSlotMs(totalSlotMs)
                 .setNumDmlAffectedRows(numDmlAffectedRows)
+                .setSessionInfo(sessionInfo)
                 .build();
         return emptyTableResult;
       }
@@ -461,6 +464,7 @@ public class Job extends JobInfo {
               .setTotalBytesProcessed(totalBytesProcessed)
               .setTotalSlotMs(totalSlotMs)
               .setNumDmlAffectedRows(numDmlAffectedRows)
+              .setSessionInfo(sessionInfo)
               .build();
       return tableResultWithJobId;
     } finally {

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigquery;
 import com.google.api.gax.paging.Page;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
+import com.google.cloud.bigquery.JobStatistics.SessionInfo;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
@@ -61,6 +62,8 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
     public abstract TableResult.Builder setTotalSlotMs(Long totalSlotMs);
 
     public abstract TableResult.Builder setNumDmlAffectedRows(Long numDmlAffectedRows);
+
+    public abstract TableResult.Builder setSessionInfo(SessionInfo sessionInfo);
 
     /** Creates a @code TableResult} object. */
     public abstract TableResult build();
@@ -124,6 +127,10 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
   @Nullable
   public abstract Long getNumDmlAffectedRows();
 
+  /** Returns information about the session if this query is part of one, if available. */
+  @Nullable
+  public abstract SessionInfo getSessionInfo();
+
   @Override
   public boolean hasNextPage() {
     return getPageNoSchema().hasNextPage();
@@ -151,6 +158,7 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
           .setTotalBytesProcessed(getTotalBytesProcessed())
           .setTotalSlotMs(getTotalSlotMs())
           .setNumDmlAffectedRows(getNumDmlAffectedRows())
+          .setSessionInfo(getSessionInfo())
           .build();
     }
     return null;
@@ -194,6 +202,7 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
         .add("totalBytesProcessed", getTotalBytesProcessed())
         .add("totalSlotMs", getTotalSlotMs())
         .add("numDmlAffectedRows", getNumDmlAffectedRows())
+        .add("sessionInfo", getSessionInfo())
         .toString();
   }
 
@@ -209,7 +218,8 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
         getTotalBytesBilled(),
         getTotalBytesProcessed(),
         getTotalSlotMs(),
-        getNumDmlAffectedRows());
+        getNumDmlAffectedRows(),
+        getSessionInfo());
   }
 
   @Override
@@ -231,6 +241,7 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
         && Objects.equals(getTotalBytesBilled(), response.getTotalBytesBilled())
         && Objects.equals(getTotalBytesProcessed(), response.getTotalBytesProcessed())
         && Objects.equals(getTotalSlotMs(), response.getTotalSlotMs())
-        && Objects.equals(getNumDmlAffectedRows(), response.getNumDmlAffectedRows());
+        && Objects.equals(getNumDmlAffectedRows(), response.getNumDmlAffectedRows())
+        && Objects.equals(getSessionInfo(), response.getSessionInfo());
   }
 }

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
@@ -26,7 +26,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import java.io.Serializable;
 import java.util.Objects;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 @AutoValue
 public abstract class TableResult implements Page<FieldValueList>, Serializable {
@@ -53,17 +53,17 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
 
     abstract TableResult.Builder setRowsInPage(Long rowsInPage);
 
-    public abstract TableResult.Builder setStatementType(StatementType statementType);
+    abstract TableResult.Builder setStatementType(@Nullable StatementType statementType);
 
-    public abstract TableResult.Builder setTotalBytesBilled(Long totalBytesBilled);
+    abstract TableResult.Builder setTotalBytesBilled(@Nullable Long totalBytesBilled);
 
-    public abstract TableResult.Builder setTotalBytesProcessed(Long totalBytesProcessed);
+    abstract TableResult.Builder setTotalBytesProcessed(@Nullable Long totalBytesProcessed);
 
-    public abstract TableResult.Builder setTotalSlotMs(Long totalSlotMs);
+    abstract TableResult.Builder setTotalSlotMs(@Nullable Long totalSlotMs);
 
-    public abstract TableResult.Builder setNumDmlAffectedRows(Long numDmlAffectedRows);
+    abstract TableResult.Builder setNumDmlAffectedRows(@Nullable Long numDmlAffectedRows);
 
-    public abstract TableResult.Builder setSessionInfo(SessionInfo sessionInfo);
+    abstract TableResult.Builder setSessionInfo(@Nullable SessionInfo sessionInfo);
 
     /** Creates a @code TableResult} object. */
     public abstract TableResult build();
@@ -76,8 +76,7 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
   }
 
   /** Returns the schema of the results. Null if the schema is not supplied. */
-  @Nullable
-  public abstract Schema getSchema();
+  public abstract @Nullable Schema getSchema();
 
   /**
    * Returns the total number of rows in the complete result set, which can be more than the number
@@ -88,48 +87,38 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
 
   public abstract Page<FieldValueList> getPageNoSchema();
 
-  @Nullable
-  public abstract JobId getJobId();
+  public abstract @Nullable JobId getJobId();
 
-  @Nullable
-  public abstract String getQueryId();
+  public abstract @Nullable String getQueryId();
 
-  @Nullable
-  public abstract JobCreationReason getJobCreationReason();
+  public abstract @Nullable JobCreationReason getJobCreationReason();
 
   /** Returns the number of rows in the current page of results. */
-  @Nullable
-  public abstract Long getRowsInPage();
+  public abstract @Nullable Long getRowsInPage();
 
   /**
    * Returns the statement type of the query (e.g. SELECT, INSERT, UPDATE, DDL, SCRIPT), if
    * available.
    */
-  @Nullable
-  public abstract StatementType getStatementType();
+  public abstract @Nullable StatementType getStatementType();
 
   /** Returns the total number of bytes billed for the query, if available. */
-  @Nullable
-  public abstract Long getTotalBytesBilled();
+  public abstract @Nullable Long getTotalBytesBilled();
 
   /** Returns the total number of bytes processed by the query, if available. */
-  @Nullable
-  public abstract Long getTotalBytesProcessed();
+  public abstract @Nullable Long getTotalBytesProcessed();
 
   /** Returns the total slot milliseconds for the query, if available. */
-  @Nullable
-  public abstract Long getTotalSlotMs();
+  public abstract @Nullable Long getTotalSlotMs();
 
   /**
    * Returns the number of rows affected by a DML statement (INSERT, UPDATE, DELETE, MERGE), if
    * available.
    */
-  @Nullable
-  public abstract Long getNumDmlAffectedRows();
+  public abstract @Nullable Long getNumDmlAffectedRows();
 
   /** Returns information about the session if this query is part of one, if available. */
-  @Nullable
-  public abstract SessionInfo getSessionInfo();
+  public abstract @Nullable SessionInfo getSessionInfo();
 
   @Override
   public boolean hasNextPage() {

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigquery;
 
 import com.google.api.gax.paging.Page;
 import com.google.auto.value.AutoValue;
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
@@ -50,6 +51,16 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
     public abstract TableResult.Builder setJobCreationReason(JobCreationReason jobCreationReason);
 
     abstract TableResult.Builder setRowsInPage(Long rowsInPage);
+
+    public abstract TableResult.Builder setStatementType(StatementType statementType);
+
+    public abstract TableResult.Builder setTotalBytesBilled(Long totalBytesBilled);
+
+    public abstract TableResult.Builder setTotalBytesProcessed(Long totalBytesProcessed);
+
+    public abstract TableResult.Builder setTotalSlotMs(Long totalSlotMs);
+
+    public abstract TableResult.Builder setNumDmlAffectedRows(Long numDmlAffectedRows);
 
     /** Creates a @code TableResult} object. */
     public abstract TableResult build();
@@ -87,6 +98,32 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
   @Nullable
   public abstract Long getRowsInPage();
 
+  /**
+   * Returns the statement type of the query (e.g. SELECT, INSERT, UPDATE, DDL, SCRIPT), if
+   * available.
+   */
+  @Nullable
+  public abstract StatementType getStatementType();
+
+  /** Returns the total number of bytes billed for the query, if available. */
+  @Nullable
+  public abstract Long getTotalBytesBilled();
+
+  /** Returns the total number of bytes processed by the query, if available. */
+  @Nullable
+  public abstract Long getTotalBytesProcessed();
+
+  /** Returns the total slot milliseconds for the query, if available. */
+  @Nullable
+  public abstract Long getTotalSlotMs();
+
+  /**
+   * Returns the number of rows affected by a DML statement (INSERT, UPDATE, DELETE, MERGE), if
+   * available.
+   */
+  @Nullable
+  public abstract Long getNumDmlAffectedRows();
+
   @Override
   public boolean hasNextPage() {
     return getPageNoSchema().hasNextPage();
@@ -109,6 +146,11 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
           .setQueryId(getQueryId())
           .setJobCreationReason(getJobCreationReason())
           .setRowsInPage(nextRows)
+          .setStatementType(getStatementType())
+          .setTotalBytesBilled(getTotalBytesBilled())
+          .setTotalBytesProcessed(getTotalBytesProcessed())
+          .setTotalSlotMs(getTotalSlotMs())
+          .setNumDmlAffectedRows(getNumDmlAffectedRows())
           .build();
     }
     return null;
@@ -147,13 +189,27 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
         .add("cursor", getNextPageToken())
         .add("queryId", getQueryId())
         .add("rowsInPage", getRowsInPage())
+        .add("statementType", getStatementType())
+        .add("totalBytesBilled", getTotalBytesBilled())
+        .add("totalBytesProcessed", getTotalBytesProcessed())
+        .add("totalSlotMs", getTotalSlotMs())
+        .add("numDmlAffectedRows", getNumDmlAffectedRows())
         .toString();
   }
 
   @Override
   public final int hashCode() {
     return Objects.hash(
-        getPageNoSchema(), getSchema(), getTotalRows(), getQueryId(), getRowsInPage());
+        getPageNoSchema(),
+        getSchema(),
+        getTotalRows(),
+        getQueryId(),
+        getRowsInPage(),
+        getStatementType(),
+        getTotalBytesBilled(),
+        getTotalBytesProcessed(),
+        getTotalSlotMs(),
+        getNumDmlAffectedRows());
   }
 
   @Override
@@ -170,6 +226,11 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
         && Objects.equals(getSchema(), response.getSchema())
         && getTotalRows() == response.getTotalRows()
         && Objects.equals(getQueryId(), response.getQueryId())
-        && Objects.equals(getRowsInPage(), response.getRowsInPage());
+        && Objects.equals(getRowsInPage(), response.getRowsInPage())
+        && Objects.equals(getStatementType(), response.getStatementType())
+        && Objects.equals(getTotalBytesBilled(), response.getTotalBytesBilled())
+        && Objects.equals(getTotalBytesProcessed(), response.getTotalBytesProcessed())
+        && Objects.equals(getTotalSlotMs(), response.getTotalSlotMs())
+        && Objects.equals(getNumDmlAffectedRows(), response.getNumDmlAffectedRows());
   }
 }

--- a/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
+++ b/java-bigquery/google-cloud-bigquery/src/main/java/com/google/cloud/bigquery/TableResult.java
@@ -97,27 +97,47 @@ public abstract class TableResult implements Page<FieldValueList>, Serializable 
   public abstract @Nullable Long getRowsInPage();
 
   /**
-   * Returns the statement type of the query (e.g. SELECT, INSERT, UPDATE, DDL, SCRIPT), if
-   * available.
+   * Returns the statement type of the query (e.g. SELECT, INSERT, UPDATE, DDL, SCRIPT).
+   *
+   * @return statement type, or {@code null} if not populated by the service
    */
   public abstract @Nullable StatementType getStatementType();
 
-  /** Returns the total number of bytes billed for the query, if available. */
+  /**
+   * Returns the total number of bytes billed for the query.
+   *
+   * @return total bytes billed, or {@code null} if not populated by the service
+   */
   public abstract @Nullable Long getTotalBytesBilled();
 
-  /** Returns the total number of bytes processed by the query, if available. */
+  /**
+   * Returns the total number of bytes processed by the query.
+   *
+   * @return total bytes processed, or {@code null} if not populated by the service
+   */
   public abstract @Nullable Long getTotalBytesProcessed();
 
-  /** Returns the total slot milliseconds for the query, if available. */
+  /**
+   * Returns the total slot milliseconds consumed by the query.
+   *
+   * @return total slot milliseconds, or {@code null} if not populated by the service
+   */
   public abstract @Nullable Long getTotalSlotMs();
 
   /**
-   * Returns the number of rows affected by a DML statement (INSERT, UPDATE, DELETE, MERGE), if
-   * available.
+   * Returns the number of rows affected by a DML statement (INSERT, UPDATE, DELETE, MERGE).
+   *
+   * @return number of affected rows for DML queries, or {@code null} if not populated by the
+   *     service
    */
   public abstract @Nullable Long getNumDmlAffectedRows();
 
-  /** Returns information about the session if this query is part of one, if available. */
+  /**
+   * Returns information about the BigQuery session if this query was executed within or created a
+   * session.
+   *
+   * @return session information, or {@code null} if not populated by the service
+   */
   public abstract @Nullable SessionInfo getSessionInfo();
 
   @Override

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -65,6 +65,7 @@ import com.google.cloud.bigquery.BigQuery.DatasetOption;
 import com.google.cloud.bigquery.BigQuery.JobOption;
 import com.google.cloud.bigquery.BigQuery.QueryResultsOption;
 import com.google.cloud.bigquery.InsertAllRequest.RowToInsert;
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
 import com.google.cloud.bigquery.spi.BigQueryRpcFactory;
 import com.google.cloud.bigquery.spi.v2.BigQueryRpc;
 import com.google.cloud.bigquery.spi.v2.HttpBigQueryRpc;
@@ -2874,7 +2875,11 @@ public class BigQueryImplTest {
             .setPageToken(null)
             .setRows(ImmutableList.of(TABLE_ROW))
             .setSchema(TABLE_SCHEMA.toPb())
+            .setStatementType("SELECT")
+            .setTotalBytesBilled(100L)
             .setTotalBytesProcessed(42L)
+            .setTotalSlotMs(50L)
+            .setNumDmlAffectedRows(0L)
             .setTotalRows(BigInteger.valueOf(1L));
 
     when(bigqueryRpcMock.queryRpcSkipExceptionTranslation(eq(PROJECT), requestPbCapture.capture()))
@@ -2883,6 +2888,12 @@ public class BigQueryImplTest {
     bigquery = options.getService();
     Object result = bigquery.queryWithTimeout(QUERY_JOB_CONFIGURATION_FOR_QUERY, null, 1000L);
     assertTrue(result instanceof TableResult);
+    TableResult tableResult = (TableResult) result;
+    assertEquals(StatementType.SELECT, tableResult.getStatementType());
+    assertEquals((Long) 100L, tableResult.getTotalBytesBilled());
+    assertEquals((Long) 42L, tableResult.getTotalBytesProcessed());
+    assertEquals((Long) 50L, tableResult.getTotalSlotMs());
+    assertEquals((Long) 0L, tableResult.getNumDmlAffectedRows());
     QueryRequest requestPb = requestPbCapture.getValue();
     assertEquals((Long) 1000L, requestPb.getTimeoutMs());
   }

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/BigQueryImplTest.java
@@ -52,6 +52,7 @@ import com.google.api.services.bigquery.model.JobStatistics;
 import com.google.api.services.bigquery.model.ProjectList;
 import com.google.api.services.bigquery.model.ProjectReference;
 import com.google.api.services.bigquery.model.QueryRequest;
+import com.google.api.services.bigquery.model.SessionInfo;
 import com.google.api.services.bigquery.model.TableCell;
 import com.google.api.services.bigquery.model.TableDataInsertAllRequest;
 import com.google.api.services.bigquery.model.TableDataInsertAllResponse;
@@ -170,6 +171,8 @@ public class BigQueryImplTest {
           .setField("timestampField");
   private static final TimePartitioning TIME_PARTITIONING_NULL_TYPE =
       TimePartitioning.fromPb(PB_TIMEPARTITIONING);
+  private static final String SESSION_ID = "test-session-id";
+  private static final SessionInfo PB_SESSION_INFO = new SessionInfo().setSessionId(SESSION_ID);
   private static final ImmutableMap<String, String> LABELS = ImmutableMap.of("key", "value");
   private static final StandardTableDefinition TABLE_DEFINITION_WITH_PARTITIONING =
       StandardTableDefinition.newBuilder()
@@ -2880,6 +2883,7 @@ public class BigQueryImplTest {
             .setTotalBytesProcessed(42L)
             .setTotalSlotMs(50L)
             .setNumDmlAffectedRows(0L)
+            .setSessionInfo(PB_SESSION_INFO)
             .setTotalRows(BigInteger.valueOf(1L));
 
     when(bigqueryRpcMock.queryRpcSkipExceptionTranslation(eq(PROJECT), requestPbCapture.capture()))
@@ -2894,6 +2898,8 @@ public class BigQueryImplTest {
     assertEquals((Long) 42L, tableResult.getTotalBytesProcessed());
     assertEquals((Long) 50L, tableResult.getTotalSlotMs());
     assertEquals((Long) 0L, tableResult.getNumDmlAffectedRows());
+    assertNotNull(tableResult.getSessionInfo());
+    assertEquals(SESSION_ID, tableResult.getSessionInfo().getSessionId());
     QueryRequest requestPb = requestPbCapture.getValue();
     assertEquals((Long) 1000L, requestPb.getTimeoutMs());
   }

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableResultTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableResultTest.java
@@ -21,6 +21,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.api.gax.paging.Page;
 import com.google.cloud.PageImpl;
+import com.google.cloud.bigquery.JobStatistics.QueryStatistics.StatementType;
+import com.google.cloud.bigquery.JobStatistics.SessionInfo;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +48,15 @@ class TableResultTest {
           null,
           ImmutableList.of(newFieldValueList("2")));
   private static final Schema SCHEMA = Schema.of(Field.of("field", LegacySQLTypeName.INTEGER));
+  private static final String SESSION_ID = "session_123";
+  private static final SessionInfo SESSION_INFO =
+      SessionInfo.newBuilder().setSessionId(SESSION_ID).build();
+  private static final String SESSION_ID_1 = "session_1";
+  private static final SessionInfo SESSION_INFO_1 =
+      SessionInfo.newBuilder().setSessionId(SESSION_ID_1).build();
+  private static final String SESSION_ID_2 = "session_2";
+  private static final SessionInfo SESSION_INFO_2 =
+      SessionInfo.newBuilder().setSessionId(SESSION_ID_2).build();
 
   private static FieldValueList newFieldValueList(String s) {
     return FieldValueList.of(ImmutableList.of(FieldValue.of(PRIMITIVE, s)));
@@ -124,27 +135,29 @@ class TableResultTest {
             .setTotalRows(3L)
             .setPageNoSchema(INNER_PAGE_0)
             .setRowsInPage(2L)
-            .setStatementType(JobStatistics.QueryStatistics.StatementType.SELECT)
+            .setStatementType(StatementType.SELECT)
             .setTotalBytesBilled(1024L)
             .setTotalBytesProcessed(2048L)
             .setTotalSlotMs(500L)
             .setNumDmlAffectedRows(0L)
+            .setSessionInfo(SESSION_INFO)
             .build();
 
-    assertThat(result.getStatementType())
-        .isEqualTo(JobStatistics.QueryStatistics.StatementType.SELECT);
+    assertThat(result.getStatementType()).isEqualTo(StatementType.SELECT);
     assertThat(result.getTotalBytesBilled()).isEqualTo(1024L);
     assertThat(result.getTotalBytesProcessed()).isEqualTo(2048L);
     assertThat(result.getTotalSlotMs()).isEqualTo(500L);
     assertThat(result.getNumDmlAffectedRows()).isEqualTo(0L);
+    assertThat(result.getSessionInfo()).isEqualTo(SESSION_INFO);
+    assertThat(result.getSessionInfo().getSessionId()).isEqualTo(SESSION_ID);
 
     TableResult next = result.getNextPage();
-    assertThat(next.getStatementType())
-        .isEqualTo(JobStatistics.QueryStatistics.StatementType.SELECT);
+    assertThat(next.getStatementType()).isEqualTo(StatementType.SELECT);
     assertThat(next.getTotalBytesBilled()).isEqualTo(1024L);
     assertThat(next.getTotalBytesProcessed()).isEqualTo(2048L);
     assertThat(next.getTotalSlotMs()).isEqualTo(500L);
     assertThat(next.getNumDmlAffectedRows()).isEqualTo(0L);
+    assertThat(next.getSessionInfo()).isEqualTo(SESSION_INFO);
   }
 
   @Test
@@ -155,23 +168,24 @@ class TableResultTest {
             .setTotalRows(3L)
             .setPageNoSchema(INNER_PAGE_0)
             .setRowsInPage(2L)
-            .setStatementType(JobStatistics.QueryStatistics.StatementType.INSERT)
+            .setStatementType(StatementType.INSERT)
             .setTotalBytesBilled(500L)
             .setTotalBytesProcessed(1000L)
             .setTotalSlotMs(250L)
             .setNumDmlAffectedRows(5L)
+            .setSessionInfo(SESSION_INFO)
             .build();
 
     TableResult modified =
         result.toBuilder()
-            .setStatementType(JobStatistics.QueryStatistics.StatementType.UPDATE)
+            .setStatementType(StatementType.UPDATE)
             .setNumDmlAffectedRows(10L)
             .build();
 
-    assertThat(modified.getStatementType())
-        .isEqualTo(JobStatistics.QueryStatistics.StatementType.UPDATE);
+    assertThat(modified.getStatementType()).isEqualTo(StatementType.UPDATE);
     assertThat(modified.getNumDmlAffectedRows()).isEqualTo(10L);
     assertThat(modified.getTotalBytesBilled()).isEqualTo(500L);
+    assertThat(modified.getSessionInfo()).isEqualTo(SESSION_INFO);
   }
 
   @Test
@@ -182,11 +196,12 @@ class TableResultTest {
             .setTotalRows(3L)
             .setPageNoSchema(INNER_PAGE_0)
             .setRowsInPage(2L)
-            .setStatementType(JobStatistics.QueryStatistics.StatementType.SELECT)
+            .setStatementType(StatementType.SELECT)
             .setTotalBytesBilled(100L)
             .setTotalBytesProcessed(200L)
             .setTotalSlotMs(50L)
             .setNumDmlAffectedRows(0L)
+            .setSessionInfo(SESSION_INFO_1)
             .build();
 
     TableResult result2 =
@@ -195,11 +210,12 @@ class TableResultTest {
             .setTotalRows(3L)
             .setPageNoSchema(INNER_PAGE_0)
             .setRowsInPage(2L)
-            .setStatementType(JobStatistics.QueryStatistics.StatementType.SELECT)
+            .setStatementType(StatementType.SELECT)
             .setTotalBytesBilled(100L)
             .setTotalBytesProcessed(200L)
             .setTotalSlotMs(50L)
             .setNumDmlAffectedRows(0L)
+            .setSessionInfo(SESSION_INFO_1)
             .build();
 
     TableResult result3 =
@@ -208,11 +224,12 @@ class TableResultTest {
             .setTotalRows(3L)
             .setPageNoSchema(INNER_PAGE_0)
             .setRowsInPage(2L)
-            .setStatementType(JobStatistics.QueryStatistics.StatementType.DELETE)
+            .setStatementType(StatementType.DELETE)
             .setTotalBytesBilled(100L)
             .setTotalBytesProcessed(200L)
             .setTotalSlotMs(50L)
             .setNumDmlAffectedRows(1L)
+            .setSessionInfo(SESSION_INFO_2)
             .build();
 
     assertThat(result1).isEqualTo(result2);
@@ -220,5 +237,6 @@ class TableResultTest {
     assertThat(result1).isNotEqualTo(result3);
     assertThat(result1.toString()).contains("statementType=SELECT");
     assertThat(result1.toString()).contains("totalBytesBilled=100");
+    assertThat(result1.toString()).contains("sessionId=" + SESSION_ID_1);
   }
 }

--- a/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableResultTest.java
+++ b/java-bigquery/google-cloud-bigquery/src/test/java/com/google/cloud/bigquery/TableResultTest.java
@@ -115,4 +115,110 @@ class TableResultTest {
             newFieldValueList("2").withSchema(SCHEMA.getFields()))
         .inOrder();
   }
+
+  @Test
+  void testStatementTypeAndExecutionStats() {
+    TableResult result =
+        TableResult.newBuilder()
+            .setSchema(SCHEMA)
+            .setTotalRows(3L)
+            .setPageNoSchema(INNER_PAGE_0)
+            .setRowsInPage(2L)
+            .setStatementType(JobStatistics.QueryStatistics.StatementType.SELECT)
+            .setTotalBytesBilled(1024L)
+            .setTotalBytesProcessed(2048L)
+            .setTotalSlotMs(500L)
+            .setNumDmlAffectedRows(0L)
+            .build();
+
+    assertThat(result.getStatementType())
+        .isEqualTo(JobStatistics.QueryStatistics.StatementType.SELECT);
+    assertThat(result.getTotalBytesBilled()).isEqualTo(1024L);
+    assertThat(result.getTotalBytesProcessed()).isEqualTo(2048L);
+    assertThat(result.getTotalSlotMs()).isEqualTo(500L);
+    assertThat(result.getNumDmlAffectedRows()).isEqualTo(0L);
+
+    TableResult next = result.getNextPage();
+    assertThat(next.getStatementType())
+        .isEqualTo(JobStatistics.QueryStatistics.StatementType.SELECT);
+    assertThat(next.getTotalBytesBilled()).isEqualTo(1024L);
+    assertThat(next.getTotalBytesProcessed()).isEqualTo(2048L);
+    assertThat(next.getTotalSlotMs()).isEqualTo(500L);
+    assertThat(next.getNumDmlAffectedRows()).isEqualTo(0L);
+  }
+
+  @Test
+  void testToBuilder() {
+    TableResult result =
+        TableResult.newBuilder()
+            .setSchema(SCHEMA)
+            .setTotalRows(3L)
+            .setPageNoSchema(INNER_PAGE_0)
+            .setRowsInPage(2L)
+            .setStatementType(JobStatistics.QueryStatistics.StatementType.INSERT)
+            .setTotalBytesBilled(500L)
+            .setTotalBytesProcessed(1000L)
+            .setTotalSlotMs(250L)
+            .setNumDmlAffectedRows(5L)
+            .build();
+
+    TableResult modified =
+        result.toBuilder()
+            .setStatementType(JobStatistics.QueryStatistics.StatementType.UPDATE)
+            .setNumDmlAffectedRows(10L)
+            .build();
+
+    assertThat(modified.getStatementType())
+        .isEqualTo(JobStatistics.QueryStatistics.StatementType.UPDATE);
+    assertThat(modified.getNumDmlAffectedRows()).isEqualTo(10L);
+    assertThat(modified.getTotalBytesBilled()).isEqualTo(500L);
+  }
+
+  @Test
+  void testEqualsAndHashCode() {
+    TableResult result1 =
+        TableResult.newBuilder()
+            .setSchema(SCHEMA)
+            .setTotalRows(3L)
+            .setPageNoSchema(INNER_PAGE_0)
+            .setRowsInPage(2L)
+            .setStatementType(JobStatistics.QueryStatistics.StatementType.SELECT)
+            .setTotalBytesBilled(100L)
+            .setTotalBytesProcessed(200L)
+            .setTotalSlotMs(50L)
+            .setNumDmlAffectedRows(0L)
+            .build();
+
+    TableResult result2 =
+        TableResult.newBuilder()
+            .setSchema(SCHEMA)
+            .setTotalRows(3L)
+            .setPageNoSchema(INNER_PAGE_0)
+            .setRowsInPage(2L)
+            .setStatementType(JobStatistics.QueryStatistics.StatementType.SELECT)
+            .setTotalBytesBilled(100L)
+            .setTotalBytesProcessed(200L)
+            .setTotalSlotMs(50L)
+            .setNumDmlAffectedRows(0L)
+            .build();
+
+    TableResult result3 =
+        TableResult.newBuilder()
+            .setSchema(SCHEMA)
+            .setTotalRows(3L)
+            .setPageNoSchema(INNER_PAGE_0)
+            .setRowsInPage(2L)
+            .setStatementType(JobStatistics.QueryStatistics.StatementType.DELETE)
+            .setTotalBytesBilled(100L)
+            .setTotalBytesProcessed(200L)
+            .setTotalSlotMs(50L)
+            .setNumDmlAffectedRows(1L)
+            .build();
+
+    assertThat(result1).isEqualTo(result2);
+    assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
+    assertThat(result1).isNotEqualTo(result3);
+    assertThat(result1.toString()).contains("statementType=SELECT");
+    assertThat(result1.toString()).contains("totalBytesBilled=100");
+  }
 }

--- a/java-bigquery/pom.xml
+++ b/java-bigquery/pom.xml
@@ -55,7 +55,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>
     <site.installationModule>google-cloud-bigquery-parent</site.installationModule>
-    <google-api-services-bigquery.version>v2-rev20251012-2.0.0</google-api-services-bigquery.version>
+    <google-api-services-bigquery.version>v2-rev20260731-2.0.0</google-api-services-bigquery.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
b/549680449

This PR exposes `StatementType` and jobless query execution metrics on `TableResult` by plumbing them from `QueryResponse` and `JobStatistics.QueryStatistics`. 

This enables downstream consumers (such as the BigQuery JDBC driver) to inspect query statement types and execution statistics directly from `TableResult` without needing to issue secondary jobs or dry-run queries.

## Changes
- **Dependency Update**: Bumped `google-api-services-bigquery` to `v2-rev20260731-2.0.0` in `google-cloud-jar-parent/pom.xml` and `java-bigquery/pom.xml`.
- **TableResult**: Added getters, builder setters, pagination propagation (`getNextPage()`), `toString()`, `hashCode()`, and `equals()` for:
  - `getStatementType()` (`StatementType`)
  - `getTotalBytesBilled()` (`Long`)
  - `getTotalBytesProcessed()` (`Long`)
  - `getTotalSlotMs()` (`Long`)
  - `getNumDmlAffectedRows()` (`Long`)
- **BigQueryImpl**: Plumbed these fields from `QueryResponse` when building `TableResult` in `queryRpc()`.
- **Job**: Plumbed `StatementType` and query metrics from `QueryStatistics` when creating `TableResult` in `getQueryResults()`.
- **Tests**: Added unit tests in `TableResultTest` and `BigQueryImplTest` verifying field retrieval, pagination propagation, builder modifications, and serialization.
