### PR TITLE
perf(bigquery-jdbc): eliminate dry run to resolve statement type

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -602,6 +602,16 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     return new ExecuteResult(tableResult, job);
   }
 
+  private StatementType getStatementType(ExecuteResult executeResult) {
+    if (executeResult.tableResult != null && executeResult.tableResult.getStatementType() != null) {
+      return executeResult.tableResult.getStatementType();
+    }
+    if (executeResult.job != null && executeResult.job.getStatistics() instanceof QueryStatistics) {
+      return ((QueryStatistics) executeResult.job.getStatistics()).getStatementType();
+    }
+    return null;
+  }
+
   /**
    * Execute the SQL script and sets the reference of the underlying job, passing null querySettings
    * will result in the FastQueryPath
@@ -620,10 +630,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     try {
       resetStatementFields();
       ExecuteResult executeResult = executeJob(jobConfiguration);
-      StatementType statementType =
-          executeResult.job == null
-              ? getStatementType(jobConfiguration)
-              : ((QueryStatistics) executeResult.job.getStatistics()).getStatementType();
+      StatementType statementType = getStatementType(executeResult);
       SqlType queryType = getQueryType(jobConfiguration, statementType);
       handleQueryResult(query, executeResult.tableResult, queryType, executeResult.job);
     } catch (InterruptedException ex) {
@@ -709,11 +716,16 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
         break;
       case DML:
       case DML_EXTRA:
-        QueryStatistics dmlStats = getQueryStatisticsFromJob(results, job);
-        Long dmlRowCount =
-            (dmlStats != null && dmlStats.getNumDmlAffectedRows() != null)
-                ? dmlStats.getNumDmlAffectedRows()
-                : 0L;
+        Long dmlRowCount;
+        if (results != null && results.getNumDmlAffectedRows() != null) {
+          dmlRowCount = results.getNumDmlAffectedRows();
+        } else {
+          QueryStatistics dmlStats = getQueryStatisticsFromJob(results, job);
+          dmlRowCount =
+              (dmlStats != null && dmlStats.getNumDmlAffectedRows() != null)
+                  ? dmlStats.getNumDmlAffectedRows()
+                  : 0L;
+        }
         updateAffectedRowCount(dmlRowCount);
         break;
       case TCL:

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -717,9 +717,8 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       case DML:
       case DML_EXTRA:
         Long dmlRowCount;
-        if (results != null) {
-          Long affectedRows = results.getNumDmlAffectedRows();
-          dmlRowCount = affectedRows != null ? affectedRows : 0L;
+        if (results != null && results.getNumDmlAffectedRows() != null) {
+          dmlRowCount = results.getNumDmlAffectedRows();
         } else {
           QueryStatistics dmlStats = getQueryStatisticsFromJob(results, job);
           dmlRowCount =

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -603,7 +603,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   }
 
   private StatementType getStatementType(ExecuteResult executeResult) {
-    if (executeResult.tableResult != null && executeResult.tableResult.getStatementType() != null) {
+    if (executeResult.tableResult.getStatementType() != null) {
       return executeResult.tableResult.getStatementType();
     }
     if (executeResult.job != null && executeResult.job.getStatistics() instanceof QueryStatistics) {
@@ -717,7 +717,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       case DML:
       case DML_EXTRA:
         Long dmlRowCount;
-        if (results != null && results.getNumDmlAffectedRows() != null) {
+        if (results.getNumDmlAffectedRows() != null) {
           dmlRowCount = results.getNumDmlAffectedRows();
         } else {
           QueryStatistics dmlStats = getQueryStatisticsFromJob(results, job);
@@ -785,7 +785,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       throws SQLException {
     try {
       Job activeJob = job;
-      if (activeJob == null) {
+      if (activeJob == null && results.getJobId() != null) {
         activeJob = this.bigQuery.getJob(results.getJobId());
       }
       Job completedJob = (activeJob != null) ? activeJob.waitFor() : null;

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -717,8 +717,9 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       case DML:
       case DML_EXTRA:
         Long dmlRowCount;
-        if (results != null && results.getNumDmlAffectedRows() != null) {
-          dmlRowCount = results.getNumDmlAffectedRows();
+        if (results != null) {
+          Long affectedRows = results.getNumDmlAffectedRows();
+          dmlRowCount = affectedRows != null ? affectedRows : 0L;
         } else {
           QueryStatistics dmlStats = getQueryStatisticsFromJob(results, job);
           dmlRowCount =

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -20,6 +20,8 @@ import static com.google.cloud.bigquery.jdbc.utils.ArrowUtilities.serializeSchem
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -169,6 +171,10 @@ public class BigQueryStatementTest {
     TableResult tableResultMock = mock(TableResult.class);
     doReturn(jobId).when(tableResultMock).getJobId();
     doReturn(Schema.of()).when(tableResultMock).getSchema();
+    doReturn(type).when(tableResultMock).getStatementType();
+    if (affectedRows != null) {
+      doReturn(affectedRows).when(tableResultMock).getNumDmlAffectedRows();
+    }
     doReturn(tableResultMock)
         .when(bigquery)
         .queryWithTimeout(any(QueryJobConfiguration.class), any(), any());
@@ -447,6 +453,7 @@ public class BigQueryStatementTest {
     TableResult tableResultMock = mock(TableResult.class);
     doReturn("queryId").when(tableResultMock).getQueryId();
     doReturn(null).when(tableResultMock).getJobId();
+    doReturn(StatementType.SELECT).when(tableResultMock).getStatementType();
     doReturn(tableResultMock)
         .when(bigquery)
         .queryWithTimeout(any(QueryJobConfiguration.class), any(), any());
@@ -454,17 +461,10 @@ public class BigQueryStatementTest {
         .when(joblessStatementSpy)
         .processJsonResultSet(eq(tableResultMock), any());
 
-    Job dryRunJobMock = getJobMock(null, null, StatementType.SELECT);
-    ArgumentCaptor<JobInfo> dryRunCaptor = ArgumentCaptor.forClass(JobInfo.class);
-    doReturn(dryRunJobMock).when(bigquery).create(dryRunCaptor.capture());
-
     joblessStatementSpy.executeQuery("SELECT 1");
 
     verify(bigquery).queryWithTimeout(any(QueryJobConfiguration.class), any(), any());
-    verify(bigquery).create(any(JobInfo.class));
-    assertTrue(
-        Boolean.TRUE.equals(
-            ((QueryJobConfiguration) dryRunCaptor.getValue().getConfiguration()).dryRun()));
+    verify(bigquery, Mockito.never()).create(any(JobInfo.class));
 
     // 2. Test JobCreationMode=1 (jobful)
     Mockito.reset(bigquery);
@@ -914,6 +914,7 @@ public class BigQueryStatementTest {
               TableResult tableResultMock = mock(TableResult.class);
               doReturn(jobId).when(tableResultMock).getJobId();
               doReturn(Schema.of()).when(tableResultMock).getSchema();
+              doReturn(StatementType.SELECT).when(tableResultMock).getStatementType();
               return tableResultMock;
             })
         .when(bigquery)
@@ -923,8 +924,6 @@ public class BigQueryStatementTest {
 
     // Setup connection mocks to allow the statement to execute successfully
     doReturn(true).when(bigQueryConnection).getUseStatelessQueryMode();
-    Job dryRunJobMock = getJobMock(null, null, StatementType.SELECT);
-    doReturn(dryRunJobMock).when(bigquery).create(Mockito.any(JobInfo.class));
 
     BigQueryJsonResultSet resultSetMock = mock(BigQueryJsonResultSet.class);
     doReturn(resultSetMock)
@@ -937,6 +936,7 @@ public class BigQueryStatementTest {
     // Verify the SDK call actually occurred
     verify(bigquery)
         .queryWithTimeout(Mockito.any(QueryJobConfiguration.class), Mockito.any(), Mockito.any());
+    verify(bigquery, Mockito.never()).create(Mockito.any(JobInfo.class));
   }
 
   @Test
@@ -1065,13 +1065,10 @@ public class BigQueryStatementTest {
     // 2. Mock bigQuery.getDataset to return null (triggering creation)
     doReturn(null).when(bigquery).getDataset(eq(DatasetId.of("temp_dataset")));
 
-    // 2b. Mock bigQuery.create for dry run during getStatementType
-    Job dryRunJobMock = getJobMock(null, null, StatementType.SELECT);
-    doReturn(dryRunJobMock).when(bigquery).create(any(JobInfo.class));
-
     // 3. Mock bigquery.queryWithTimeout(...) to return tableResult (so execution doesn't fail on
     // query execution)
     TableResult result = mock(TableResult.class);
+    doReturn(StatementType.SELECT).when(result).getStatementType();
     doReturn(result)
         .when(bigquery)
         .queryWithTimeout(any(QueryJobConfiguration.class), any(JobId.class), any());
@@ -1090,5 +1087,33 @@ public class BigQueryStatementTest {
     DatasetInfo createdDatasetInfo = datasetInfoCaptor.getValue();
     assertEquals("temp_dataset", createdDatasetInfo.getDatasetId().getDataset());
     assertEquals("europe-west3", createdDatasetInfo.getLocation());
+  }
+
+  @Test
+  public void testStatelessQueryExecutionDoesNotInvokeDryRun() throws Exception {
+    TableResult tableResultMock = setupMockQueryResults(null, StatementType.SELECT, null);
+    BigQueryStatement statementSpy = Mockito.spy(bigQueryStatement);
+    doReturn(mock(BigQueryJsonResultSet.class))
+        .when(statementSpy)
+        .processJsonResultSet(eq(tableResultMock), any());
+
+    boolean hasResultSet = statementSpy.execute("SELECT 1");
+
+    assertTrue(hasResultSet);
+    assertNotNull(statementSpy.getResultSet());
+    verify(bigquery, Mockito.never()).create(any(JobInfo.class));
+  }
+
+  @Test
+  public void testStatelessDmlExecutionUsesTableResultWithoutDryRunOrGetJob() throws Exception {
+    setupMockQueryResults(null, StatementType.UPDATE, 15L);
+
+    int updatedCount = bigQueryStatement.executeUpdate("UPDATE dataset.table SET col = 1");
+
+    assertEquals(15, updatedCount);
+    assertEquals(15L, bigQueryStatement.getLargeUpdateCount());
+    assertNull(bigQueryStatement.getResultSet());
+    verify(bigquery, Mockito.never()).create(any(JobInfo.class));
+    verify(bigquery, Mockito.never()).getJob(any(JobId.class));
   }
 }


### PR DESCRIPTION
b/549675845

This PR eliminates the pre-execution dry-run query previously required to determine `StatementType` during query execution in the BigQuery JDBC driver.

### Changes
1. **Direct `StatementType` Resolution**: Updated `BigQueryStatement.runQuery()` to extract `StatementType` directly from `TableResult` (for stateless/jobless queries) or `JobStatistics` (for job-based queries), removing the dry-run query fallback.
2. **DML Row Count Optimization**: Updated `BigQueryStatement.handleQueryResult()` to retrieve `numDmlAffectedRows` directly from `TableResult`, avoiding extra `getJob()` polling RPCs for DML statements.
3. **Unit Tests**: Added test cases in `BigQueryStatementTest` verifying that `bigquery.create()` and `bigquery.getJob()` are never invoked during stateless query and DML executions.
