### PR TITLE
fix(auth): add missing @Nullable annotations across credential types and providers

### DIFF
--- a/google-auth-library-java/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/google-auth-library-java/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -68,7 +68,8 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
 
   private transient AppIdentityService appIdentityService;
 
-  private AppEngineCredentials(Collection<String> scopes, AppIdentityService appIdentityService) {
+  private AppEngineCredentials(
+      @Nullable Collection<String> scopes, @Nullable AppIdentityService appIdentityService) {
     this.scopes = scopes == null ? ImmutableSet.<String>of() : ImmutableList.copyOf(scopes);
     this.appIdentityService =
         appIdentityService != null
@@ -175,8 +176,8 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
 
   public static class Builder extends GoogleCredentials.Builder {
 
-    private Collection<String> scopes;
-    private AppIdentityService appIdentityService;
+    private @Nullable Collection<String> scopes;
+    private @Nullable AppIdentityService appIdentityService;
 
     protected Builder() {}
 
@@ -186,22 +187,22 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       this.scopes = scopes;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setAppIdentityService(AppIdentityService appIdentityService) {
+    public Builder setAppIdentityService(@Nullable AppIdentityService appIdentityService) {
       this.appIdentityService = appIdentityService;
       return this;
     }
 
-    public Collection<String> getScopes() {
+    public @Nullable Collection<String> getScopes() {
       return scopes;
     }
 
-    public AppIdentityService getAppIdentityService() {
+    public @Nullable AppIdentityService getAppIdentityService() {
       return appIdentityService;
     }
 

--- a/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -604,8 +604,8 @@ public class ClientSideCredentialAccessBoundaryFactory {
    */
   public static class Builder {
     private GoogleCredentials sourceCredential;
-    private HttpTransportFactory transportFactory;
-    private String universeDomain;
+    private @Nullable HttpTransportFactory transportFactory;
+    private @Nullable String universeDomain;
     private String tokenExchangeEndpoint;
     private Duration minimumTokenLifetime;
     private Duration refreshMargin;
@@ -686,7 +686,7 @@ public class ClientSideCredentialAccessBoundaryFactory {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
@@ -698,7 +698,7 @@ public class ClientSideCredentialAccessBoundaryFactory {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       this.universeDomain = universeDomain;
       return this;
     }
@@ -742,8 +742,8 @@ public class ClientSideCredentialAccessBoundaryFactory {
       try {
         if (!universeDomain.equals(sourceCredential.getUniverseDomain())) {
           throw new IllegalArgumentException(
-              "The client side access boundary credential's universe domain must be the same as the source "
-                  + "credential.");
+              "The client side access boundary credential's universe domain must be the same as the"
+                  + " source credential.");
         }
       } catch (IOException e) {
         // Throwing an IOException would be a breaking change, so wrap it here.

--- a/google-auth-library-java/credentials/java/com/google/auth/Credentials.java
+++ b/google-auth-library-java/credentials/java/com/google/auth/Credentials.java
@@ -121,7 +121,7 @@ public abstract class Credentials implements Serializable {
    * @param callback Callback to execute when the request is finished.
    */
   public void getRequestMetadata(
-      final URI uri, Executor executor, final RequestMetadataCallback callback) {
+      final @Nullable URI uri, Executor executor, final RequestMetadataCallback callback) {
     executor.execute(
         new Runnable() {
           @Override
@@ -137,7 +137,7 @@ public abstract class Credentials implements Serializable {
    * @param uri URI of the entry point for the request.
    * @param callback Callback handler to execute when the metadata completes.
    */
-  protected final void blockingGetToCallback(URI uri, RequestMetadataCallback callback) {
+  protected final void blockingGetToCallback(@Nullable URI uri, RequestMetadataCallback callback) {
     Map<String, List<String>> result;
     try {
       result = getRequestMetadata(uri);

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/MtlsUtils.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/MtlsUtils.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utility class for mTLS related operations.
@@ -65,14 +66,17 @@ public class MtlsUtils {
    * @throws IOException if the certificate configuration cannot be found or loaded.
    */
   public static String getCertificatePath(
-      EnvironmentProvider envProvider, PropertyProvider propProvider, String certConfigPathOverride)
+      EnvironmentProvider envProvider,
+      PropertyProvider propProvider,
+      @Nullable String certConfigPathOverride)
       throws IOException {
     String certPath =
         getWorkloadCertificateConfiguration(envProvider, propProvider, certConfigPathOverride)
             .getCertPath();
     if (Strings.isNullOrEmpty(certPath)) {
       throw new CertificateSourceUnavailableException(
-          "Certificate configuration loaded successfully, but does not contain a 'certificate_file' path.");
+          "Certificate configuration loaded successfully, but does not contain a 'certificate_file'"
+              + " path.");
     }
     return certPath;
   }
@@ -92,7 +96,9 @@ public class MtlsUtils {
    * @throws IOException if the configuration file cannot be found, read, or parsed
    */
   static WorkloadCertificateConfiguration getWorkloadCertificateConfiguration(
-      EnvironmentProvider envProvider, PropertyProvider propProvider, String certConfigPathOverride)
+      EnvironmentProvider envProvider,
+      PropertyProvider propProvider,
+      @Nullable String certConfigPathOverride)
       throws IOException {
     File certConfig;
     if (certConfigPathOverride != null) {

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/X509Provider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/mtls/X509Provider.java
@@ -54,7 +54,7 @@ import org.jspecify.annotations.Nullable;
 public class X509Provider implements MtlsProvider {
   private final EnvironmentProvider envProvider;
   private final PropertyProvider propProvider;
-  private final String certConfigPathOverride;
+  private final @Nullable String certConfigPathOverride;
 
   /**
    * Creates an X509 provider with an override path for the certificate configuration, bypassing the
@@ -69,7 +69,7 @@ public class X509Provider implements MtlsProvider {
   public X509Provider(
       EnvironmentProvider envProvider,
       PropertyProvider propProvider,
-      String certConfigPathOverride) {
+      @Nullable String certConfigPathOverride) {
     this.envProvider = envProvider;
     this.propProvider = propProvider;
     this.certConfigPathOverride = certConfigPathOverride;

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AccessToken.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AccessToken.java
@@ -56,7 +56,7 @@ public class AccessToken implements Serializable {
    * @param tokenValue String representation of the access token.
    * @param expirationTime Time when access token will expire.
    */
-  public AccessToken(String tokenValue, Date expirationTime) {
+  public AccessToken(String tokenValue, @Nullable Date expirationTime) {
     this.tokenValue = tokenValue;
     this.expirationTimeMillis = (expirationTime == null) ? null : expirationTime.getTime();
     this.scopes = new ArrayList<>();
@@ -108,7 +108,7 @@ public class AccessToken implements Serializable {
     return new Date(expirationTimeMillis);
   }
 
-  Long getExpirationTimeMillis() {
+  @Nullable Long getExpirationTimeMillis() {
     return expirationTimeMillis;
   }
 
@@ -145,8 +145,8 @@ public class AccessToken implements Serializable {
   }
 
   public static class Builder {
-    private String tokenValue;
-    private Date expirationTime;
+    private @Nullable String tokenValue;
+    private @Nullable Date expirationTime;
     private List<String> scopes = new ArrayList<>();
 
     protected Builder() {}
@@ -157,7 +157,7 @@ public class AccessToken implements Serializable {
       this.scopes = accessToken.getScopes();
     }
 
-    public String getTokenValue() {
+    public @Nullable String getTokenValue() {
       return this.tokenValue;
     }
 
@@ -165,7 +165,7 @@ public class AccessToken implements Serializable {
       return this.scopes;
     }
 
-    public Date getExpirationTime() {
+    public @Nullable Date getExpirationTime() {
       return this.expirationTime;
     }
 
@@ -176,7 +176,7 @@ public class AccessToken implements Serializable {
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(String scopes) {
+    public Builder setScopes(@Nullable String scopes) {
       if (scopes != null && scopes.trim().length() > 0) {
         this.scopes = Arrays.asList(scopes.split(" "));
       }
@@ -184,7 +184,7 @@ public class AccessToken implements Serializable {
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(List<String> scopes) {
+    public Builder setScopes(@Nullable List<String> scopes) {
       if (scopes == null) {
         this.scopes = new ArrayList<>();
       } else {
@@ -195,7 +195,7 @@ public class AccessToken implements Serializable {
     }
 
     @CanIgnoreReturnValue
-    public Builder setExpirationTime(Date expirationTime) {
+    public Builder setExpirationTime(@Nullable Date expirationTime) {
       this.expirationTime = expirationTime;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AppEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AppEngineCredentials.java
@@ -74,15 +74,16 @@ class AppEngineCredentials extends GoogleCredentials implements ServiceAccountSi
   private final Collection<String> scopes;
   private final boolean scopesRequired;
 
-  private transient Object appIdentityService;
-  private transient Method getAccessToken;
-  private transient Method getAccessTokenResult;
-  private transient Method getExpirationTime;
-  private transient Method signForApp;
-  private transient Method getSignature;
-  private transient String account;
+  private transient @Nullable Object appIdentityService;
+  private transient @Nullable Method getAccessToken;
+  private transient @Nullable Method getAccessTokenResult;
+  private transient @Nullable Method getExpirationTime;
+  private transient @Nullable Method signForApp;
+  private transient @Nullable Method getSignature;
+  private transient @Nullable String account;
 
-  AppEngineCredentials(Collection<String> scopes, Collection<String> defaultScopes)
+  AppEngineCredentials(
+      @Nullable Collection<String> scopes, @Nullable Collection<String> defaultScopes)
       throws IOException {
     // Use defaultScopes only when scopes don't exist.
     if (scopes == null || scopes.isEmpty()) {
@@ -96,7 +97,7 @@ class AppEngineCredentials extends GoogleCredentials implements ServiceAccountSi
   }
 
   AppEngineCredentials(
-      Collection<String> scopes,
+      @Nullable Collection<String> scopes,
       @Nullable Collection<String> defaultScopes,
       AppEngineCredentials unscoped) {
     this.appIdentityService = unscoped.appIdentityService;
@@ -164,13 +165,13 @@ class AppEngineCredentials extends GoogleCredentials implements ServiceAccountSi
   }
 
   @Override
-  public GoogleCredentials createScoped(Collection<String> scopes) {
+  public GoogleCredentials createScoped(@Nullable Collection<String> scopes) {
     return new AppEngineCredentials(scopes, null, this);
   }
 
   @Override
   public GoogleCredentials createScoped(
-      Collection<String> scopes, Collection<String> defaultScopes) {
+      @Nullable Collection<String> scopes, @Nullable Collection<String> defaultScopes) {
     return new AppEngineCredentials(scopes, defaultScopes, this);
   }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -83,7 +83,8 @@ public class AwsCredentials extends ExternalAccountCredentials {
     // Check that one and only one of supplier or credential source are provided.
     if (builder.awsSecurityCredentialsSupplier != null && builder.credentialSource != null) {
       throw new IllegalArgumentException(
-          "AwsCredentials cannot have both an awsSecurityCredentialsSupplier and a credentialSource.");
+          "AwsCredentials cannot have both an awsSecurityCredentialsSupplier and a"
+              + " credentialSource.");
     }
     if (builder.awsSecurityCredentialsSupplier == null && builder.credentialSource == null) {
       throw new IllegalArgumentException(
@@ -203,8 +204,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
     return this.awsSecurityCredentialsSupplier;
   }
 
-  @Nullable
-  public String getRegionalCredentialVerificationUrlOverride() {
+  public @Nullable String getRegionalCredentialVerificationUrlOverride() {
     return this.regionalCredentialVerificationUrlOverride;
   }
 
@@ -239,7 +239,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
 
     private AwsSecurityCredentialsSupplier awsSecurityCredentialsSupplier;
 
-    private String regionalCredentialVerificationUrlOverride;
+    private @Nullable String regionalCredentialVerificationUrlOverride;
 
     Builder() {}
 
@@ -277,13 +277,13 @@ public class AwsCredentials extends ExternalAccountCredentials {
      */
     @CanIgnoreReturnValue
     public Builder setRegionalCredentialVerificationUrlOverride(
-        String regionalCredentialVerificationUrlOverride) {
+        @Nullable String regionalCredentialVerificationUrlOverride) {
       this.regionalCredentialVerificationUrlOverride = regionalCredentialVerificationUrlOverride;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       super.setHttpTransportFactory(transportFactory);
       return this;
     }
@@ -319,55 +319,56 @@ public class AwsCredentials extends ExternalAccountCredentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
+    public Builder setServiceAccountImpersonationUrl(
+        @Nullable String serviceAccountImpersonationUrl) {
       super.setServiceAccountImpersonationUrl(serviceAccountImpersonationUrl);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+    public Builder setTokenInfoUrl(@Nullable String tokenInfoUrl) {
       super.setTokenInfoUrl(tokenInfoUrl);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientId(String clientId) {
+    public Builder setClientId(@Nullable String clientId) {
       super.setClientId(clientId);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientSecret(String clientSecret) {
+    public Builder setClientSecret(@Nullable String clientSecret) {
       super.setClientSecret(clientSecret);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       super.setScopes(scopes);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
+    public Builder setWorkforcePoolUserProject(@Nullable String workforcePoolUserProject) {
       super.setWorkforcePoolUserProject(workforcePoolUserProject);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
+    public Builder setServiceAccountImpersonationOptions(@Nullable Map<String, Object> optionsMap) {
       super.setServiceAccountImpersonationOptions(optionsMap);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       super.setUniverseDomain(universeDomain);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -145,7 +145,7 @@ public class CloudShellCredentials extends GoogleCredentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.quotaProjectId = quotaProjectId;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -358,7 +358,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
    *     no fallback project ID can be determined.
    */
   @Override
-  public String getProjectId() {
+  public @Nullable String getProjectId() {
     synchronized (this) {
       if (this.projectId != null) {
         return this.projectId;
@@ -377,7 +377,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
     return this.projectId;
   }
 
-  private String getProjectIdFromMetadata() {
+  private @Nullable String getProjectIdFromMetadata() {
     try {
       HttpResponse response = getMetadataResponse(getProjectIdUrl(), RequestType.UNTRACKED, false);
       int statusCode = response.getStatusCode();
@@ -427,11 +427,10 @@ public class ComputeEngineCredentials extends GoogleCredentials
     if (statusCode == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
       throw new IOException(
           String.format(
-              "Error code %s trying to get security access token from"
-                  + " Compute Engine metadata for the default service account. This may be because"
-                  + " the virtual machine instance does not have permission scopes specified."
-                  + " It is possible to skip checking for Compute Engine metadata by specifying the environment "
-                  + " variable "
+              "Error code %s trying to get security access token from Compute Engine metadata for"
+                  + " the default service account. This may be because the virtual machine instance"
+                  + " does not have permission scopes specified. It is possible to skip checking"
+                  + " for Compute Engine metadata by specifying the environment  variable "
                   + DefaultCredentialsProvider.NO_GCE_CHECK_ENV_VAR
                   + "=true.",
               statusCode));
@@ -476,7 +475,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
    * @return IdToken object which includes the raw id_token, JsonWebSignature
    */
   @Override
-  public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options)
+  public IdToken idTokenWithAudience(
+      @Nullable String targetAudience, @Nullable List<IdTokenProvider.Option> options)
       throws IOException {
     GenericUrl documentUrl = new GenericUrl(getIdentityDocumentUrl());
     if (options != null) {
@@ -504,7 +504,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
     if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
       throw new IOException(
           String.format(
-              "Unexpected Error code %s trying to get identity token from Compute Engine metadata: %s",
+              "Unexpected Error code %s trying to get identity token from Compute Engine metadata:"
+                  + " %s",
               statusCode, response.parseAsString()));
     }
     InputStream content = response.getContent();
@@ -644,7 +645,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
   }
 
   @VisibleForTesting
-  void setProjectId(String projectId) {
+  void setProjectId(@Nullable String projectId) {
     this.projectId = projectId;
   }
 
@@ -867,12 +868,12 @@ public class ComputeEngineCredentials extends GoogleCredentials
   }
 
   public static class Builder extends GoogleCredentials.Builder {
-    private HttpTransportFactory transportFactory;
-    private Collection<String> scopes;
-    private Collection<String> defaultScopes;
+    private @Nullable HttpTransportFactory transportFactory;
+    private @Nullable Collection<String> scopes;
+    private @Nullable Collection<String> defaultScopes;
 
-    private GoogleAuthTransport transport;
-    private BindingEnforcement bindingEnforcement;
+    private @Nullable GoogleAuthTransport transport;
+    private @Nullable BindingEnforcement bindingEnforcement;
 
     protected Builder() {
       setRefreshMargin(COMPUTE_REFRESH_MARGIN);
@@ -886,31 +887,31 @@ public class ComputeEngineCredentials extends GoogleCredentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       this.scopes = scopes;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setDefaultScopes(Collection<String> defaultScopes) {
+    public Builder setDefaultScopes(@Nullable Collection<String> defaultScopes) {
       this.defaultScopes = defaultScopes;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       this.universeDomain = universeDomain;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.quotaProjectId = quotaProjectId;
       return this;
     }
@@ -921,7 +922,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
      * @param transport the transport type over which to authenticate to Google APIs
      */
     @CanIgnoreReturnValue
-    public Builder setGoogleAuthTransport(GoogleAuthTransport transport) {
+    public Builder setGoogleAuthTransport(@Nullable GoogleAuthTransport transport) {
       this.transport = transport;
       return this;
     }
@@ -932,20 +933,20 @@ public class ComputeEngineCredentials extends GoogleCredentials
      * @param bindingEnforcement the token binding enforcement policy.
      */
     @CanIgnoreReturnValue
-    public Builder setBindingEnforcement(BindingEnforcement bindingEnforcement) {
+    public Builder setBindingEnforcement(@Nullable BindingEnforcement bindingEnforcement) {
       this.bindingEnforcement = bindingEnforcement;
       return this;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 
-    public Collection<String> getScopes() {
+    public @Nullable Collection<String> getScopes() {
       return scopes;
     }
 
-    public Collection<String> getDefaultScopes() {
+    public @Nullable Collection<String> getDefaultScopes() {
       return defaultScopes;
     }
 
@@ -954,7 +955,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
      *
      * @return the transport type over which to authenticate to Google APIs
      */
-    public GoogleAuthTransport getGoogleAuthTransport() {
+    public @Nullable GoogleAuthTransport getGoogleAuthTransport() {
       return transport;
     }
 
@@ -963,7 +964,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
      *
      * @return the token binding enforcement policy.
      */
-    public BindingEnforcement getBindingEnforcement() {
+    public @Nullable BindingEnforcement getBindingEnforcement() {
       return bindingEnforcement;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java
@@ -197,8 +197,7 @@ public final class CredentialAccessBoundary {
       return availablePermissions;
     }
 
-    @Nullable
-    public AvailabilityCondition getAvailabilityCondition() {
+    public @Nullable AvailabilityCondition getAvailabilityCondition() {
       return availabilityCondition;
     }
 
@@ -269,7 +268,8 @@ public final class CredentialAccessBoundary {
        * @return this {@code Builder} object
        */
       @CanIgnoreReturnValue
-      public Builder setAvailabilityCondition(AvailabilityCondition availabilityCondition) {
+      public Builder setAvailabilityCondition(
+          @Nullable AvailabilityCondition availabilityCondition) {
         this.availabilityCondition = availabilityCondition;
         return this;
       }
@@ -358,7 +358,7 @@ public final class CredentialAccessBoundary {
          * @return this {@code Builder} object
          */
         @CanIgnoreReturnValue
-        public Builder setTitle(String title) {
+        public Builder setTitle(@Nullable String title) {
           this.title = title;
           return this;
         }
@@ -370,7 +370,7 @@ public final class CredentialAccessBoundary {
          * @return this {@code Builder} object
          */
         @CanIgnoreReturnValue
-        public Builder setDescription(String description) {
+        public Builder setDescription(@Nullable String description) {
           this.description = description;
           return this;
         }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
@@ -41,6 +41,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * DownscopedCredentials enables the ability to downscope, or restrict, the Identity and Access
@@ -206,8 +207,8 @@ public final class DownscopedCredentials extends OAuth2Credentials {
 
     private GoogleCredentials sourceCredential;
     private CredentialAccessBoundary credentialAccessBoundary;
-    private HttpTransportFactory transportFactory;
-    private String universeDomain;
+    private @Nullable HttpTransportFactory transportFactory;
+    private @Nullable String universeDomain;
 
     private Builder() {}
 
@@ -243,7 +244,7 @@ public final class DownscopedCredentials extends OAuth2Credentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
@@ -255,7 +256,7 @@ public final class DownscopedCredentials extends OAuth2Credentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       this.universeDomain = universeDomain;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/EnvironmentProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/EnvironmentProvider.java
@@ -32,6 +32,7 @@ package com.google.auth.oauth2;
 
 import com.google.api.core.InternalApi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for an environment provider.
@@ -41,5 +42,5 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @InternalApi
 public interface EnvironmentProvider {
-  String getEnv(String name);
+  @Nullable String getEnv(String name);
 }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -265,7 +265,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     this.workforcePoolUserProject = builder.workforcePoolUserProject;
     if (workforcePoolUserProject != null && !isWorkforcePoolConfiguration()) {
       throw new IllegalArgumentException(
-          "The workforce_pool_user_project parameter should only be provided for a Workforce Pool configuration.");
+          "The workforce_pool_user_project parameter should only be provided for a Workforce Pool"
+              + " configuration.");
     }
 
     validateTokenUrl(tokenUrl);
@@ -318,7 +319,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
 
   @Override
   public void getRequestMetadata(
-      URI uri, Executor executor, final RequestMetadataCallback callback) {
+      @Nullable URI uri, Executor executor, final RequestMetadataCallback callback) {
     super.getRequestMetadata(
         uri,
         executor,
@@ -591,6 +592,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     return tokenUrl;
   }
 
+  @Nullable
   public String getTokenInfoUrl() {
     return tokenInfoUrl;
   }
@@ -771,11 +773,11 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     protected String audience;
     protected String subjectTokenType;
     protected String tokenUrl;
-    protected String tokenInfoUrl;
+    protected @Nullable String tokenInfoUrl;
     protected CredentialSource credentialSource;
     protected EnvironmentProvider environmentProvider;
     protected PropertyProvider propertyProvider;
-    protected HttpTransportFactory transportFactory;
+    protected @Nullable HttpTransportFactory transportFactory;
 
     @Nullable protected String serviceAccountImpersonationUrl;
     @Nullable protected String clientId;
@@ -819,7 +821,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
@@ -896,7 +898,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
+    public Builder setServiceAccountImpersonationUrl(
+        @Nullable String serviceAccountImpersonationUrl) {
       this.serviceAccountImpersonationUrl = serviceAccountImpersonationUrl;
       return this;
     }
@@ -909,7 +912,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+    public Builder setTokenInfoUrl(@Nullable String tokenInfoUrl) {
       this.tokenInfoUrl = tokenInfoUrl;
       return this;
     }
@@ -922,7 +925,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      */
     @Override
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
@@ -934,7 +937,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setClientId(String clientId) {
+    public Builder setClientId(@Nullable String clientId) {
       this.clientId = clientId;
       return this;
     }
@@ -946,7 +949,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setClientSecret(String clientSecret) {
+    public Builder setClientSecret(@Nullable String clientSecret) {
       this.clientSecret = clientSecret;
       return this;
     }
@@ -958,7 +961,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       this.scopes = scopes;
       return this;
     }
@@ -972,7 +975,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
+    public Builder setWorkforcePoolUserProject(@Nullable String workforcePoolUserProject) {
       this.workforcePoolUserProject = workforcePoolUserProject;
       return this;
     }
@@ -984,7 +987,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
+    public Builder setServiceAccountImpersonationOptions(@Nullable Map<String, Object> optionsMap) {
       this.serviceAccountImpersonationOptions = new ServiceAccountImpersonationOptions(optionsMap);
       return this;
     }
@@ -997,7 +1000,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      */
     @CanIgnoreReturnValue
     @Override
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       super.setUniverseDomain(universeDomain);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GdchCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GdchCredentials.java
@@ -110,10 +110,10 @@ public class GdchCredentials extends GoogleCredentials {
   private final String projectId;
   private final String serviceIdentityName;
   private final URI tokenServerUri;
-  private final String apiAudience;
+  private final @Nullable String apiAudience;
   private final int lifetime;
   private final String transportFactoryClassName;
-  private final String caCertPath;
+  private final @Nullable String caCertPath;
   private transient HttpTransportFactory transportFactory;
 
   /**
@@ -444,7 +444,7 @@ public class GdchCredentials extends GoogleCredentials {
    *
    * @return the audience string, or null if no audience has been set.
    */
-  public final String getGdchAudience() {
+  public final @Nullable String getGdchAudience() {
     return apiAudience;
   }
 
@@ -472,7 +472,7 @@ public class GdchCredentials extends GoogleCredentials {
     return transportFactory;
   }
 
-  public final String getCaCertPath() {
+  public final @Nullable String getCaCertPath() {
     return caCertPath;
   }
 
@@ -602,7 +602,7 @@ public class GdchCredentials extends GoogleCredentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setCaCertPath(String caCertPath) {
+    public Builder setCaCertPath(@Nullable String caCertPath) {
       this.caCertPath = caCertPath;
       return this;
     }
@@ -628,7 +628,7 @@ public class GdchCredentials extends GoogleCredentials {
       return projectId;
     }
 
-    public String getPrivateKeyId() {
+    public @Nullable String getPrivateKeyId() {
       return privateKeyId;
     }
 
@@ -648,7 +648,7 @@ public class GdchCredentials extends GoogleCredentials {
       return transportFactory;
     }
 
-    public String getCaCertPath() {
+    public @Nullable String getCaCertPath() {
       return caCertPath;
     }
 
@@ -942,7 +942,8 @@ public class GdchCredentials extends GoogleCredentials {
       throw new GoogleAuthException(
           false,
           0,
-          "Failed to create EC Private Key for GDCH. Please ensure the private key data is valid and represents a P-256 private key.",
+          "Failed to create EC Private Key for GDCH. Please ensure the private key data is valid"
+              + " and represents a P-256 private key.",
           e);
     }
   }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -97,12 +97,12 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
 
   // The following package-private fields to provide additional info for errors message
   // Source of the credential (e.g. env var value or well know file location)
-  String source;
+  @Nullable String source;
   // User-friendly name of the Credential class
-  String name;
+  @Nullable String name;
   // Identity of the credential
   // Note: This field may contain data such as serviceAccountEmail which should not be serialized
-  transient String principal;
+  transient @Nullable String principal;
 
   private final String universeDomain;
   private final boolean isExplicitUniverseDomain;
@@ -230,7 +230,8 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @throws IOException if the credential cannot be created from the stream.
    */
   @ObsoleteApi(
-      "This method is obsolete because of a potential security risk. Use the credential specific load method instead")
+      "This method is obsolete because of a potential security risk. Use the credential specific"
+          + " load method instead")
   public static GoogleCredentials fromStream(InputStream credentialsStream) throws IOException {
     return fromStream(credentialsStream, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
   }
@@ -296,7 +297,8 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @throws IOException if the credential cannot be created from the stream.
    */
   @ObsoleteApi(
-      "This method is obsolete because of a potential security risk. Use the credential specific load method instead")
+      "This method is obsolete because of a potential security risk. Use the credential specific"
+          + " load method instead")
   public static GoogleCredentials fromStream(
       InputStream credentialsStream, HttpTransportFactory transportFactory) throws IOException {
     Preconditions.checkNotNull(transportFactory);
@@ -344,7 +346,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @param quotaProject the quota project to set on the credential
    * @return credential with the provided quota project
    */
-  public GoogleCredentials createWithQuotaProject(String quotaProject) {
+  public GoogleCredentials createWithQuotaProject(@Nullable String quotaProject) {
     return this.toBuilder().setQuotaProjectId(quotaProject).build();
   }
 
@@ -424,7 +426,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @param quotaProjectId a quotaProjectId, a project id to be used for billing purposes
    */
   @Deprecated
-  protected GoogleCredentials(AccessToken accessToken, @Nullable String quotaProjectId) {
+  protected GoogleCredentials(@Nullable AccessToken accessToken, @Nullable String quotaProjectId) {
     this(
         GoogleCredentials.newBuilder()
             .setAccessToken(accessToken)
@@ -437,7 +439,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @param accessToken initial or temporary access token
    */
   @Deprecated
-  public GoogleCredentials(AccessToken accessToken) {
+  public GoogleCredentials(@Nullable AccessToken accessToken) {
     this(accessToken, null);
   }
 
@@ -527,7 +529,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   }
 
   @Override
-  public String getQuotaProjectId() {
+  public @Nullable String getQuotaProjectId() {
     return this.quotaProjectId;
   }
 
@@ -538,6 +540,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    *
    * @return the project id for a Credential type
    */
+  @Nullable
   public String getProjectId() {
     return null;
   }
@@ -679,32 +682,32 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
       return this;
     }
 
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       this.universeDomain = universeDomain;
       return this;
     }
 
-    public String getQuotaProjectId() {
+    public @Nullable String getQuotaProjectId() {
       return this.quotaProjectId;
     }
 
-    public String getUniverseDomain() {
+    public @Nullable String getUniverseDomain() {
       return this.universeDomain;
     }
 
-    Builder setSource(String source) {
+    Builder setSource(@Nullable String source) {
       this.source = source;
       return this;
     }
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setAccessToken(AccessToken token) {
+    public Builder setAccessToken(@Nullable AccessToken token) {
       super.setAccessToken(token);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -109,8 +109,8 @@ public class IdTokenCredentials extends OAuth2Credentials {
   private static final long serialVersionUID = -2133257318957588431L;
 
   private final IdTokenProvider idTokenProvider;
-  private final List<IdTokenProvider.Option> options;
-  private String targetAudience;
+  private final @Nullable List<IdTokenProvider.Option> options;
+  private @Nullable String targetAudience;
 
   private IdTokenCredentials(Builder builder) {
     this.idTokenProvider = Preconditions.checkNotNull(builder.getIdTokenProvider());
@@ -128,7 +128,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
     return this.idTokenProvider.idTokenWithAudience(targetAudience, options);
   }
 
-  public IdToken getIdToken() {
+  public @Nullable IdToken getIdToken() {
     return (IdToken) getAccessToken();
   }
 
@@ -168,8 +168,8 @@ public class IdTokenCredentials extends OAuth2Credentials {
   public static class Builder extends OAuth2Credentials.Builder {
 
     private IdTokenProvider idTokenProvider;
-    private String targetAudience;
-    private List<IdTokenProvider.Option> options;
+    private @Nullable String targetAudience;
+    private @Nullable List<IdTokenProvider.Option> options;
 
     protected Builder() {}
 
@@ -197,12 +197,12 @@ public class IdTokenCredentials extends OAuth2Credentials {
      * @return the builder object
      */
     @CanIgnoreReturnValue
-    public Builder setTargetAudience(String targetAudience) {
+    public Builder setTargetAudience(@Nullable String targetAudience) {
       this.targetAudience = targetAudience;
       return this;
     }
 
-    public String getTargetAudience() {
+    public @Nullable String getTargetAudience() {
       return this.targetAudience;
     }
 
@@ -213,12 +213,12 @@ public class IdTokenCredentials extends OAuth2Credentials {
      * @return the builder object
      */
     @CanIgnoreReturnValue
-    public Builder setOptions(List<IdTokenProvider.Option> options) {
+    public Builder setOptions(@Nullable List<IdTokenProvider.Option> options) {
       this.options = options;
       return this;
     }
 
-    public List<IdTokenProvider.Option> getOptions() {
+    public @Nullable List<IdTokenProvider.Option> getOptions() {
       return this.options;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -34,6 +34,7 @@ package com.google.auth.oauth2;
 import java.io.IOException;
 import java.util.List;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** Interface for an Google OIDC token provider. This type represents a google issued OIDC token. */
 @NullMarked
@@ -83,5 +84,6 @@ public interface IdTokenProvider {
    * @throws IOException if token creation fails
    * @return IdToken object which includes the raw id_token, expiration and audience.
    */
-  IdToken idTokenWithAudience(String targetAudience, List<Option> options) throws IOException;
+  IdToken idTokenWithAudience(@Nullable String targetAudience, @Nullable List<Option> options)
+      throws IOException;
 }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -77,7 +77,8 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
     // Check that one and only one of supplier or credential source are provided.
     if (builder.subjectTokenSupplier != null && credentialSource != null) {
       throw new IllegalArgumentException(
-          "IdentityPoolCredentials cannot have both a subjectTokenSupplier and a credentialSource.");
+          "IdentityPoolCredentials cannot have both a subjectTokenSupplier and a"
+              + " credentialSource.");
     }
     if (builder.subjectTokenSupplier == null && credentialSource == null) {
       throw new IllegalArgumentException(
@@ -104,7 +105,8 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
         throw new RuntimeException(
             // Wrap IOException in RuntimeException because constructors cannot throw checked
             // exceptions.
-            "Failed to initialize IdentityPoolCredentials from certificate source due to an I/O error.",
+            "Failed to initialize IdentityPoolCredentials from certificate source due to an I/O"
+                + " error.",
             e);
       }
       this.metricsHeaderValue = CERTIFICATE_METRICS_HEADER_VALUE;
@@ -245,7 +247,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       super.setHttpTransportFactory(transportFactory);
       return this;
     }
@@ -281,56 +283,57 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
+    public Builder setServiceAccountImpersonationUrl(
+        @Nullable String serviceAccountImpersonationUrl) {
       super.setServiceAccountImpersonationUrl(serviceAccountImpersonationUrl);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+    public Builder setTokenInfoUrl(@Nullable String tokenInfoUrl) {
       super.setTokenInfoUrl(tokenInfoUrl);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientId(String clientId) {
+    public Builder setClientId(@Nullable String clientId) {
       super.setClientId(clientId);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientSecret(String clientSecret) {
+    public Builder setClientSecret(@Nullable String clientSecret) {
       super.setClientSecret(clientSecret);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       super.setScopes(scopes);
       return this;
     }
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
+    public Builder setWorkforcePoolUserProject(@Nullable String workforcePoolUserProject) {
       super.setWorkforcePoolUserProject(workforcePoolUserProject);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
+    public Builder setServiceAccountImpersonationOptions(@Nullable Map<String, Object> optionsMap) {
       super.setServiceAccountImpersonationOptions(optionsMap);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       super.setUniverseDomain(universeDomain);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -145,10 +145,10 @@ public class ImpersonatedCredentials extends GoogleCredentials
   public static ImpersonatedCredentials create(
       GoogleCredentials sourceCredentials,
       String targetPrincipal,
-      List<String> delegates,
+      @Nullable List<String> delegates,
       List<String> scopes,
       int lifetime,
-      HttpTransportFactory transportFactory) {
+      @Nullable HttpTransportFactory transportFactory) {
     return ImpersonatedCredentials.newBuilder()
         .setSourceCredentials(sourceCredentials)
         .setTargetPrincipal(targetPrincipal)
@@ -187,11 +187,11 @@ public class ImpersonatedCredentials extends GoogleCredentials
   public static ImpersonatedCredentials create(
       GoogleCredentials sourceCredentials,
       String targetPrincipal,
-      List<String> delegates,
+      @Nullable List<String> delegates,
       List<String> scopes,
       int lifetime,
-      HttpTransportFactory transportFactory,
-      String quotaProjectId) {
+      @Nullable HttpTransportFactory transportFactory,
+      @Nullable String quotaProjectId) {
     return ImpersonatedCredentials.newBuilder()
         .setSourceCredentials(sourceCredentials)
         .setTargetPrincipal(targetPrincipal)
@@ -233,12 +233,12 @@ public class ImpersonatedCredentials extends GoogleCredentials
   public static ImpersonatedCredentials create(
       GoogleCredentials sourceCredentials,
       String targetPrincipal,
-      List<String> delegates,
+      @Nullable List<String> delegates,
       List<String> scopes,
       int lifetime,
-      HttpTransportFactory transportFactory,
-      String quotaProjectId,
-      String iamEndpointOverride) {
+      @Nullable HttpTransportFactory transportFactory,
+      @Nullable String quotaProjectId,
+      @Nullable String iamEndpointOverride) {
     return ImpersonatedCredentials.newBuilder()
         .setSourceCredentials(sourceCredentials)
         .setTargetPrincipal(targetPrincipal)
@@ -276,7 +276,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
   public static ImpersonatedCredentials create(
       GoogleCredentials sourceCredentials,
       String targetPrincipal,
-      List<String> delegates,
+      @Nullable List<String> delegates,
       List<String> scopes,
       int lifetime) {
     return ImpersonatedCredentials.newBuilder()
@@ -317,12 +317,12 @@ public class ImpersonatedCredentials extends GoogleCredentials
   }
 
   @VisibleForTesting
-  List<String> getDelegates() {
+  @Nullable List<String> getDelegates() {
     return delegates;
   }
 
   @VisibleForTesting
-  List<String> getScopes() {
+  @Nullable List<String> getScopes() {
     return scopes;
   }
 
@@ -685,7 +685,8 @@ public class ImpersonatedCredentials extends GoogleCredentials
    * @throws IOException if the attempt to get an ID token failed
    */
   @Override
-  public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options)
+  public IdToken idTokenWithAudience(
+      @Nullable String targetAudience, @Nullable List<IdTokenProvider.Option> options)
       throws IOException {
     boolean includeEmail =
         options != null && options.contains(IdTokenProvider.Option.INCLUDE_EMAIL);
@@ -765,12 +766,12 @@ public class ImpersonatedCredentials extends GoogleCredentials
 
     private GoogleCredentials sourceCredentials;
     private String targetPrincipal;
-    private List<String> delegates;
-    private List<String> scopes;
+    private @Nullable List<String> delegates;
+    private @Nullable List<String> scopes;
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
-    private HttpTransportFactory transportFactory;
-    private String iamEndpointOverride;
-    private Calendar calendar = Calendar.getInstance();
+    private @Nullable HttpTransportFactory transportFactory;
+    private @Nullable String iamEndpointOverride;
+    private @Nullable Calendar calendar = Calendar.getInstance();
 
     protected Builder() {}
 
@@ -818,12 +819,12 @@ public class ImpersonatedCredentials extends GoogleCredentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setDelegates(List<String> delegates) {
+    public Builder setDelegates(@Nullable List<String> delegates) {
       this.delegates = delegates;
       return this;
     }
 
-    public List<String> getDelegates() {
+    public @Nullable List<String> getDelegates() {
       return this.delegates;
     }
 
@@ -843,7 +844,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
     /**
      * @return List of scopes to be applied to the impersonated token.
      */
-    public List<String> getScopes() {
+    public @Nullable List<String> getScopes() {
       return this.scopes;
     }
 
@@ -858,24 +859,24 @@ public class ImpersonatedCredentials extends GoogleCredentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setIamEndpointOverride(String iamEndpointOverride) {
+    public Builder setIamEndpointOverride(@Nullable String iamEndpointOverride) {
       this.iamEndpointOverride = iamEndpointOverride;
       return this;
     }
@@ -891,7 +892,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
      */
     @CanIgnoreReturnValue
     @ObsoleteApi("This method is obsolete and will be removed in a future release.")
-    public Builder setCalendar(Calendar calendar) {
+    public Builder setCalendar(@Nullable Calendar calendar) {
       this.calendar = calendar;
       return this;
     }
@@ -905,7 +906,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
      * @return the calendar
      */
     @ObsoleteApi("This method is obsolete and will be removed in a future release.")
-    public Calendar getCalendar() {
+    public @Nullable Calendar getCalendar() {
       return this.calendar;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -79,14 +79,14 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   // byte[] is serializable, so the lock variable can be final
   private final Object lock = new byte[0];
   private final PrivateKey privateKey;
-  private final String privateKeyId;
+  private final @Nullable String privateKeyId;
   private final JwtClaims jwtClaims;
   private final Long lifeSpanSeconds;
   @VisibleForTesting transient Clock clock;
 
-  private transient String jwt;
+  private transient @Nullable String jwt;
   // The date (represented as seconds since the epoch) that the generated JWT expires
-  private transient Long expiryInSeconds;
+  private transient @Nullable Long expiryInSeconds;
 
   private JwtCredentials(Builder builder) {
     this.privateKey = Preconditions.checkNotNull(builder.getPrivateKey());
@@ -207,7 +207,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
 
   public static class Builder {
     private PrivateKey privateKey;
-    private String privateKeyId;
+    private @Nullable String privateKeyId;
     private JwtClaims jwtClaims;
     private Clock clock = Clock.SYSTEM;
     private Long lifeSpanSeconds = TimeUnit.HOURS.toSeconds(1);
@@ -225,12 +225,12 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
 
     @CanIgnoreReturnValue
-    public Builder setPrivateKeyId(String privateKeyId) {
+    public Builder setPrivateKeyId(@Nullable String privateKeyId) {
       this.privateKeyId = privateKeyId;
       return this;
     }
 
-    public String getPrivateKeyId() {
+    public @Nullable String getPrivateKeyId() {
       return privateKeyId;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/MemoryTokensStorage.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/MemoryTokensStorage.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** Represents an in-memory storage of tokens. */
 @NullMarked

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -115,7 +115,7 @@ public class OAuth2Credentials extends Credentials {
   }
 
   protected OAuth2Credentials(
-      AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
+      @Nullable AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
     if (accessToken != null) {
       this.value = OAuthValue.create(accessToken, EMPTY_EXTRA_HEADERS);
     }
@@ -172,7 +172,7 @@ public class OAuth2Credentials extends Credentials {
 
   @Override
   public void getRequestMetadata(
-      final URI uri, Executor executor, final RequestMetadataCallback callback) {
+      final @Nullable URI uri, Executor executor, final RequestMetadataCallback callback) {
 
     Futures.addCallback(
         asyncFetch(executor),
@@ -711,7 +711,7 @@ public class OAuth2Credentials extends Credentials {
 
   public static class Builder {
 
-    private AccessToken accessToken;
+    private @Nullable AccessToken accessToken;
     private Duration refreshMargin = DEFAULT_REFRESH_MARGIN;
     private Duration expirationMargin = DEFAULT_EXPIRATION_MARGIN;
 
@@ -724,7 +724,7 @@ public class OAuth2Credentials extends Credentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setAccessToken(AccessToken token) {
+    public Builder setAccessToken(@Nullable AccessToken token) {
       this.accessToken = token;
       return this;
     }
@@ -749,7 +749,7 @@ public class OAuth2Credentials extends Credentials {
       return expirationMargin;
     }
 
-    public AccessToken getAccessToken() {
+    public @Nullable AccessToken getAccessToken() {
       return accessToken;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
@@ -233,7 +233,7 @@ public class PluggableAuthCredentials extends ExternalAccountCredentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       super.setHttpTransportFactory(transportFactory);
       return this;
     }
@@ -269,55 +269,56 @@ public class PluggableAuthCredentials extends ExternalAccountCredentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
+    public Builder setServiceAccountImpersonationUrl(
+        @Nullable String serviceAccountImpersonationUrl) {
       super.setServiceAccountImpersonationUrl(serviceAccountImpersonationUrl);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+    public Builder setTokenInfoUrl(@Nullable String tokenInfoUrl) {
       super.setTokenInfoUrl(tokenInfoUrl);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientId(String clientId) {
+    public Builder setClientId(@Nullable String clientId) {
       super.setClientId(clientId);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientSecret(String clientSecret) {
+    public Builder setClientSecret(@Nullable String clientSecret) {
       super.setClientSecret(clientSecret);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       super.setScopes(scopes);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
+    public Builder setWorkforcePoolUserProject(@Nullable String workforcePoolUserProject) {
       super.setWorkforcePoolUserProject(workforcePoolUserProject);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
+    public Builder setServiceAccountImpersonationOptions(@Nullable Map<String, Object> optionsMap) {
       super.setServiceAccountImpersonationOptions(optionsMap);
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       super.setUniverseDomain(universeDomain);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/PropertyProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/PropertyProvider.java
@@ -32,6 +32,7 @@ package com.google.auth.oauth2;
 
 import com.google.api.core.InternalApi;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Interface for a system property provider.
@@ -41,5 +42,5 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 @InternalApi
 public interface PropertyProvider {
-  String getProperty(String property, String def);
+  @Nullable String getProperty(String property, @Nullable String def);
 }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdProvider.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** Interface for {@link GoogleCredentials} that return a quota project ID. */
 @NullMarked
@@ -39,5 +40,5 @@ public interface QuotaProjectIdProvider {
   /**
    * @return the quota project ID used for quota and billing purposes
    */
-  String getQuotaProjectId();
+  @Nullable String getQuotaProjectId();
 }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -223,11 +223,11 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @throws IOException if the credential cannot be created from the private key.
    */
   public static ServiceAccountCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
-      Collection<String> scopes)
+      @Nullable String privateKeyId,
+      @Nullable Collection<String> scopes)
       throws IOException {
     ServiceAccountCredentials.Builder builder =
         ServiceAccountCredentials.newBuilder()
@@ -252,12 +252,12 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @throws IOException if the credential cannot be created from the private key
    */
   public static ServiceAccountCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
-      Collection<String> scopes,
-      Collection<String> defaultScopes)
+      @Nullable String privateKeyId,
+      @Nullable Collection<String> scopes,
+      @Nullable Collection<String> defaultScopes)
       throws IOException {
     ServiceAccountCredentials.Builder builder =
         ServiceAccountCredentials.newBuilder()
@@ -286,13 +286,13 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @throws IOException if the credential cannot be created from the private key.
    */
   public static ServiceAccountCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
-      Collection<String> scopes,
-      HttpTransportFactory transportFactory,
-      URI tokenServerUri)
+      @Nullable String privateKeyId,
+      @Nullable Collection<String> scopes,
+      @Nullable HttpTransportFactory transportFactory,
+      @Nullable URI tokenServerUri)
       throws IOException {
 
     ServiceAccountCredentials.Builder builder =
@@ -326,14 +326,14 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @throws IOException if the credential cannot be created from the private key
    */
   public static ServiceAccountCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
-      Collection<String> scopes,
-      Collection<String> defaultScopes,
-      HttpTransportFactory transportFactory,
-      URI tokenServerUri)
+      @Nullable String privateKeyId,
+      @Nullable Collection<String> scopes,
+      @Nullable Collection<String> defaultScopes,
+      @Nullable HttpTransportFactory transportFactory,
+      @Nullable URI tokenServerUri)
       throws IOException {
 
     ServiceAccountCredentials.Builder builder =
@@ -367,14 +367,14 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @throws IOException if the credential cannot be created from the private key.
    */
   public static ServiceAccountCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
-      Collection<String> scopes,
-      HttpTransportFactory transportFactory,
-      URI tokenServerUri,
-      String serviceAccountUser)
+      @Nullable String privateKeyId,
+      @Nullable Collection<String> scopes,
+      @Nullable HttpTransportFactory transportFactory,
+      @Nullable URI tokenServerUri,
+      @Nullable String serviceAccountUser)
       throws IOException {
 
     ServiceAccountCredentials.Builder builder =
@@ -411,15 +411,15 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @throws IOException if the credential cannot be created from the private key
    */
   public static ServiceAccountCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
-      Collection<String> scopes,
-      Collection<String> defaultScopes,
-      HttpTransportFactory transportFactory,
-      URI tokenServerUri,
-      String serviceAccountUser)
+      @Nullable String privateKeyId,
+      @Nullable Collection<String> scopes,
+      @Nullable Collection<String> defaultScopes,
+      @Nullable HttpTransportFactory transportFactory,
+      @Nullable URI tokenServerUri,
+      @Nullable String serviceAccountUser)
       throws IOException {
     ServiceAccountCredentials.Builder builder =
         ServiceAccountCredentials.newBuilder()
@@ -606,8 +606,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @return IdToken object which includes the raw id_token, expiration and audience
    */
   @Override
-  public IdToken idTokenWithAudience(String targetAudience, List<Option> options)
-      throws IOException {
+  public IdToken idTokenWithAudience(
+      @Nullable String targetAudience, @Nullable List<Option> options) throws IOException {
     return isDefaultUniverseDomain()
         ? getIdTokenOauthEndpoint(targetAudience)
         : getIdTokenIamEndpoint(targetAudience);
@@ -784,7 +784,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return this.toBuilder().setServiceAccountUser(user).build();
   }
 
-  public final String getClientId() {
+  public final @Nullable String getClientId() {
     return clientId;
   }
 
@@ -796,7 +796,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return privateKey;
   }
 
-  public final String getPrivateKeyId() {
+  public final @Nullable String getPrivateKeyId() {
     return privateKeyId;
   }
 
@@ -808,7 +808,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return defaultScopes;
   }
 
-  public final String getServiceAccountUser() {
+  public final @Nullable String getServiceAccountUser() {
     return serviceAccountUser;
   }
 
@@ -816,7 +816,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @return the projectId set in the SA Key file or the user set projectId
    */
   @Override
-  public final String getProjectId() {
+  public final @Nullable String getProjectId() {
     return projectId;
   }
 
@@ -963,8 +963,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
   }
 
   @VisibleForTesting
-  String createAssertionForIdToken(long currentTime, String audience, String targetAudience)
-      throws IOException {
+  String createAssertionForIdToken(
+      long currentTime, @Nullable String audience, String targetAudience) throws IOException {
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     JsonWebSignature.Header header = new JsonWebSignature.Header();
     header.setAlgorithm("RS256");
@@ -1184,7 +1184,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientId(String clientId) {
+    public Builder setClientId(@Nullable String clientId) {
       this.clientId = clientId;
       return this;
     }
@@ -1208,52 +1208,53 @@ public class ServiceAccountCredentials extends GoogleCredentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setPrivateKeyId(String privateKeyId) {
+    public Builder setPrivateKeyId(@Nullable String privateKeyId) {
       this.privateKeyId = privateKeyId;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       this.scopes = scopes;
       this.defaultScopes = ImmutableSet.<String>of();
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes, Collection<String> defaultScopes) {
+    public Builder setScopes(
+        @Nullable Collection<String> scopes, @Nullable Collection<String> defaultScopes) {
       this.scopes = scopes;
       this.defaultScopes = defaultScopes;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setServiceAccountUser(String serviceAccountUser) {
+    public Builder setServiceAccountUser(@Nullable String serviceAccountUser) {
       this.serviceAccountUser = serviceAccountUser;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setProjectId(String projectId) {
+    public Builder setProjectId(@Nullable String projectId) {
       this.projectId = projectId;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setTokenServerUri(URI tokenServerUri) {
+    public Builder setTokenServerUri(@Nullable URI tokenServerUri) {
       this.tokenServerUri = tokenServerUri;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
@@ -1280,12 +1281,12 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return this;
     }
 
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       super.universeDomain = universeDomain;
       return this;
     }
 
-    public String getClientId() {
+    public @Nullable String getClientId() {
       return clientId;
     }
 
@@ -1297,31 +1298,31 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return privateKey;
     }
 
-    public String getPrivateKeyId() {
+    public @Nullable String getPrivateKeyId() {
       return privateKeyId;
     }
 
-    public Collection<String> getScopes() {
+    public @Nullable Collection<String> getScopes() {
       return scopes;
     }
 
-    public Collection<String> getDefaultScopes() {
+    public @Nullable Collection<String> getDefaultScopes() {
       return defaultScopes;
     }
 
-    public String getServiceAccountUser() {
+    public @Nullable String getServiceAccountUser() {
       return serviceAccountUser;
     }
 
-    public String getProjectId() {
+    public @Nullable String getProjectId() {
       return projectId;
     }
 
-    public URI getTokenServerUri() {
+    public @Nullable URI getTokenServerUri() {
       return tokenServerUri;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -85,10 +85,10 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   @VisibleForTesting static final long LIFE_SPAN_SECS = TimeUnit.HOURS.toSeconds(1);
   private static final long CLOCK_SKEW = TimeUnit.MINUTES.toSeconds(5);
 
-  private final String clientId;
+  private final @Nullable String clientId;
   private final String clientEmail;
   private final PrivateKey privateKey;
-  private final String privateKeyId;
+  private final @Nullable String privateKeyId;
   private final URI defaultAudience;
   private final String quotaProjectId;
   private final String universeDomain;
@@ -107,7 +107,10 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param privateKeyId Private key identifier for the service account. May be null.
    */
   private ServiceAccountJwtAccessCredentials(
-      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId) {
+      @Nullable String clientId,
+      String clientEmail,
+      PrivateKey privateKey,
+      @Nullable String privateKeyId) {
     this(
         clientId,
         clientEmail,
@@ -130,10 +133,10 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    *     googleapis.com
    */
   private ServiceAccountJwtAccessCredentials(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       PrivateKey privateKey,
-      String privateKeyId,
+      @Nullable String privateKeyId,
       @Nullable URI defaultAudience,
       @Nullable String quotaProjectId,
       String universeDomain) {
@@ -212,7 +215,10 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @throws IOException if the credential cannot be created from the private key.
    */
   public static ServiceAccountJwtAccessCredentials fromPkcs8(
-      String clientId, String clientEmail, String privateKeyPkcs8, String privateKeyId)
+      @Nullable String clientId,
+      String clientEmail,
+      String privateKeyPkcs8,
+      @Nullable String privateKeyId)
       throws IOException {
     return fromPkcs8(clientId, clientEmail, privateKeyPkcs8, privateKeyId, null);
   }
@@ -229,10 +235,10 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @throws IOException if the credential cannot be created from the private key.
    */
   public static ServiceAccountJwtAccessCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
+      @Nullable String privateKeyId,
       @Nullable URI defaultAudience)
       throws IOException {
     return ServiceAccountJwtAccessCredentials.fromPkcs8(
@@ -246,11 +252,11 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   }
 
   static ServiceAccountJwtAccessCredentials fromPkcs8(
-      String clientId,
+      @Nullable String clientId,
       String clientEmail,
       String privateKeyPkcs8,
-      String privateKeyId,
-      URI defaultAudience,
+      @Nullable String privateKeyId,
+      @Nullable URI defaultAudience,
       @Nullable String quotaProjectId,
       String universeDomain)
       throws IOException {
@@ -423,7 +429,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     credentialsCache.invalidateAll();
   }
 
-  public final String getClientId() {
+  public final @Nullable String getClientId() {
     return clientId;
   }
 
@@ -435,7 +441,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     return privateKey;
   }
 
-  public final String getPrivateKeyId() {
+  public final @Nullable String getPrivateKeyId() {
     return privateKeyId;
   }
 
@@ -508,19 +514,19 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   }
 
   @Override
-  public String getQuotaProjectId() {
+  public @Nullable String getQuotaProjectId() {
     return quotaProjectId;
   }
 
   public static class Builder {
 
-    private String clientId;
+    private @Nullable String clientId;
     private String clientEmail;
     private PrivateKey privateKey;
-    private String privateKeyId;
-    private URI defaultAudience;
-    private String quotaProjectId;
-    private String universeDomain;
+    private @Nullable String privateKeyId;
+    private @Nullable URI defaultAudience;
+    private @Nullable String quotaProjectId;
+    private @Nullable String universeDomain;
 
     protected Builder() {}
 
@@ -535,7 +541,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientId(String clientId) {
+    public Builder setClientId(@Nullable String clientId) {
       this.clientId = clientId;
       return this;
     }
@@ -553,31 +559,31 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setPrivateKeyId(String privateKeyId) {
+    public Builder setPrivateKeyId(@Nullable String privateKeyId) {
       this.privateKeyId = privateKeyId;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setDefaultAudience(URI defaultAudience) {
+    public Builder setDefaultAudience(@Nullable URI defaultAudience) {
       this.defaultAudience = defaultAudience;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
       return this;
     }
 
     @CanIgnoreReturnValue
     /** Sets the universe domain (example, googleapis.com). */
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       this.universeDomain = universeDomain;
       return this;
     }
 
-    public String getClientId() {
+    public @Nullable String getClientId() {
       return clientId;
     }
 
@@ -589,20 +595,20 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
       return privateKey;
     }
 
-    public String getPrivateKeyId() {
+    public @Nullable String getPrivateKeyId() {
       return privateKeyId;
     }
 
-    public URI getDefaultAudience() {
+    public @Nullable URI getDefaultAudience() {
       return defaultAudience;
     }
 
-    public String getQuotaProjectId() {
+    public @Nullable String getQuotaProjectId() {
       return quotaProjectId;
     }
 
     /** Returns the universe domain (example, googleapis.com) for the credentials instance. */
-    public String getUniverseDomain() {
+    public @Nullable String getUniverseDomain() {
       return universeDomain;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
@@ -224,13 +224,13 @@ public final class StsRequestHandler {
     }
 
     @CanIgnoreReturnValue
-    public StsRequestHandler.Builder setHeaders(HttpHeaders headers) {
+    public StsRequestHandler.Builder setHeaders(@Nullable HttpHeaders headers) {
       this.headers = headers;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public StsRequestHandler.Builder setInternalOptions(String internalOptions) {
+    public StsRequestHandler.Builder setInternalOptions(@Nullable String internalOptions) {
       this.internalOptions = internalOptions;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeRequest.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeRequest.java
@@ -108,33 +108,27 @@ public final class StsTokenExchangeRequest {
     return subjectTokenType;
   }
 
-  @Nullable
-  public String getResource() {
+  public @Nullable String getResource() {
     return resource;
   }
 
-  @Nullable
-  public String getAudience() {
+  public @Nullable String getAudience() {
     return audience;
   }
 
-  @Nullable
-  public String getRequestedTokenType() {
+  public @Nullable String getRequestedTokenType() {
     return requestedTokenType;
   }
 
-  @Nullable
-  public List<String> getScopes() {
+  public @Nullable List<String> getScopes() {
     return scopes;
   }
 
-  @Nullable
-  public ActingParty getActingParty() {
+  public @Nullable ActingParty getActingParty() {
     return actingParty;
   }
 
-  @Nullable
-  public String getInternalOptions() {
+  public @Nullable String getInternalOptions() {
     return internalOptions;
   }
 
@@ -175,37 +169,38 @@ public final class StsTokenExchangeRequest {
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeRequest.Builder setResource(String resource) {
+    public StsTokenExchangeRequest.Builder setResource(@Nullable String resource) {
       this.resource = resource;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeRequest.Builder setAudience(String audience) {
+    public StsTokenExchangeRequest.Builder setAudience(@Nullable String audience) {
       this.audience = audience;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeRequest.Builder setRequestTokenType(String requestedTokenType) {
+    public StsTokenExchangeRequest.Builder setRequestTokenType(
+        @Nullable String requestedTokenType) {
       this.requestedTokenType = requestedTokenType;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeRequest.Builder setScopes(List<String> scopes) {
+    public StsTokenExchangeRequest.Builder setScopes(@Nullable List<String> scopes) {
       this.scopes = scopes;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeRequest.Builder setActingParty(ActingParty actingParty) {
+    public StsTokenExchangeRequest.Builder setActingParty(@Nullable ActingParty actingParty) {
       this.actingParty = actingParty;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeRequest.Builder setInternalOptions(String internalOptions) {
+    public StsTokenExchangeRequest.Builder setInternalOptions(@Nullable String internalOptions) {
       this.internalOptions = internalOptions;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeResponse.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeResponse.java
@@ -111,18 +111,15 @@ public final class StsTokenExchangeResponse {
     return tokenType;
   }
 
-  @Nullable
-  public Long getExpiresInSeconds() {
+  public @Nullable Long getExpiresInSeconds() {
     return expiresInSeconds;
   }
 
-  @Nullable
-  public String getRefreshToken() {
+  public @Nullable String getRefreshToken() {
     return refreshToken;
   }
 
-  @Nullable
-  public List<String> getScopes() {
+  public @Nullable List<String> getScopes() {
     if (scopes == null) {
       return null;
     }
@@ -134,8 +131,7 @@ public final class StsTokenExchangeResponse {
    *
    * @return the access boundary session key or {@code null} if not present
    */
-  @Nullable
-  public String getAccessBoundarySessionKey() {
+  public @Nullable String getAccessBoundarySessionKey() {
     return accessBoundarySessionKey;
   }
 
@@ -162,13 +158,13 @@ public final class StsTokenExchangeResponse {
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeResponse.Builder setRefreshToken(String refreshToken) {
+    public StsTokenExchangeResponse.Builder setRefreshToken(@Nullable String refreshToken) {
       this.refreshToken = refreshToken;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public StsTokenExchangeResponse.Builder setScopes(List<String> scopes) {
+    public StsTokenExchangeResponse.Builder setScopes(@Nullable List<String> scopes) {
       if (scopes != null) {
         this.scopes = new ArrayList<>(scopes);
       }
@@ -183,7 +179,7 @@ public final class StsTokenExchangeResponse {
      */
     @CanIgnoreReturnValue
     public StsTokenExchangeResponse.Builder setAccessBoundarySessionKey(
-        String accessBoundarySessionKey) {
+        @Nullable String accessBoundarySessionKey) {
       this.accessBoundarySessionKey = accessBoundarySessionKey;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/SystemEnvironmentProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/SystemEnvironmentProvider.java
@@ -33,6 +33,7 @@ package com.google.auth.oauth2;
 import com.google.api.core.InternalApi;
 import java.io.Serializable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the default system environment provider.
@@ -48,7 +49,7 @@ public class SystemEnvironmentProvider implements EnvironmentProvider, Serializa
   private SystemEnvironmentProvider() {}
 
   @Override
-  public String getEnv(String name) {
+  public @Nullable String getEnv(String name) {
     return System.getenv(name);
   }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/SystemPropertyProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/SystemPropertyProvider.java
@@ -33,6 +33,7 @@ package com.google.auth.oauth2;
 import com.google.api.core.InternalApi;
 import java.io.Serializable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Represents the default system property provider.
@@ -48,7 +49,7 @@ public class SystemPropertyProvider implements PropertyProvider, Serializable {
   private SystemPropertyProvider() {}
 
   @Override
-  public String getProperty(String property, String def) {
+  public @Nullable String getProperty(String property, @Nullable String def) {
     return System.getProperty(property, def);
   }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/TokenVerifier.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/TokenVerifier.java
@@ -90,10 +90,10 @@ public class TokenVerifier {
       "https://www.googleapis.com/oauth2/v3/certs";
   private static final Set<String> SUPPORTED_ALGORITHMS = ImmutableSet.of("RS256", "ES256");
 
-  private final String audience;
+  private final @Nullable String audience;
   private final String certificatesLocation;
-  private final String issuer;
-  private final PublicKey publicKey;
+  private final @Nullable String issuer;
+  private final @Nullable PublicKey publicKey;
   private final Clock clock;
   private final LoadingCache<String, Map<String, PublicKey>> publicKeyCache;
 
@@ -193,10 +193,10 @@ public class TokenVerifier {
   }
 
   public static class Builder {
-    private String audience;
+    private @Nullable String audience;
     private String certificatesLocation;
-    private String issuer;
-    private PublicKey publicKey;
+    private @Nullable String issuer;
+    private @Nullable PublicKey publicKey;
     private Clock clock;
     private HttpTransportFactory httpTransportFactory;
 
@@ -206,7 +206,7 @@ public class TokenVerifier {
      * @param audience the audience claim to verify
      * @return the builder
      */
-    public Builder setAudience(String audience) {
+    public Builder setAudience(@Nullable String audience) {
       this.audience = audience;
       return this;
     }
@@ -229,7 +229,7 @@ public class TokenVerifier {
      * @param issuer the issuer claim to verify
      * @return the builder
      */
-    public Builder setIssuer(String issuer) {
+    public Builder setIssuer(@Nullable String issuer) {
       this.issuer = issuer;
       return this;
     }
@@ -241,7 +241,7 @@ public class TokenVerifier {
      * @param publicKey the public key to validate the signature
      * @return the builder
      */
-    public Builder setPublicKey(PublicKey publicKey) {
+    public Builder setPublicKey(@Nullable PublicKey publicKey) {
       this.publicKey = publicKey;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -184,7 +184,7 @@ public class UserAuthorizer {
    * @param baseUri The URI to resolve the OAuth2 callback URI relative to.
    * @return The URL that can be navigated or redirected to.
    */
-  public URL getAuthorizationUrl(String userId, String state, @Nullable URI baseUri) {
+  public URL getAuthorizationUrl(@Nullable String userId, @Nullable String state, @Nullable URI baseUri) {
     return this.getAuthorizationUrl(userId, state, baseUri, null);
   }
 
@@ -198,8 +198,8 @@ public class UserAuthorizer {
    * @return The URL that can be navigated or redirected to.
    */
   public URL getAuthorizationUrl(
-      String userId,
-      String state,
+      @Nullable String userId,
+      @Nullable String state,
       @Nullable URI baseUri,
       @Nullable Map<String, String> additionalParameters) {
     URI resolvedCallbackUri = getCallbackUri(baseUri);
@@ -241,7 +241,7 @@ public class UserAuthorizer {
    * @throws IOException If there is error retrieving or loading the credentials.
    */
   @Nullable
-  public UserCredentials getCredentials(String userId) throws IOException {
+  public @Nullable UserCredentials getCredentials(String userId) throws IOException {
     Preconditions.checkNotNull(userId);
     if (tokenStore == null) {
       throw new IllegalStateException("Method cannot be called if token store is not specified.");

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -75,7 +75,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
   private final String clientId;
   private final String clientSecret;
-  private final String refreshToken;
+  private final @Nullable String refreshToken;
   private final URI tokenServerUri;
   private final String transportFactoryClassName;
 
@@ -217,8 +217,8 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
    * @return IdToken object which includes the raw id_token, expiration and audience
    */
   @Override
-  public IdToken idTokenWithAudience(String targetAudience, List<Option> options)
-      throws IOException {
+  public IdToken idTokenWithAudience(
+      @Nullable String targetAudience, @Nullable List<Option> options) throws IOException {
     GenericData responseData = doRefreshAccessToken();
     String idTokenKey = "id_token";
     if (responseData.containsKey(idTokenKey)) {
@@ -257,6 +257,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
    *
    * @return refresh token
    */
+  @Nullable
   public final String getRefreshToken() {
     return refreshToken;
   }
@@ -417,12 +418,12 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
   public static class Builder extends GoogleCredentials.Builder {
 
-    private String clientId;
-    private String clientSecret;
-    private String refreshToken;
-    private URI tokenServerUri;
-    private String account;
-    private HttpTransportFactory transportFactory;
+    private @Nullable String clientId;
+    private @Nullable String clientSecret;
+    private @Nullable String refreshToken;
+    private @Nullable URI tokenServerUri;
+    private @Nullable String account;
+    private @Nullable HttpTransportFactory transportFactory;
 
     protected Builder() {}
 
@@ -449,25 +450,25 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     }
 
     @CanIgnoreReturnValue
-    public Builder setRefreshToken(String refreshToken) {
+    public Builder setRefreshToken(@Nullable String refreshToken) {
       this.refreshToken = refreshToken;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setTokenServerUri(URI tokenServerUri) {
+    public Builder setTokenServerUri(@Nullable URI tokenServerUri) {
       this.tokenServerUri = tokenServerUri;
       return this;
     }
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
 
     @CanIgnoreReturnValue
-    Builder setAccount(String account) {
+    Builder setAccount(@Nullable String account) {
       this.account = account;
       return this;
     }
@@ -495,32 +496,32 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
 
-    public String getClientId() {
+    public @Nullable String getClientId() {
       return clientId;
     }
 
-    public String getClientSecret() {
+    public @Nullable String getClientSecret() {
       return clientSecret;
     }
 
-    public String getRefreshToken() {
+    public @Nullable String getRefreshToken() {
       return refreshToken;
     }
 
-    public URI getTokenServerUri() {
+    public @Nullable URI getTokenServerUri() {
       return tokenServerUri;
     }
 
-    String getAccount() {
+    @Nullable String getAccount() {
       return account;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -202,7 +202,7 @@ class UserAuthorizerTest {
   }
 
   @Test
-  void getAuthorizationUrl_nullBaseUri() throws IOException {
+  void getAuthorizationUrl_nullArguments() throws IOException {
     final String protocol = "https";
     final String host = "accounts.test.com";
     final String path = "/o/o/oauth2/auth";
@@ -216,18 +216,21 @@ class UserAuthorizerTest {
             .setUserAuthUri(authUri)
             .build();
 
-    URL authorizationUrl = authorizer.getAuthorizationUrl(USER_ID, "state", null);
+    URL authorizationUrl = authorizer.getAuthorizationUrl(null, null, null);
 
     assertEquals(protocol, authorizationUrl.getProtocol());
     assertEquals(path, authorizationUrl.getPath());
     assertEquals(host, authorizationUrl.getHost());
     String query = authorizationUrl.getQuery();
     Map<String, String> parameters = TestUtils.parseQuery(query);
-    assertEquals("state", parameters.get("state"));
-    assertEquals(USER_ID, parameters.get("login_hint"));
+    assertFalse(parameters.containsKey("state"));
+    assertFalse(parameters.containsKey("login_hint"));
     assertEquals(absoluteCallbackUri.toString(), parameters.get("redirect_uri"));
     assertEquals(CLIENT_ID_VALUE, parameters.get("client_id"));
     assertEquals(DUMMY_SCOPE, parameters.get("scope"));
+
+    URL authorizationUrlWithNullMap = authorizer.getAuthorizationUrl(null, null, null, null);
+    assertEquals(authorizationUrl, authorizationUrlWithNullMap);
   }
 
   @Test


### PR DESCRIPTION
This PR is **part 2 of 3** in a stacked series of JSpecify nullability fixes for `google-auth-library-java`:
1. #14150: `fix(auth): fix JSpecify nullability in UserAuthorizer and TokenStore` (resolves #14147)
2. **This PR (#14153)**: `fix(auth): add missing @Nullable annotations across credential types and providers`
3. #14154: `fix(auth): annotate builder fields, setters, and getters as @Nullable across credential builders`

---

### Description
Following the migration of `google-auth-library-java` to `@NullMarked`, an audit of all credential types, credential providers, and token utilities identified several methods that can accept or return `null` in standard usage patterns.

This PR adds `@Nullable` annotations to the following non-builder surfaces:
- `IdTokenProvider`: `targetAudience` parameter in `idTokenWithAudience(...)Option` and `Option#getOptionTargetAudience()` return type.
- `UserAuthorizer`: `getCredentials` return type, `getCredentialsFromCallback` parameters, `getAuthorizationUrl` parameters (`userId`, `state`).
- `UserCredentials`: constructor `clientId` and `clientSecret` parameters (and corresponding getter returns), which are nullable for 3-legged scenarios and user credential definitions.
- `ServiceAccountCredentials` / `ServiceAccountJwtAccessCredentials`: nullable `serviceAccountUser` constructor parameter and getters, `privateKeyId`, `privateKey`, `clientEmail`, `clientId` where optional.
- `ExternalAccountCredentials` & subclasses (`AwsCredentials`, `IdentityPoolCredentials`, `PluggableAuthCredentials`, `ExternalAccountAuthorizedUserCredentials`): nullable constructor parameters and getters for optional parameters (`workforcePoolUserProject`, `serviceAccountImpersonationUrl`, `quotaProjectId`, `subjectToken`, etc.).
- `DownscopedCredentials` & `ImpersonatedCredentials`: nullable optional fields and constructors.
- `GdchCredentials`: nullable constructor parameters and getters for optional endpoints/tokens.
- Token refresh utilities: `OAuth2CredentialsWithRefresh`, `RefreshHandler`, `DefaultTokenRefresher`, `SecureSessionAgent`.