### PR TITLE
test(bigtable): resolve NullArgumentForNonNullParameter error in MaybePointWriteCallableTest

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/mutaterows/MaybePointWriteCallableTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/mutaterows/MaybePointWriteCallableTest.java
@@ -56,7 +56,7 @@ public class MaybePointWriteCallableTest {
     ApiFuture<Void> future = callable.futureCall(request, null);
     pointWriter.response.set(null);
 
-    assertThat((Object) future.get()).isNull();
+    future.get();
     assertThat(classic.request).isNull();
     assertThat(pointWriter.request).isNotNull();
     // The single entry is converted back into a RowMutation targeting the same row.


### PR DESCRIPTION
Fixes #14174

### Problem
During GraalVM native presubmit CI compilation under JDK 21 with ErrorProne enabled, `MaybePointWriteCallableTest.java` failed with:
`[NullArgumentForNonNullParameter]` at line 59: `assertThat((Object) future.get()).isNull()`.
   - `future.get()` on `ApiFuture<Void>` evaluates to `null` (or throws an exception).
   - ErrorProne failed to resolve Truth's `@Nullable` parameter annotation on `assertThat(@Nullable Object actual)` inside the `@NullMarked` package when reading bytecode in CI, flagging passing a known-null value.

### Solution
Replace `assertThat((Object) future.get()).isNull()` with direct `future.get()` to verify successful completion without exception.