### PR TITLE
fix(auth): annotate builder fields, setters, and getters as @Nullable across credential builders

### DIFF
--- a/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/google-auth-library-java/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -603,12 +603,12 @@ public class ClientSideCredentialAccessBoundaryFactory {
    * with the desired configuration options.
    */
   public static class Builder {
-    private GoogleCredentials sourceCredential;
+    private @Nullable GoogleCredentials sourceCredential;
     private @Nullable HttpTransportFactory transportFactory;
     private @Nullable String universeDomain;
-    private String tokenExchangeEndpoint;
-    private Duration minimumTokenLifetime;
-    private Duration refreshMargin;
+    private @Nullable String tokenExchangeEndpoint;
+    private @Nullable Duration minimumTokenLifetime;
+    private @Nullable Duration refreshMargin;
     private Clock clock = Clock.SYSTEM; // Default to system clock;
 
     private Builder() {}

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -237,7 +237,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
 
   public static class Builder extends ExternalAccountCredentials.Builder {
 
-    private AwsSecurityCredentialsSupplier awsSecurityCredentialsSupplier;
+    private @Nullable AwsSecurityCredentialsSupplier awsSecurityCredentialsSupplier;
 
     private @Nullable String regionalCredentialVerificationUrlOverride;
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AwsRequestSignature.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/AwsRequestSignature.java
@@ -35,6 +35,7 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.HashMap;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Stores the AWS API request signature based on the AWS Signature Version 4 signing process, and
@@ -122,16 +123,16 @@ class AwsRequestSignature {
 
   static class Builder {
 
-    private AwsSecurityCredentials awsSecurityCredentials;
-    private Map<String, String> canonicalHeaders;
+    private @Nullable AwsSecurityCredentials awsSecurityCredentials;
+    private @Nullable Map<String, String> canonicalHeaders;
 
-    private String signature;
-    private String credentialScope;
-    private String url;
-    private String httpMethod;
-    private String date;
-    private String region;
-    private String authorizationHeader;
+    private @Nullable String signature;
+    private @Nullable String credentialScope;
+    private @Nullable String url;
+    private @Nullable String httpMethod;
+    private @Nullable String date;
+    private @Nullable String region;
+    private @Nullable String authorizationHeader;
 
     @CanIgnoreReturnValue
     Builder setSignature(String signature) {

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ClientId.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ClientId.java
@@ -40,6 +40,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An OAuth2 user authorization Client ID and associated information.
@@ -56,7 +57,7 @@ public class ClientId {
   private static final String JSON_PARSE_ERROR = "Error parsing Client ID JSON: ";
 
   private final String clientId;
-  private final String clientSecret;
+  private final @Nullable String clientSecret;
 
   /**
    * Constructs a client ID from an explicit ID and secret.
@@ -143,7 +144,7 @@ public class ClientId {
    * @param clientId Text identifier of the Client ID.
    * @param clientSecret Secret to associated with the Client ID.
    */
-  private ClientId(String clientId, String clientSecret) {
+  private ClientId(String clientId, @Nullable String clientSecret) {
     this.clientId = Preconditions.checkNotNull(clientId);
     this.clientSecret = clientSecret;
   }
@@ -162,7 +163,7 @@ public class ClientId {
    *
    * @return The secret associated with the Client ID.
    */
-  public final String getClientSecret() {
+  public final @Nullable String getClientSecret() {
     return clientSecret;
   }
 
@@ -176,9 +177,9 @@ public class ClientId {
 
   public static class Builder {
 
-    private String clientId;
+    private @Nullable String clientId;
 
-    private String clientSecret;
+    private @Nullable String clientSecret;
 
     protected Builder() {}
 
@@ -194,12 +195,12 @@ public class ClientId {
     }
 
     @CanIgnoreReturnValue
-    public Builder setClientSecret(String clientSecret) {
+    public Builder setClientSecret(@Nullable String clientSecret) {
       this.clientSecret = clientSecret;
       return this;
     }
 
-    public String getClientSecret() {
+    public @Nullable String getClientSecret() {
       return clientSecret;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java
@@ -206,8 +206,8 @@ public final class CredentialAccessBoundary {
     }
 
     public static class Builder {
-      private String availableResource;
-      private List<String> availablePermissions;
+      private @Nullable String availableResource;
+      private @Nullable List<String> availablePermissions;
 
       @Nullable private AvailabilityCondition availabilityCondition;
 
@@ -327,7 +327,7 @@ public final class CredentialAccessBoundary {
       }
 
       public static final class Builder {
-        private String expression;
+        private @Nullable String expression;
 
         @Nullable private String title;
         @Nullable private String description;

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
@@ -205,8 +205,8 @@ public final class DownscopedCredentials extends OAuth2Credentials {
 
   public static class Builder extends OAuth2Credentials.Builder {
 
-    private GoogleCredentials sourceCredential;
-    private CredentialAccessBoundary credentialAccessBoundary;
+    private @Nullable GoogleCredentials sourceCredential;
+    private @Nullable CredentialAccessBoundary credentialAccessBoundary;
     private @Nullable HttpTransportFactory transportFactory;
     private @Nullable String universeDomain;
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentials.java
@@ -85,14 +85,14 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
   private static final long serialVersionUID = -2181779590486283287L;
 
   private final String transportFactoryClassName;
-  private final String audience;
-  private final String tokenUrl;
-  private final String tokenInfoUrl;
-  private final String revokeUrl;
-  private final String clientId;
-  private final String clientSecret;
+  private final @Nullable String audience;
+  private final @Nullable String tokenUrl;
+  private final @Nullable String tokenInfoUrl;
+  private final @Nullable String revokeUrl;
+  private final @Nullable String clientId;
+  private final @Nullable String clientSecret;
 
-  private String refreshToken;
+  private @Nullable String refreshToken;
 
   private transient HttpTransportFactory transportFactory;
 
@@ -417,14 +417,14 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
   /** Builder for {@link ExternalAccountAuthorizedUserCredentials}. */
   public static class Builder extends GoogleCredentials.Builder {
 
-    private HttpTransportFactory transportFactory;
-    private String audience;
-    private String refreshToken;
-    private String tokenUrl;
-    private String tokenInfoUrl;
-    private String revokeUrl;
-    private String clientId;
-    private String clientSecret;
+    private @Nullable HttpTransportFactory transportFactory;
+    private @Nullable String audience;
+    private @Nullable String refreshToken;
+    private @Nullable String tokenUrl;
+    private @Nullable String tokenInfoUrl;
+    private @Nullable String revokeUrl;
+    private @Nullable String clientId;
+    private @Nullable String clientSecret;
 
     protected Builder() {}
 
@@ -447,7 +447,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
@@ -460,7 +460,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setAudience(String audience) {
+    public Builder setAudience(@Nullable String audience) {
       this.audience = audience;
       return this;
     }
@@ -472,7 +472,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setTokenUrl(String tokenUrl) {
+    public Builder setTokenUrl(@Nullable String tokenUrl) {
       this.tokenUrl = tokenUrl;
       return this;
     }
@@ -484,7 +484,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+    public Builder setTokenInfoUrl(@Nullable String tokenInfoUrl) {
       this.tokenInfoUrl = tokenInfoUrl;
       return this;
     }
@@ -496,7 +496,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setRevokeUrl(String revokeUrl) {
+    public Builder setRevokeUrl(@Nullable String revokeUrl) {
       this.revokeUrl = revokeUrl;
       return this;
     }
@@ -508,7 +508,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setRefreshToken(String refreshToken) {
+    public Builder setRefreshToken(@Nullable String refreshToken) {
       this.refreshToken = refreshToken;
       return this;
     }
@@ -520,7 +520,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setClientId(String clientId) {
+    public Builder setClientId(@Nullable String clientId) {
       this.clientId = clientId;
       return this;
     }
@@ -532,7 +532,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setClientSecret(String clientSecret) {
+    public Builder setClientSecret(@Nullable String clientSecret) {
       this.clientSecret = clientSecret;
       return this;
     }
@@ -545,7 +545,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      */
     @Override
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
@@ -558,7 +558,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      */
     @Override
     @CanIgnoreReturnValue
-    public Builder setAccessToken(AccessToken accessToken) {
+    public Builder setAccessToken(@Nullable AccessToken accessToken) {
       super.setAccessToken(accessToken);
       return this;
     }
@@ -571,7 +571,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      */
     @CanIgnoreReturnValue
     @Override
-    public Builder setUniverseDomain(String universeDomain) {
+    public Builder setUniverseDomain(@Nullable String universeDomain) {
       super.setUniverseDomain(universeDomain);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -770,13 +770,13 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
   /** Base builder for external account credentials. */
   public abstract static class Builder extends GoogleCredentials.Builder {
 
-    protected String audience;
-    protected String subjectTokenType;
-    protected String tokenUrl;
+    protected @Nullable String audience;
+    protected @Nullable String subjectTokenType;
+    protected @Nullable String tokenUrl;
     protected @Nullable String tokenInfoUrl;
-    protected CredentialSource credentialSource;
-    protected EnvironmentProvider environmentProvider;
-    protected PropertyProvider propertyProvider;
+    protected @Nullable CredentialSource credentialSource;
+    protected @Nullable EnvironmentProvider environmentProvider;
+    protected @Nullable PropertyProvider propertyProvider;
     protected @Nullable HttpTransportFactory transportFactory;
 
     @Nullable protected String serviceAccountImpersonationUrl;

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountSupplierContext.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ExternalAccountSupplierContext.java
@@ -35,6 +35,7 @@ import com.google.auth.oauth2.ExternalAccountCredentials.SubjectTokenTypes;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.Serializable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Context object to pass relevant variables from external account credentials to suppliers. This
@@ -87,8 +88,8 @@ public class ExternalAccountSupplierContext implements Serializable {
   /** Builder for external account supplier context. */
   static class Builder {
 
-    protected String audience;
-    protected String subjectTokenType;
+    protected @Nullable String audience;
+    protected @Nullable String subjectTokenType;
 
     /**
      * Sets the Audience.

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GdchCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GdchCredentials.java
@@ -542,14 +542,14 @@ public class GdchCredentials extends GoogleCredentials {
   }
 
   public static class Builder extends GoogleCredentials.Builder {
-    private String projectId;
-    private String privateKeyId;
-    private PrivateKey privateKey;
-    private String serviceIdentityName;
-    private URI tokenServerUri;
-    private String apiAudience;
-    private HttpTransportFactory transportFactory;
-    private String caCertPath;
+    private @Nullable String projectId;
+    private @Nullable String privateKeyId;
+    private @Nullable PrivateKey privateKey;
+    private @Nullable String serviceIdentityName;
+    private @Nullable URI tokenServerUri;
+    private @Nullable String apiAudience;
+    private @Nullable HttpTransportFactory transportFactory;
+    private @Nullable String caCertPath;
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
 
     protected Builder() {}
@@ -624,7 +624,7 @@ public class GdchCredentials extends GoogleCredentials {
       return this;
     }
 
-    public String getProjectId() {
+    public @Nullable String getProjectId() {
       return projectId;
     }
 
@@ -632,19 +632,19 @@ public class GdchCredentials extends GoogleCredentials {
       return privateKeyId;
     }
 
-    public PrivateKey getPrivateKey() {
+    public @Nullable PrivateKey getPrivateKey() {
       return privateKey;
     }
 
-    public String getServiceIdentityName() {
+    public @Nullable String getServiceIdentityName() {
       return serviceIdentityName;
     }
 
-    public URI getTokenServerUri() {
+    public @Nullable URI getTokenServerUri() {
       return tokenServerUri;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -167,7 +167,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
 
   public static class Builder extends OAuth2Credentials.Builder {
 
-    private IdTokenProvider idTokenProvider;
+    private @Nullable IdTokenProvider idTokenProvider;
     private @Nullable String targetAudience;
     private @Nullable List<IdTokenProvider.Option> options;
 
@@ -185,7 +185,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
       return this;
     }
 
-    public IdTokenProvider getIdTokenProvider() {
+    public @Nullable IdTokenProvider getIdTokenProvider() {
       return this.idTokenProvider;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -206,8 +206,8 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
 
   public static class Builder extends ExternalAccountCredentials.Builder {
 
-    private IdentityPoolSubjectTokenSupplier subjectTokenSupplier;
-    private X509Provider x509Provider;
+    private @Nullable IdentityPoolSubjectTokenSupplier subjectTokenSupplier;
+    private @Nullable X509Provider x509Provider;
 
     Builder() {}
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -764,8 +764,8 @@ public class ImpersonatedCredentials extends GoogleCredentials
 
   public static class Builder extends GoogleCredentials.Builder {
 
-    private GoogleCredentials sourceCredentials;
-    private String targetPrincipal;
+    private @Nullable GoogleCredentials sourceCredentials;
+    private @Nullable String targetPrincipal;
     private @Nullable List<String> delegates;
     private @Nullable List<String> scopes;
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
@@ -804,7 +804,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
       return this;
     }
 
-    public GoogleCredentials getSourceCredentials() {
+    public @Nullable GoogleCredentials getSourceCredentials() {
       return this.sourceCredentials;
     }
 
@@ -814,7 +814,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
       return this;
     }
 
-    public String getTargetPrincipal() {
+    public @Nullable String getTargetPrincipal() {
       return this.targetPrincipal;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -206,9 +206,9 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   }
 
   public static class Builder {
-    private PrivateKey privateKey;
+    private @Nullable PrivateKey privateKey;
     private @Nullable String privateKeyId;
-    private JwtClaims jwtClaims;
+    private @Nullable JwtClaims jwtClaims;
     private Clock clock = Clock.SYSTEM;
     private Long lifeSpanSeconds = TimeUnit.HOURS.toSeconds(1);
 
@@ -220,7 +220,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
       return this;
     }
 
-    public PrivateKey getPrivateKey() {
+    public @Nullable PrivateKey getPrivateKey() {
       return privateKey;
     }
 
@@ -240,7 +240,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
       return this;
     }
 
-    public JwtClaims getJwtClaims() {
+    public @Nullable JwtClaims getJwtClaims() {
       return jwtClaims;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
@@ -36,6 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.IOException;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A refreshable alternative to {@link OAuth2Credentials}.
@@ -63,7 +64,7 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
   }
 
   protected OAuth2CredentialsWithRefresh(
-      AccessToken accessToken, OAuth2RefreshHandler refreshHandler) {
+      @Nullable AccessToken accessToken, OAuth2RefreshHandler refreshHandler) {
     super(accessToken);
 
     // If no expirationTime is provided, the token will never be refreshed.
@@ -93,7 +94,7 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
 
   public static class Builder extends OAuth2Credentials.Builder {
 
-    private OAuth2RefreshHandler refreshHandler;
+    private @Nullable OAuth2RefreshHandler refreshHandler;
 
     private Builder() {}
 
@@ -103,7 +104,7 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
      */
     @Override
     @CanIgnoreReturnValue
-    public Builder setAccessToken(AccessToken token) {
+    public Builder setAccessToken(@Nullable AccessToken token) {
       super.setAccessToken(token);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
@@ -217,7 +217,7 @@ public class PluggableAuthCredentials extends ExternalAccountCredentials {
 
   public static class Builder extends ExternalAccountCredentials.Builder {
 
-    private ExecutableHandler handler;
+    private @Nullable ExecutableHandler handler;
 
     Builder() {}
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/SecureSessionAgent.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/SecureSessionAgent.java
@@ -50,6 +50,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import javax.annotation.concurrent.ThreadSafe;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utilities to fetch the S2A (Secure Session Agent) address from the mTLS configuration.
@@ -76,7 +77,7 @@ public class SecureSessionAgent {
   private static final String MDS_MTLS_ENDPOINT =
       ComputeEngineCredentials.getMetadataServerUrl() + S2A_CONFIG_ENDPOINT_POSTFIX;
 
-  private transient HttpTransportFactory transportFactory;
+  private transient @Nullable HttpTransportFactory transportFactory;
 
   SecureSessionAgent(SecureSessionAgent.Builder builder) {
     this.transportFactory = builder.getHttpTransportFactory();
@@ -104,17 +105,17 @@ public class SecureSessionAgent {
   }
 
   public static class Builder {
-    private HttpTransportFactory transportFactory;
+    private @Nullable HttpTransportFactory transportFactory;
 
     protected Builder() {}
 
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return this.transportFactory;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -103,12 +103,12 @@ public class ServiceAccountCredentials extends GoogleCredentials
   private static final LoggerProvider LOGGER_PROVIDER =
       LoggerProvider.forClazz(ServiceAccountCredentials.class);
 
-  private final String clientId;
+  private final @Nullable String clientId;
   private final String clientEmail;
   private final PrivateKey privateKey;
-  private final String privateKeyId;
-  private final String serviceAccountUser;
-  private final String projectId;
+  private final @Nullable String privateKeyId;
+  private final @Nullable String serviceAccountUser;
+  private final @Nullable String projectId;
   private final String transportFactoryClassName;
   private final URI tokenServerUri;
   private final Collection<String> scopes;
@@ -1150,16 +1150,16 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
   public static class Builder extends GoogleCredentials.Builder {
 
-    private String clientId;
-    private String clientEmail;
-    private PrivateKey privateKey;
-    private String privateKeyId;
-    private String serviceAccountUser;
-    private String projectId;
-    private URI tokenServerUri;
-    private Collection<String> scopes;
-    private Collection<String> defaultScopes;
-    private HttpTransportFactory transportFactory;
+    private @Nullable String clientId;
+    private @Nullable String clientEmail;
+    private @Nullable PrivateKey privateKey;
+    private @Nullable String privateKeyId;
+    private @Nullable String serviceAccountUser;
+    private @Nullable String projectId;
+    private @Nullable URI tokenServerUri;
+    private @Nullable Collection<String> scopes;
+    private @Nullable Collection<String> defaultScopes;
+    private @Nullable HttpTransportFactory transportFactory;
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
     private boolean useJwtAccessWithScope = false;
     private boolean defaultRetriesEnabled = true;
@@ -1290,11 +1290,11 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return clientId;
     }
 
-    public String getClientEmail() {
+    public @Nullable String getClientEmail() {
       return clientEmail;
     }
 
-    public PrivateKey getPrivateKey() {
+    public @Nullable PrivateKey getPrivateKey() {
       return privateKey;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -521,8 +521,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   public static class Builder {
 
     private @Nullable String clientId;
-    private String clientEmail;
-    private PrivateKey privateKey;
+    private @Nullable String clientEmail;
+    private @Nullable PrivateKey privateKey;
     private @Nullable String privateKeyId;
     private @Nullable URI defaultAudience;
     private @Nullable String quotaProjectId;
@@ -587,11 +587,11 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
       return clientId;
     }
 
-    public String getClientEmail() {
+    public @Nullable String getClientEmail() {
       return clientEmail;
     }
 
-    public PrivateKey getPrivateKey() {
+    public @Nullable PrivateKey getPrivateKey() {
       return privateKey;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/TokenVerifier.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/TokenVerifier.java
@@ -194,11 +194,11 @@ public class TokenVerifier {
 
   public static class Builder {
     private @Nullable String audience;
-    private String certificatesLocation;
+    private @Nullable String certificatesLocation;
     private @Nullable String issuer;
     private @Nullable PublicKey publicKey;
-    private Clock clock;
-    private HttpTransportFactory httpTransportFactory;
+    private @Nullable Clock clock;
+    private @Nullable HttpTransportFactory httpTransportFactory;
 
     /**
      * Set a target audience to verify.
@@ -218,7 +218,7 @@ public class TokenVerifier {
      * @param certificatesLocation URL to published public keys
      * @return the builder
      */
-    public Builder setCertificatesLocation(String certificatesLocation) {
+    public Builder setCertificatesLocation(@Nullable String certificatesLocation) {
       this.certificatesLocation = certificatesLocation;
       return this;
     }
@@ -252,7 +252,7 @@ public class TokenVerifier {
      * @param clock the clock to use. Defaults to the system clock
      * @return the builder
      */
-    public Builder setClock(Clock clock) {
+    public Builder setClock(@Nullable Clock clock) {
       this.clock = clock;
       return this;
     }
@@ -264,7 +264,7 @@ public class TokenVerifier {
      * @param httpTransportFactory the HttpTransportFactory used to build certificate URL requests
      * @return the builder
      */
-    public Builder setHttpTransportFactory(HttpTransportFactory httpTransportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory httpTransportFactory) {
       this.httpTransportFactory = httpTransportFactory;
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -184,7 +184,8 @@ public class UserAuthorizer {
    * @param baseUri The URI to resolve the OAuth2 callback URI relative to.
    * @return The URL that can be navigated or redirected to.
    */
-  public URL getAuthorizationUrl(@Nullable String userId, @Nullable String state, @Nullable URI baseUri) {
+  public URL getAuthorizationUrl(
+      @Nullable String userId, @Nullable String state, @Nullable URI baseUri) {
     return this.getAuthorizationUrl(userId, state, baseUri, null);
   }
 
@@ -241,7 +242,7 @@ public class UserAuthorizer {
    * @throws IOException If there is error retrieving or loading the credentials.
    */
   @Nullable
-  public @Nullable UserCredentials getCredentials(String userId) throws IOException {
+  public UserCredentials getCredentials(String userId) throws IOException {
     Preconditions.checkNotNull(userId);
     if (tokenStore == null) {
       throw new IllegalStateException("Method cannot be called if token store is not specified.");
@@ -288,7 +289,8 @@ public class UserAuthorizer {
    * @return the UserCredentials instance created from the authorization code.
    * @throws IOException An error from the server API call to get the tokens.
    */
-  public UserCredentials getCredentialsFromCode(String code, @Nullable URI baseUri) throws IOException {
+  public UserCredentials getCredentialsFromCode(String code, @Nullable URI baseUri)
+      throws IOException {
     return getCredentialsFromCode(code, baseUri, null);
   }
 
@@ -330,7 +332,8 @@ public class UserAuthorizer {
    * @throws IOException If an error occurs during the token exchange process.
    */
   public TokenResponseWithConfig getTokenResponseFromAuthCodeExchange(
-      String code, @Nullable URI callbackUri, @Nullable Map<String, String> additionalParameters) throws IOException {
+      String code, @Nullable URI callbackUri, @Nullable Map<String, String> additionalParameters)
+      throws IOException {
     return getCredentialsFromCodeInternal(code, callbackUri, additionalParameters);
   }
 
@@ -343,8 +346,8 @@ public class UserAuthorizer {
    * @return UserCredentials instance created from the authorization code.
    * @throws IOException An error from the server API call to get the tokens or store the tokens.
    */
-  public UserCredentials getAndStoreCredentialsFromCode(String userId, String code, @Nullable URI baseUri)
-      throws IOException {
+  public UserCredentials getAndStoreCredentialsFromCode(
+      String userId, String code, @Nullable URI baseUri) throws IOException {
     Preconditions.checkNotNull(userId);
     Preconditions.checkNotNull(code);
     UserCredentials credentials = getCredentialsFromCode(code, baseUri);
@@ -451,7 +454,8 @@ public class UserAuthorizer {
   }
 
   private TokenResponseWithConfig getCredentialsFromCodeInternal(
-      String code, @Nullable URI baseUri, @Nullable Map<String, String> additionalParameters) throws IOException {
+      String code, @Nullable URI baseUri, @Nullable Map<String, String> additionalParameters)
+      throws IOException {
     Preconditions.checkNotNull(code);
     URI resolvedCallbackUri = getCallbackUri(baseUri);
 
@@ -558,15 +562,15 @@ public class UserAuthorizer {
 
   public static class Builder {
 
-    private ClientId clientId;
-    private TokenStore tokenStore;
-    private URI callbackUri;
-    private URI tokenServerUri;
-    private URI userAuthUri;
-    private Collection<String> scopes;
-    private HttpTransportFactory transportFactory;
-    private PKCEProvider pkce;
-    private ClientAuthenticationType clientAuthenticationType;
+    private @Nullable ClientId clientId;
+    private @Nullable TokenStore tokenStore;
+    private @Nullable URI callbackUri;
+    private @Nullable URI tokenServerUri;
+    private @Nullable URI userAuthUri;
+    private @Nullable Collection<String> scopes;
+    private @Nullable HttpTransportFactory transportFactory;
+    private @Nullable PKCEProvider pkce;
+    private @Nullable ClientAuthenticationType clientAuthenticationType;
 
     protected Builder() {}
 
@@ -589,7 +593,7 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setClientId(ClientId clientId) {
+    public Builder setClientId(@Nullable ClientId clientId) {
       this.clientId = clientId;
       return this;
     }
@@ -601,7 +605,7 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setTokenStore(TokenStore tokenStore) {
+    public Builder setTokenStore(@Nullable TokenStore tokenStore) {
       this.tokenStore = tokenStore;
       return this;
     }
@@ -613,7 +617,7 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setScopes(Collection<String> scopes) {
+    public Builder setScopes(@Nullable Collection<String> scopes) {
       this.scopes = scopes;
       return this;
     }
@@ -625,7 +629,7 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setTokenServerUri(URI tokenServerUri) {
+    public Builder setTokenServerUri(@Nullable URI tokenServerUri) {
       this.tokenServerUri = tokenServerUri;
       return this;
     }
@@ -638,7 +642,7 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setCallbackUri(URI callbackUri) {
+    public Builder setCallbackUri(@Nullable URI callbackUri) {
       this.callbackUri = callbackUri;
       return this;
     }
@@ -650,7 +654,7 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setUserAuthUri(URI userAuthUri) {
+    public Builder setUserAuthUri(@Nullable URI userAuthUri) {
       this.userAuthUri = userAuthUri;
       return this;
     }
@@ -662,7 +666,7 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+    public Builder setHttpTransportFactory(@Nullable HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
       return this;
     }
@@ -676,14 +680,15 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setPKCEProvider(PKCEProvider pkce) {
+    public Builder setPKCEProvider(@Nullable PKCEProvider pkce) {
       if (pkce != null) {
         if (pkce.getCodeChallenge() == null
             || pkce.getCodeVerifier() == null
             || pkce.getCodeChallengeMethod() == null) {
 
           throw new IllegalArgumentException(
-              "PKCE provider contained null implementations. PKCE object must implement all PKCEProvider methods.");
+              "PKCE provider contained null implementations. PKCE object must implement all"
+                  + " PKCEProvider methods.");
         }
       }
       this.pkce = pkce;
@@ -699,44 +704,45 @@ public class UserAuthorizer {
      * @return this {@code Builder} object
      */
     @CanIgnoreReturnValue
-    public Builder setClientAuthenticationType(ClientAuthenticationType clientAuthentication) {
+    public Builder setClientAuthenticationType(
+        @Nullable ClientAuthenticationType clientAuthentication) {
       this.clientAuthenticationType = clientAuthentication;
       return this;
     }
 
-    public ClientId getClientId() {
+    public @Nullable ClientId getClientId() {
       return clientId;
     }
 
-    public TokenStore getTokenStore() {
+    public @Nullable TokenStore getTokenStore() {
       return tokenStore;
     }
 
-    public Collection<String> getScopes() {
+    public @Nullable Collection<String> getScopes() {
       return scopes;
     }
 
-    public URI getTokenServerUri() {
+    public @Nullable URI getTokenServerUri() {
       return tokenServerUri;
     }
 
-    public URI getCallbackUri() {
+    public @Nullable URI getCallbackUri() {
       return callbackUri;
     }
 
-    public URI getUserAuthUri() {
+    public @Nullable URI getUserAuthUri() {
       return userAuthUri;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 
-    public PKCEProvider getPKCEProvider() {
+    public @Nullable PKCEProvider getPKCEProvider() {
       return pkce;
     }
 
-    public ClientAuthenticationType getClientAuthenticationType() {
+    public @Nullable ClientAuthenticationType getClientAuthenticationType() {
       return clientAuthenticationType;
     }
 
@@ -776,12 +782,12 @@ public class UserAuthorizer {
    */
   public static class TokenResponseWithConfig {
 
-    private final String clientId;
-    private final String clientSecret;
-    private final String refreshToken;
-    private final AccessToken accessToken;
-    private URI tokenServerUri;
-    private final HttpTransportFactory httpTransportFactory;
+    private final @Nullable String clientId;
+    private final @Nullable String clientSecret;
+    private final @Nullable String refreshToken;
+    private final @Nullable AccessToken accessToken;
+    private @Nullable URI tokenServerUri;
+    private final @Nullable HttpTransportFactory httpTransportFactory;
 
     private TokenResponseWithConfig(Builder builder) {
       this.clientId = builder.clientId;
@@ -797,7 +803,7 @@ public class UserAuthorizer {
      *
      * @return The client ID.
      */
-    public String getClientId() {
+    public @Nullable String getClientId() {
       return clientId;
     }
 
@@ -806,7 +812,7 @@ public class UserAuthorizer {
      *
      * @return The client secret.
      */
-    public String getClientSecret() {
+    public @Nullable String getClientSecret() {
       return clientSecret;
     }
 
@@ -815,7 +821,7 @@ public class UserAuthorizer {
      *
      * @return The access token.
      */
-    public AccessToken getAccessToken() {
+    public @Nullable AccessToken getAccessToken() {
       return accessToken;
     }
 
@@ -824,7 +830,7 @@ public class UserAuthorizer {
      *
      * @return The HTTP transport factory.
      */
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return httpTransportFactory;
     }
 
@@ -833,7 +839,7 @@ public class UserAuthorizer {
      *
      * @return The token server URI.
      */
-    public URI getTokenServerUri() {
+    public @Nullable URI getTokenServerUri() {
       return tokenServerUri;
     }
 
@@ -852,45 +858,45 @@ public class UserAuthorizer {
     }
 
     static class Builder {
-      private String clientId;
-      private String clientSecret;
-      private String refreshToken;
-      private AccessToken accessToken;
-      private URI tokenServerUri;
-      private HttpTransportFactory httpTransportFactory;
+      private @Nullable String clientId;
+      private @Nullable String clientSecret;
+      private @Nullable String refreshToken;
+      private @Nullable AccessToken accessToken;
+      private @Nullable URI tokenServerUri;
+      private @Nullable HttpTransportFactory httpTransportFactory;
 
       @CanIgnoreReturnValue
-      Builder setClientId(String clientId) {
+      Builder setClientId(@Nullable String clientId) {
         this.clientId = clientId;
         return this;
       }
 
       @CanIgnoreReturnValue
-      Builder setClientSecret(String clientSecret) {
+      Builder setClientSecret(@Nullable String clientSecret) {
         this.clientSecret = clientSecret;
         return this;
       }
 
       @CanIgnoreReturnValue
-      Builder setRefreshToken(String refreshToken) {
+      Builder setRefreshToken(@Nullable String refreshToken) {
         this.refreshToken = refreshToken;
         return this;
       }
 
       @CanIgnoreReturnValue
-      Builder setAccessToken(AccessToken accessToken) {
+      Builder setAccessToken(@Nullable AccessToken accessToken) {
         this.accessToken = accessToken;
         return this;
       }
 
       @CanIgnoreReturnValue
-      Builder setHttpTransportFactory(HttpTransportFactory httpTransportFactory) {
+      Builder setHttpTransportFactory(@Nullable HttpTransportFactory httpTransportFactory) {
         this.httpTransportFactory = httpTransportFactory;
         return this;
       }
 
       @CanIgnoreReturnValue
-      Builder setTokenServerUri(URI tokenServerUri) {
+      Builder setTokenServerUri(@Nullable URI tokenServerUri) {
         this.tokenServerUri = tokenServerUri;
         return this;
       }


### PR DESCRIPTION
This PR is **part 3 of 3** in a stacked series of JSpecify nullability fixes for `google-auth-library-java`:
1. #14150: `fix(auth): fix JSpecify nullability in UserAuthorizer and TokenStore` (resolves #14147)
2. #14153: `fix(auth): add missing @Nullable annotations across credential types and providers`
3. **This PR (#14154)**: `fix(auth): annotate builder fields, setters, and getters as @Nullable across credential builders`

---

### Description
In `@NullMarked` credential classes and their corresponding `Builder` nested classes, fields that default to `null` before setter invocation, or represent optional configuration (such as optional tokens, transport factories, quotas, boundary rules, audiences, scopes, or endpoints), were unannotated, causing IDEs and static analysis tools to flag null assignments or null checks as warnings/errors.

This PR aligns `@Nullable` annotations across builder fields, builder setters (parameters and returns), and corresponding credential getter return types across 21 credential and authorizer builder classes.