### PR TITLE
feat(gax): implement queryStatusCallable for resumable uploads

### DIFF
--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClient.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClient.java
@@ -34,6 +34,8 @@ import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.resumable.ChunkUploadRequest;
 import com.google.api.gax.resumable.ChunkUploadResponse;
+import com.google.api.gax.resumable.QueryStatusRequest;
+import com.google.api.gax.resumable.QueryStatusResponse;
 import com.google.api.gax.resumable.ResumableUploadClient;
 import com.google.api.gax.resumable.ResumableUploadSession;
 import com.google.api.gax.rpc.ClientContext;
@@ -58,6 +60,8 @@ public final class HttpJsonResumableUploadClient<RequestT, ResponseT>
   private final UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable;
   private final UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>>
       uploadChunkCallable;
+  private final UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>>
+      queryStatusCallable;
 
   public static <RequestT, ResponseT> HttpJsonResumableUploadClient<RequestT, ResponseT> create(
       ClientContext clientContext, ApiMethodDescriptor<RequestT, ResponseT> methodDescriptor) {
@@ -82,6 +86,8 @@ public final class HttpJsonResumableUploadClient<RequestT, ResponseT>
     this.startUploadCallable =
         ResumableUploadStartCallable.create(clientContext, startUploadDescriptor);
     this.uploadChunkCallable = ResumableUploadChunkCallable.create(clientContext, responseParser);
+    this.queryStatusCallable =
+        ResumableUploadQueryStatusCallable.create(clientContext, responseParser);
   }
 
   @Override
@@ -92,5 +98,10 @@ public final class HttpJsonResumableUploadClient<RequestT, ResponseT>
   @Override
   public UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> uploadChunkCallable() {
     return uploadChunkCallable;
+  }
+
+  @Override
+  public UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>> queryStatusCallable() {
+    return queryStatusCallable;
   }
 }

--- a/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadQueryStatusCallable.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/main/java/com/google/api/gax/httpjson/ResumableUploadQueryStatusCallable.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.httpjson;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.resumable.QueryStatusRequest;
+import com.google.api.gax.resumable.QueryStatusResponse;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A {@link UnaryCallable} that queries the committed status and offset of a resumable upload
+ * session.
+ */
+@NullMarked
+class ResumableUploadQueryStatusCallable<ResponseT>
+    extends UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>> {
+
+  private static final String UPLOAD_COMMAND_HEADER = "X-Goog-Upload-Command";
+  private static final String UPLOAD_STATUS_HEADER = "X-Goog-Upload-Status";
+  private static final String UPLOAD_SIZE_RECEIVED_HEADER = "X-Goog-Upload-Size-Received";
+  private static final String STATUS_FINAL = "final";
+  private static final String COMMAND_QUERY = "query";
+
+  private static final Map<String, List<String>> QUERY_STATUS_HEADERS =
+      ImmutableMap.of(UPLOAD_COMMAND_HEADER, ImmutableList.of(COMMAND_QUERY));
+
+  private static final PathTemplate PATH_TEMPLATE = PathTemplate.create("**");
+
+  private static final ApiMethodDescriptor<QueryStatusRequest, String> QUERY_STATUS_DESCRIPTOR =
+      ApiMethodDescriptor.<QueryStatusRequest, String>newBuilder()
+          .setFullMethodName("ResumableUpload/QueryStatus")
+          .setHttpMethod(HttpMethods.POST)
+          .setType(ApiMethodDescriptor.MethodType.UNARY)
+          .setRequestFormatter(
+              new HttpRequestFormatter<QueryStatusRequest>() {
+                @Override
+                public Map<String, List<String>> getQueryParamNames(QueryStatusRequest request) {
+                  return Collections.emptyMap();
+                }
+
+                @Override
+                public String getRequestBody(QueryStatusRequest request) {
+                  return "";
+                }
+
+                @Override
+                public String getPath(QueryStatusRequest request) {
+                  return request.getUploadUrl();
+                }
+
+                @Override
+                public PathTemplate getPathTemplate() {
+                  return PATH_TEMPLATE;
+                }
+              })
+          .setResponseParser(ResumableUploadResponseParser.create())
+          .build();
+
+  private final ClientContext clientContext;
+  private final HttpResponseParser<ResponseT> responseParser;
+
+  private ResumableUploadQueryStatusCallable(
+      ClientContext clientContext, HttpResponseParser<ResponseT> responseParser) {
+    this.clientContext = Preconditions.checkNotNull(clientContext);
+    this.responseParser = Preconditions.checkNotNull(responseParser);
+  }
+
+  @Override
+  public ApiFuture<QueryStatusResponse<ResponseT>> futureCall(
+      QueryStatusRequest request, @Nullable ApiCallContext inputContext) {
+    Preconditions.checkNotNull(request);
+    HttpJsonCallContext context =
+        (HttpJsonCallContext)
+            HttpJsonCallContext.createDefault()
+                .nullToSelf(clientContext.getDefaultCallContext())
+                .merge(inputContext)
+                .withExtraHeaders(QUERY_STATUS_HEADERS);
+
+    HttpJsonClientCall<QueryStatusRequest, String> clientCall =
+        HttpJsonClientCalls.newCall(QUERY_STATUS_DESCRIPTOR, context);
+
+    ResumableUploadHttpJsonFuture<QueryStatusResponse<ResponseT>> future =
+        new ResumableUploadHttpJsonFuture<>(clientCall);
+    HttpJsonClientCalls.startUnaryCall(
+        clientCall, request, context, new QueryStatusResponseListener<>(future, responseParser));
+
+    return future;
+  }
+
+  static <ResponseT> UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>> create(
+      ClientContext clientContext, HttpResponseParser<ResponseT> responseParser) {
+    UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>> rawCallable =
+        new ResumableUploadQueryStatusCallable<>(clientContext, responseParser);
+    UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>> callable =
+        new HttpJsonExceptionCallable<>(
+            rawCallable,
+            // Wire calls do not retry directly; retries are managed by ResumableUploadCallable.
+            Collections.emptySet());
+    return callable.withDefaultCallContext(clientContext.getDefaultCallContext());
+  }
+
+  @Nullable
+  private static Long parseSizeReceived(HttpJsonMetadata responseHeaders) {
+    String sizeReceivedStr =
+        HttpHeadersUtils.getSingleHeader(responseHeaders.getHeaders(), UPLOAD_SIZE_RECEIVED_HEADER);
+    if (!Strings.isNullOrEmpty(sizeReceivedStr)) {
+      try {
+        long parsed = Long.parseLong(sizeReceivedStr);
+        if (parsed < 0) {
+          throw ApiExceptionFactory.createException(
+              "Response contained negative "
+                  + UPLOAD_SIZE_RECEIVED_HEADER
+                  + " header: "
+                  + sizeReceivedStr,
+              /* cause= */ null,
+              HttpJsonStatusCode.of(StatusCode.Code.INTERNAL),
+              /* retryable= */ false);
+        }
+        return parsed;
+      } catch (NumberFormatException e) {
+        throw ApiExceptionFactory.createException(
+            "Response contained invalid "
+                + UPLOAD_SIZE_RECEIVED_HEADER
+                + " header: "
+                + sizeReceivedStr,
+            e,
+            HttpJsonStatusCode.of(StatusCode.Code.INTERNAL),
+            /* retryable= */ false);
+      }
+    }
+    return null;
+  }
+
+  /** A listener that parses query response headers to produce the {@link QueryStatusResponse}. */
+  private static class QueryStatusResponseListener<ResponseT>
+      extends HttpJsonClientCall.Listener<String> {
+
+    private final ResumableUploadHttpJsonFuture<QueryStatusResponse<ResponseT>> future;
+    private final HttpResponseParser<ResponseT> responseParser;
+    @Nullable private String uploadStatus = null;
+    @Nullable private Long committedOffset = null;
+    @Nullable private Throwable headerParsingException;
+    private String responseBody = "";
+
+    private QueryStatusResponseListener(
+        ResumableUploadHttpJsonFuture<QueryStatusResponse<ResponseT>> future,
+        HttpResponseParser<ResponseT> responseParser) {
+      this.future = future;
+      this.responseParser = responseParser;
+    }
+
+    @Override
+    public void onHeaders(HttpJsonMetadata responseHeaders) {
+      Map<String, Object> headers = responseHeaders.getHeaders();
+      this.uploadStatus = HttpHeadersUtils.getSingleHeader(headers, UPLOAD_STATUS_HEADER);
+      try {
+        this.committedOffset = parseSizeReceived(responseHeaders);
+      } catch (Throwable t) {
+        this.headerParsingException = t;
+      }
+    }
+
+    @Override
+    public void onMessage(@Nullable String message) {
+      if (message != null) {
+        this.responseBody = message;
+      }
+    }
+
+    @Override
+    public void onClose(int statusCode, HttpJsonMetadata trailers) {
+      try {
+        if (statusCode >= 200 && statusCode < 300) {
+          if (headerParsingException != null) {
+            future.setException(headerParsingException);
+            return;
+          }
+          boolean isComplete = STATUS_FINAL.equalsIgnoreCase(uploadStatus);
+          if (isComplete) {
+            QueryStatusResponse.Builder<ResponseT> queryResponseBuilder =
+                QueryStatusResponse.<ResponseT>newBuilder().setComplete(true);
+            InputStream stream =
+                new ByteArrayInputStream(responseBody.getBytes(StandardCharsets.UTF_8));
+            queryResponseBuilder.setResponse(responseParser.parse(stream));
+            future.set(queryResponseBuilder.build());
+          } else if (committedOffset != null) {
+            future.set(
+                QueryStatusResponse.<ResponseT>newBuilder()
+                    .setComplete(false)
+                    .setCommittedOffset(committedOffset)
+                    .build());
+          } else {
+            future.setException(
+                ApiExceptionFactory.createException(
+                    "Query status response did not contain valid "
+                        + UPLOAD_SIZE_RECEIVED_HEADER
+                        + " header",
+                    /* cause= */ null,
+                    HttpJsonStatusCode.of(StatusCode.Code.INTERNAL),
+                    /* retryable= */ false));
+          }
+        } else {
+          Throwable cause = trailers.getException();
+          future.setException(
+              cause != null
+                  ? cause
+                  : new HttpJsonStatusRuntimeException(
+                      statusCode,
+                      "Failed to query upload status with status code: " + statusCode,
+                      null));
+        }
+      } catch (Throwable t) {
+        future.setException(t);
+      }
+    }
+  }
+}

--- a/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClientTest.java
+++ b/sdk-platform-java/gax-java/gax-httpjson/src/test/java/com/google/api/gax/httpjson/HttpJsonResumableUploadClientTest.java
@@ -42,6 +42,8 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.api.core.InternalApi;
 import com.google.api.gax.resumable.ChunkUploadRequest;
 import com.google.api.gax.resumable.ChunkUploadResponse;
+import com.google.api.gax.resumable.QueryStatusRequest;
+import com.google.api.gax.resumable.QueryStatusResponse;
 import com.google.api.gax.resumable.ResumableUploadSession;
 import com.google.api.gax.rpc.AbortedException;
 import com.google.api.gax.rpc.ApiCallContext;
@@ -422,6 +424,125 @@ class HttpJsonResumableUploadClientTest {
     ApiException apiException = (ApiException) exception.getCause();
     assertThat(apiException.isRetryable()).isFalse();
     assertThat(apiException.getStatusCode().getCode()).isEqualTo(StatusCode.Code.UNAVAILABLE);
+  }
+
+  @Test
+  void queryStatus_activeUpload_returnsCommittedOffset() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Status", "active");
+    httpResponse.addHeader("X-Goog-Upload-Size-Received", "524288");
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(httpResponse);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+    QueryStatusRequest request = QueryStatusRequest.create(TEST_UPLOAD_URL);
+
+    QueryStatusResponse<String> response = client.queryStatusCallable().call(request);
+
+    assertThat(response.isComplete()).isFalse();
+    assertThat(response.getCommittedOffset()).isEqualTo(524288L);
+    assertThat(response.getResponse()).isNull();
+
+    assertThat(transport.capturedHeaders.get("x-goog-upload-command")).containsExactly("query");
+  }
+
+  @Test
+  void queryStatus_finalUpload_returnsCompleteAndResponseBody() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Status", "final");
+    httpResponse.setContent("{\"name\":\"uploaded-file.txt\",\"size\":1048576}");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    QueryStatusRequest request = QueryStatusRequest.create(TEST_UPLOAD_URL);
+
+    QueryStatusResponse<String> response = client.queryStatusCallable().call(request);
+
+    assertThat(response.isComplete()).isTrue();
+    assertThat(response.getCommittedOffset()).isNull();
+    assertThat(response.getResponse())
+        .isEqualTo("{\"name\":\"uploaded-file.txt\",\"size\":1048576}");
+  }
+
+  @Test
+  void queryStatus_withCustomExtraHeaders_preservesHeaders() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(200);
+    httpResponse.addHeader("X-Goog-Upload-Status", "active");
+    httpResponse.addHeader("X-Goog-Upload-Size-Received", "256");
+
+    CapturingHttpTransport transport = new CapturingHttpTransport(httpResponse);
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(transport);
+    QueryStatusRequest request = QueryStatusRequest.create(TEST_UPLOAD_URL);
+
+    Map<String, List<String>> customHeaders =
+        Collections.singletonMap(
+            "X-Custom-Query-Header", Collections.singletonList("CustomQueryValue"));
+
+    ApiCallContext callContext =
+        HttpJsonCallContext.createDefault().withExtraHeaders(customHeaders);
+
+    client.queryStatusCallable().call(request, callContext);
+
+    assertThat(transport.capturedHeaders.get("x-custom-query-header"))
+        .containsExactly("CustomQueryValue");
+  }
+
+  @Test
+  void queryStatus_serverReturnsError_throwsApiException() {
+    MockLowLevelHttpResponse httpResponse = new MockLowLevelHttpResponse();
+    httpResponse.setStatusCode(404);
+    httpResponse.setContent("{\"error\":{\"message\":\"Session not found\"}}");
+
+    HttpJsonResumableUploadClient<TestRequest, String> client = createClient(httpResponse);
+    QueryStatusRequest request =
+        QueryStatusRequest.create("https://test.googleapis.com/upload/session/invalid");
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class, () -> client.queryStatusCallable().futureCall(request).get());
+
+    assertThat(exception.getCause()).isInstanceOf(NotFoundException.class);
+    NotFoundException notFoundException = (NotFoundException) exception.getCause();
+    assertThat(notFoundException.getStatusCode().getCode()).isEqualTo(StatusCode.Code.NOT_FOUND);
+  }
+
+  @Test
+  void queryStatus_missingOrMalformedSizeReceivedHeader_throwsException() {
+    QueryStatusRequest request = QueryStatusRequest.create(TEST_UPLOAD_URL);
+
+    // Missing header
+    MockLowLevelHttpResponse missingHeaderResponse = new MockLowLevelHttpResponse();
+    missingHeaderResponse.setStatusCode(200);
+    missingHeaderResponse.addHeader("X-Goog-Upload-Status", "active");
+
+    HttpJsonResumableUploadClient<TestRequest, String> missingClient =
+        createClient(missingHeaderResponse);
+    ExecutionException missingException =
+        assertThrows(
+            ExecutionException.class,
+            () -> missingClient.queryStatusCallable().futureCall(request).get());
+    assertThat(missingException.getCause()).isInstanceOf(InternalException.class);
+    assertThat(missingException.getCause())
+        .hasMessageThat()
+        .contains("Query status response did not contain valid X-Goog-Upload-Size-Received header");
+
+    // Malformed header
+    MockLowLevelHttpResponse malformedHeaderResponse = new MockLowLevelHttpResponse();
+    malformedHeaderResponse.setStatusCode(200);
+    malformedHeaderResponse.addHeader("X-Goog-Upload-Status", "active");
+    malformedHeaderResponse.addHeader("X-Goog-Upload-Size-Received", "not-a-number");
+
+    HttpJsonResumableUploadClient<TestRequest, String> malformedClient =
+        createClient(malformedHeaderResponse);
+    ExecutionException malformedException =
+        assertThrows(
+            ExecutionException.class,
+            () -> malformedClient.queryStatusCallable().futureCall(request).get());
+    assertThat(malformedException.getCause()).isInstanceOf(InternalException.class);
+    assertThat(malformedException.getCause())
+        .hasMessageThat()
+        .contains("Response contained invalid X-Goog-Upload-Size-Received header: not-a-number");
   }
 
   private static HttpJsonResumableUploadClient<TestRequest, String> createClient(

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/QueryStatusRequest.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/QueryStatusRequest.java
@@ -31,26 +31,20 @@ package com.google.api.gax.resumable;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
-import com.google.api.gax.rpc.UnaryCallable;
+import com.google.auto.value.AutoValue;
 import org.jspecify.annotations.NullMarked;
 
-/**
- * Client interface for executing low-level resumable upload operations.
- *
- * @param <RequestT> request type for starting an upload
- * @param <ResponseT> response type of the upload operation
- */
+/** Request value object for querying the status of an active resumable upload session. */
 @NullMarked
 @BetaApi
 @InternalApi
-public interface ResumableUploadClient<RequestT, ResponseT> {
+@AutoValue
+public abstract class QueryStatusRequest {
 
-  /** Returns a {@link UnaryCallable} to initiate a resumable upload session. */
-  UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable();
+  /** Returns the upload session URL to query. */
+  public abstract String getUploadUrl();
 
-  /** Returns a {@link UnaryCallable} to transmit an individual chunk. */
-  UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> uploadChunkCallable();
-
-  /** Returns a {@link UnaryCallable} to query the status and offset of an active upload session. */
-  UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>> queryStatusCallable();
+  public static QueryStatusRequest create(String uploadUrl) {
+    return new AutoValue_QueryStatusRequest(uploadUrl);
+  }
 }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/QueryStatusResponse.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/QueryStatusResponse.java
@@ -31,26 +31,54 @@ package com.google.api.gax.resumable;
 
 import com.google.api.core.BetaApi;
 import com.google.api.core.InternalApi;
-import com.google.api.gax.rpc.UnaryCallable;
+import com.google.auto.value.AutoValue;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
- * Client interface for executing low-level resumable upload operations.
+ * Response value object representing the status and committed offset of a resumable upload session.
  *
- * @param <RequestT> request type for starting an upload
  * @param <ResponseT> response type of the upload operation
  */
 @NullMarked
 @BetaApi
 @InternalApi
-public interface ResumableUploadClient<RequestT, ResponseT> {
+@AutoValue
+public abstract class QueryStatusResponse<ResponseT> {
 
-  /** Returns a {@link UnaryCallable} to initiate a resumable upload session. */
-  UnaryCallable<RequestT, ResumableUploadSession> startUploadCallable();
+  /**
+   * The total number of bytes successfully received and committed by the server so far, or {@code
+   * null} if the server did not return a committed offset (e.g. if the upload is already
+   * finalized).
+   *
+   * <p>When {@link #isComplete()} is {@code false}, this value is guaranteed to be non-null and
+   * represents the starting offset for resuming the upload.
+   */
+  public abstract @Nullable Long getCommittedOffset();
 
-  /** Returns a {@link UnaryCallable} to transmit an individual chunk. */
-  UnaryCallable<ChunkUploadRequest, ChunkUploadResponse<ResponseT>> uploadChunkCallable();
+  /** Whether the resumable upload session has finalized and completed on the server. */
+  public abstract boolean isComplete();
 
-  /** Returns a {@link UnaryCallable} to query the status and offset of an active upload session. */
-  UnaryCallable<QueryStatusRequest, QueryStatusResponse<ResponseT>> queryStatusCallable();
+  /**
+   * The response object returned by the server upon final completion (e.g. metadata of the uploaded
+   * resource), or {@code null} if the upload is still in progress.
+   */
+  public abstract @Nullable ResponseT getResponse();
+
+  public abstract Builder<ResponseT> toBuilder();
+
+  public static <ResponseT> Builder<ResponseT> newBuilder() {
+    return new AutoValue_QueryStatusResponse.Builder<ResponseT>().setComplete(false);
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder<ResponseT> {
+    public abstract Builder<ResponseT> setCommittedOffset(@Nullable Long committedOffset);
+
+    public abstract Builder<ResponseT> setComplete(boolean isComplete);
+
+    public abstract Builder<ResponseT> setResponse(@Nullable ResponseT response);
+
+    public abstract QueryStatusResponse<ResponseT> build();
+  }
 }


### PR DESCRIPTION
This provides the ability for callers to query the server for the committed byte offset so far and detect if the upload has already finalized. This is needed for resumable uploads to be able to recover from occasional interruptions.
