### PR TITLE
fix(auth): refine JSpecify nullability for ServiceAccountCredentials and UserCredentials

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -33,13 +33,13 @@ package com.google.auth.oauth2;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonObjectParser;
-import com.google.api.client.util.Preconditions;
 import com.google.api.core.ObsoleteApi;
 import com.google.auth.Credentials;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -79,7 +79,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     COMPUTE_ENGINE_CREDENTIALS("Compute Engine Credentials", null);
 
     private final String credentialName;
-    @Nullable private final String fileType;
+    private final @Nullable String fileType;
 
     GoogleCredentialsInfo(String credentialName, @Nullable String fileType) {
       this.credentialName = credentialName;
@@ -97,17 +97,17 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
 
   // The following package-private fields to provide additional info for errors message
   // Source of the credential (e.g. env var value or well know file location)
-  String source;
+  @Nullable String source;
   // User-friendly name of the Credential class
-  String name;
+  @Nullable String name;
   // Identity of the credential
   // Note: This field may contain data such as serviceAccountEmail which should not be serialized
-  transient String principal;
+  transient @Nullable String principal;
 
   private final String universeDomain;
   private final boolean isExplicitUniverseDomain;
 
-  protected final String quotaProjectId;
+  protected final @Nullable String quotaProjectId;
 
   private static final DefaultCredentialsProvider defaultCredentialsProvider =
       new DefaultCredentialsProvider();
@@ -230,7 +230,8 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @throws IOException if the credential cannot be created from the stream.
    */
   @ObsoleteApi(
-      "This method is obsolete because of a potential security risk. Use the credential specific load method instead")
+      "This method is obsolete because of a potential security risk. Use the credential specific"
+          + " load method instead")
   public static GoogleCredentials fromStream(InputStream credentialsStream) throws IOException {
     return fromStream(credentialsStream, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
   }
@@ -296,7 +297,8 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @throws IOException if the credential cannot be created from the stream.
    */
   @ObsoleteApi(
-      "This method is obsolete because of a potential security risk. Use the credential specific load method instead")
+      "This method is obsolete because of a potential security risk. Use the credential specific"
+          + " load method instead")
   public static GoogleCredentials fromStream(
       InputStream credentialsStream, HttpTransportFactory transportFactory) throws IOException {
     Preconditions.checkNotNull(transportFactory);
@@ -389,7 +391,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @return a new map with quotaProjectId added if needed
    */
   static Map<String, List<String>> addQuotaProjectIdToRequestMetadata(
-      String quotaProjectId, Map<String, List<String>> requestMetadata) {
+      @Nullable String quotaProjectId, Map<String, List<String>> requestMetadata) {
     Preconditions.checkNotNull(requestMetadata);
     Map<String, List<String>> newRequestMetadata = new HashMap<>(requestMetadata);
     if (quotaProjectId != null && !requestMetadata.containsKey(QUOTA_PROJECT_ID_HEADER_KEY)) {
@@ -527,7 +529,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   }
 
   @Override
-  public String getQuotaProjectId() {
+  public @Nullable String getQuotaProjectId() {
     return this.quotaProjectId;
   }
 
@@ -538,7 +540,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    *
    * @return the project id for a Credential type
    */
-  public String getProjectId() {
+  public @Nullable String getProjectId() {
     return null;
   }
 
@@ -653,8 +655,8 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   }
 
   public static class Builder extends OAuth2Credentials.Builder {
-    @Nullable protected String quotaProjectId;
-    @Nullable protected String universeDomain;
+    protected @Nullable String quotaProjectId;
+    protected @Nullable String universeDomain;
     @Nullable String source;
 
     protected Builder() {}
@@ -679,7 +681,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     }
 
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
       return this;
     }
@@ -689,22 +691,23 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
       return this;
     }
 
-    public String getQuotaProjectId() {
+    public @Nullable String getQuotaProjectId() {
       return this.quotaProjectId;
     }
 
-    public String getUniverseDomain() {
+    public @Nullable String getUniverseDomain() {
       return this.universeDomain;
     }
 
-    Builder setSource(String source) {
+    @CanIgnoreReturnValue
+    Builder setSource(@Nullable String source) {
       this.source = source;
       return this;
     }
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setAccessToken(AccessToken token) {
+    public Builder setAccessToken(@Nullable AccessToken token) {
       super.setAccessToken(token);
       return this;
     }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -82,11 +82,11 @@ public class OAuth2Credentials extends Credentials {
 
   // byte[] is serializable, so the lock variable can be final
   @VisibleForTesting final Object lock = new byte[0];
-  @Nullable private volatile OAuthValue value = null;
+  private volatile @Nullable OAuthValue value = null;
   @Nullable @VisibleForTesting transient RefreshTask refreshTask;
 
   // Change listeners are not serialized
-  private transient List<CredentialsChangedListener> changeListeners;
+  private transient @Nullable List<CredentialsChangedListener> changeListeners;
   // Until we expose this to the users it can remain transient and non-serializable
   transient Clock clock = Clock.SYSTEM;
 
@@ -115,7 +115,7 @@ public class OAuth2Credentials extends Credentials {
   }
 
   protected OAuth2Credentials(
-      AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
+      @Nullable AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
     if (accessToken != null) {
       this.value = OAuthValue.create(accessToken, EMPTY_EXTRA_HEADERS);
     }
@@ -149,8 +149,7 @@ public class OAuth2Credentials extends Credentials {
    *
    * @return The cached access token.
    */
-  @Nullable
-  public final AccessToken getAccessToken() {
+  public final @Nullable AccessToken getAccessToken() {
     OAuthValue localState = value;
     if (localState != null) {
       return localState.temporaryAccess;
@@ -440,8 +439,7 @@ public class OAuth2Credentials extends Credentials {
     return Objects.hashCode(value);
   }
 
-  @Nullable
-  protected Map<String, List<String>> getRequestMetadataInternal() {
+  protected @Nullable Map<String, List<String>> getRequestMetadataInternal() {
     OAuthValue localValue = value;
     if (localValue != null) {
       return localValue.requestMetadata;
@@ -711,7 +709,7 @@ public class OAuth2Credentials extends Credentials {
 
   public static class Builder {
 
-    private AccessToken accessToken;
+    private @Nullable AccessToken accessToken;
     private Duration refreshMargin = DEFAULT_REFRESH_MARGIN;
     private Duration expirationMargin = DEFAULT_EXPIRATION_MARGIN;
 
@@ -724,7 +722,7 @@ public class OAuth2Credentials extends Credentials {
     }
 
     @CanIgnoreReturnValue
-    public Builder setAccessToken(AccessToken token) {
+    public Builder setAccessToken(@Nullable AccessToken token) {
       this.accessToken = token;
       return this;
     }
@@ -749,7 +747,7 @@ public class OAuth2Credentials extends Credentials {
       return expirationMargin;
     }
 
-    public AccessToken getAccessToken() {
+    public @Nullable AccessToken getAccessToken() {
       return accessToken;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdProvider.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdProvider.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /** Interface for {@link GoogleCredentials} that return a quota project ID. */
 @NullMarked
@@ -39,5 +40,5 @@ public interface QuotaProjectIdProvider {
   /**
    * @return the quota project ID used for quota and billing purposes
    */
-  String getQuotaProjectId();
+  @Nullable String getQuotaProjectId();
 }

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -51,7 +51,6 @@ import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.GenericData;
 import com.google.api.client.util.Joiner;
-import com.google.api.client.util.Preconditions;
 import com.google.auth.CredentialTypeForMetrics;
 import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
@@ -61,6 +60,7 @@ import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.MetricsUtils.RequestType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -103,12 +103,12 @@ public class ServiceAccountCredentials extends GoogleCredentials
   private static final LoggerProvider LOGGER_PROVIDER =
       LoggerProvider.forClazz(ServiceAccountCredentials.class);
 
-  private final String clientId;
+  private final @Nullable String clientId;
   private final String clientEmail;
   private final PrivateKey privateKey;
-  private final String privateKeyId;
-  private final String serviceAccountUser;
-  private final String projectId;
+  private final @Nullable String privateKeyId;
+  private final @Nullable String serviceAccountUser;
+  private final @Nullable String projectId;
   private final String transportFactoryClassName;
   private final URI tokenServerUri;
   private final Collection<String> scopes;
@@ -784,7 +784,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return this.toBuilder().setServiceAccountUser(user).build();
   }
 
-  public final String getClientId() {
+  public final @Nullable String getClientId() {
     return clientId;
   }
 
@@ -796,7 +796,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return privateKey;
   }
 
-  public final String getPrivateKeyId() {
+  public final @Nullable String getPrivateKeyId() {
     return privateKeyId;
   }
 
@@ -808,7 +808,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return defaultScopes;
   }
 
-  public final String getServiceAccountUser() {
+  public final @Nullable String getServiceAccountUser() {
     return serviceAccountUser;
   }
 
@@ -816,7 +816,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @return the projectId set in the SA Key file or the user set projectId
    */
   @Override
-  public final String getProjectId() {
+  public final @Nullable String getProjectId() {
     return projectId;
   }
 
@@ -1150,16 +1150,16 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
   public static class Builder extends GoogleCredentials.Builder {
 
-    private String clientId;
-    private String clientEmail;
-    private PrivateKey privateKey;
-    private String privateKeyId;
-    private String serviceAccountUser;
-    private String projectId;
-    private URI tokenServerUri;
-    private Collection<String> scopes;
-    private Collection<String> defaultScopes;
-    private HttpTransportFactory transportFactory;
+    private @Nullable String clientId;
+    private @Nullable String clientEmail;
+    private @Nullable PrivateKey privateKey;
+    private @Nullable String privateKeyId;
+    private @Nullable String serviceAccountUser;
+    private @Nullable String projectId;
+    private @Nullable URI tokenServerUri;
+    private @Nullable Collection<String> scopes;
+    private @Nullable Collection<String> defaultScopes;
+    private @Nullable HttpTransportFactory transportFactory;
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
     private boolean useJwtAccessWithScope = false;
     private boolean defaultRetriesEnabled = true;
@@ -1240,7 +1240,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     }
 
     @CanIgnoreReturnValue
-    public Builder setTokenServerUri(URI tokenServerUri) {
+    public Builder setTokenServerUri(@Nullable URI tokenServerUri) {
       this.tokenServerUri = tokenServerUri;
       return this;
     }
@@ -1253,7 +1253,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
@@ -1280,48 +1280,50 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return this;
     }
 
+    @Override
+    @CanIgnoreReturnValue
     public Builder setUniverseDomain(String universeDomain) {
-      super.universeDomain = universeDomain;
+      super.setUniverseDomain(universeDomain);
       return this;
     }
 
-    public String getClientId() {
+    public @Nullable String getClientId() {
       return clientId;
     }
 
-    public String getClientEmail() {
+    public @Nullable String getClientEmail() {
       return clientEmail;
     }
 
-    public PrivateKey getPrivateKey() {
+    public @Nullable PrivateKey getPrivateKey() {
       return privateKey;
     }
 
-    public String getPrivateKeyId() {
+    public @Nullable String getPrivateKeyId() {
       return privateKeyId;
     }
 
-    public Collection<String> getScopes() {
+    public @Nullable Collection<String> getScopes() {
       return scopes;
     }
 
-    public Collection<String> getDefaultScopes() {
+    public @Nullable Collection<String> getDefaultScopes() {
       return defaultScopes;
     }
 
-    public String getServiceAccountUser() {
+    public @Nullable String getServiceAccountUser() {
       return serviceAccountUser;
     }
 
-    public String getProjectId() {
+    public @Nullable String getProjectId() {
       return projectId;
     }
 
-    public URI getTokenServerUri() {
+    public @Nullable URI getTokenServerUri() {
       return tokenServerUri;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 

--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -43,11 +43,11 @@ import com.google.api.client.http.UrlEncodedContent;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.GenericData;
-import com.google.api.client.util.Preconditions;
 import com.google.auth.CredentialTypeForMetrics;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.MetricsUtils.RequestType;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -75,7 +75,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
   private final String clientId;
   private final String clientSecret;
-  private final String refreshToken;
+  private final @Nullable String refreshToken;
   private final URI tokenServerUri;
   private final String transportFactoryClassName;
 
@@ -257,7 +257,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
    *
    * @return refresh token
    */
-  public final String getRefreshToken() {
+  public final @Nullable String getRefreshToken() {
     return refreshToken;
   }
 
@@ -321,15 +321,9 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     if (refreshToken != null) {
       json.put("refresh_token", refreshToken);
     }
-    if (tokenServerUri != null) {
-      json.put("token_server_uri", tokenServerUri);
-    }
-    if (clientId != null) {
-      json.put("client_id", clientId);
-    }
-    if (clientSecret != null) {
-      json.put("client_secret", clientSecret);
-    }
+    json.put("token_server_uri", tokenServerUri);
+    json.put("client_id", clientId);
+    json.put("client_secret", clientSecret);
     if (quotaProjectId != null) {
       json.put("quota_project_id", quotaProjectId);
     }
@@ -417,12 +411,12 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
   public static class Builder extends GoogleCredentials.Builder {
 
-    private String clientId;
-    private String clientSecret;
-    private String refreshToken;
-    private URI tokenServerUri;
-    private String account;
-    private HttpTransportFactory transportFactory;
+    private @Nullable String clientId;
+    private @Nullable String clientSecret;
+    private @Nullable String refreshToken;
+    private @Nullable URI tokenServerUri;
+    private @Nullable String account;
+    private @Nullable HttpTransportFactory transportFactory;
 
     protected Builder() {}
 
@@ -455,7 +449,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     }
 
     @CanIgnoreReturnValue
-    public Builder setTokenServerUri(URI tokenServerUri) {
+    public Builder setTokenServerUri(@Nullable URI tokenServerUri) {
       this.tokenServerUri = tokenServerUri;
       return this;
     }
@@ -467,7 +461,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     }
 
     @CanIgnoreReturnValue
-    Builder setAccount(String account) {
+    Builder setAccount(@Nullable String account) {
       this.account = account;
       return this;
     }
@@ -495,32 +489,32 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
     @Override
     @CanIgnoreReturnValue
-    public Builder setQuotaProjectId(String quotaProjectId) {
+    public Builder setQuotaProjectId(@Nullable String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
       return this;
     }
 
-    public String getClientId() {
+    public @Nullable String getClientId() {
       return clientId;
     }
 
-    public String getClientSecret() {
+    public @Nullable String getClientSecret() {
       return clientSecret;
     }
 
-    public String getRefreshToken() {
+    public @Nullable String getRefreshToken() {
       return refreshToken;
     }
 
-    public URI getTokenServerUri() {
+    public @Nullable URI getTokenServerUri() {
       return tokenServerUri;
     }
 
-    String getAccount() {
+    @Nullable String getAccount() {
       return account;
     }
 
-    public HttpTransportFactory getHttpTransportFactory() {
+    public @Nullable HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }
 


### PR DESCRIPTION
## Description
Refines JSpecify nullability annotations and checks for `ServiceAccountCredentials`, `UserCredentials`, and their base hierarchy (`GoogleCredentials`, `OAuth2Credentials`, `QuotaProjectIdProvider`).

- **JSpecify Type-Use Nullability**: Annotates return types, fields, and builder methods with standard type-use `@Nullable` annotations.
- **Guava Preconditions**: Migrates from `com.google.api.client.util.Preconditions` to `com.google.common.base.Preconditions`.
- **Null-Check Cleanup**: Removes redundant null checks on constructor-validated non-null fields in `UserCredentials`.