### PR TITLE
fix(spanner): prioritize leader replica for read-write transactions in location-aware routing

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyRangeCache.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/spi/v1/KeyRangeCache.java
@@ -936,22 +936,6 @@ public final class KeyRangeCache {
         List<SkippedTabletDetail> skippedTabletDetails,
         Map<String, ChannelEndpoint> resolvedEndpoints,
         SelectionState selectionStats) {
-      if (!preferLeader || hintBuilder.getOperationUid() > 0L) {
-        TabletSnapshot preferredLeader =
-            preferLeader ? localLeaderForScoreBias(snapshot, hasDirectedReadOptions) : null;
-        return selectScoreAwareTablet(
-            snapshot,
-            preferLeader,
-            directedReadOptions,
-            hintBuilder,
-            excludedEndpoints,
-            skippedTabletUids,
-            skippedTabletDetails,
-            resolvedEndpoints,
-            selectionStats,
-            preferredLeader);
-      }
-
       boolean checkedLeader = false;
       if (preferLeader
           && !hasDirectedReadOptions
@@ -970,6 +954,22 @@ public final class KeyRangeCache {
             selectionStats)) {
           return snapshot.leader();
         }
+      }
+
+      if (!preferLeader || hintBuilder.getOperationUid() > 0L) {
+        TabletSnapshot preferredLeader =
+            preferLeader ? localLeaderForScoreBias(snapshot, hasDirectedReadOptions) : null;
+        return selectScoreAwareTablet(
+            snapshot,
+            preferLeader,
+            directedReadOptions,
+            hintBuilder,
+            excludedEndpoints,
+            skippedTabletUids,
+            skippedTabletDetails,
+            resolvedEndpoints,
+            selectionStats,
+            preferredLeader);
       }
       for (int index = 0; index < snapshot.tablets.size(); index++) {
         if (checkedLeader && index == snapshot.leaderIndex) {

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyRangeCacheTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/spi/v1/KeyRangeCacheTest.java
@@ -784,7 +784,7 @@ public class KeyRangeCacheTest {
   }
 
   @Test
-  public void preferLeaderTrueUsesLatencyScoresWhenOperationUidAvailable() {
+  public void preferLeaderTrueWithOperationUidSelectsLeaderEvenWhenFollowerHasLowerLatency() {
     FakeEndpointCache endpointCache = new FakeEndpointCache();
     KeyRangeCache cache = new KeyRangeCache(endpointCache);
     cache.useDeterministicRandom();
@@ -793,6 +793,38 @@ public class KeyRangeCacheTest {
     endpointCache.get("server1");
     endpointCache.get("server2");
     endpointCache.get("server3");
+
+    EndpointLatencyRegistry.recordLatency(
+        null, TEST_OPERATION_UID, true, "server1", Duration.ofNanos(300_000L));
+    EndpointLatencyRegistry.recordLatency(
+        null, TEST_OPERATION_UID, true, "server2", Duration.ofNanos(100_000L));
+    EndpointLatencyRegistry.recordLatency(
+        null, TEST_OPERATION_UID, true, "server3", Duration.ofNanos(200_000L));
+
+    RoutingHint.Builder hint =
+        RoutingHint.newBuilder().setKey(bytes("a")).setOperationUid(TEST_OPERATION_UID);
+    ChannelEndpoint server =
+        cache.fillRoutingHint(
+            true,
+            KeyRangeCache.RangeMode.COVERING_SPLIT,
+            DirectedReadOptions.getDefaultInstance(),
+            hint);
+
+    assertNotNull(server);
+    assertEquals("server1", server.getAddress());
+  }
+
+  @Test
+  public void preferLeaderTrueWithOperationUidFallsBackToScoreAwareWhenLeaderUnhealthy() {
+    FakeEndpointCache endpointCache = new FakeEndpointCache();
+    KeyRangeCache cache = new KeyRangeCache(endpointCache);
+    cache.useDeterministicRandom();
+    cache.addRanges(threeReplicaUpdate());
+
+    endpointCache.get("server1");
+    endpointCache.get("server2");
+    endpointCache.get("server3");
+    endpointCache.setState("server1", EndpointHealthState.TRANSIENT_FAILURE);
 
     EndpointLatencyRegistry.recordLatency(
         null, TEST_OPERATION_UID, true, "server1", Duration.ofNanos(300_000L));


### PR DESCRIPTION

When experimental location-aware routing is enabled, read-write transactions starting with an inline begin (preferLeader=true) could be routed to follower replicas because operationUid > 0L on SQL requests caused selectTablet() to bypass the local leader and take the score-aware replica selection path.

This change reorders the checks in KeyRangeCache.selectTablet() so that when preferLeader=true and a healthy local Paxos leader exists, the leader is selected directly. If the leader is unhealthy or in transient failure, it gracefully falls back to score-aware replica selection.