### PR TITLE
build(deps): align httpcore5 with httpclient5

### DIFF
--- a/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
+++ b/sdk-platform-java/java-shared-dependencies/third-party-dependencies/pom.xml
@@ -32,7 +32,7 @@
     <httpcomponents.httpcore.version>4.4.16</httpcomponents.httpcore.version>
     <httpcomponents.httpclient.version>4.5.14</httpcomponents.httpclient.version>
     <apache-httpclient-5.version>5.6.3</apache-httpclient-5.version>
-    <apache-httpcore-5.version>5.2.5</apache-httpcore-5.version>
+    <apache-httpcore-5.version>5.4.3</apache-httpcore-5.version>
     <!-- ensure checker-qual version matches what Guava uses -->
     <checker-qual.version>3.49.0</checker-qual.version>
     <perfmark-api.version>0.27.0</perfmark-api.version>


### PR DESCRIPTION
This is a companion fix for #14070, based on its exact head commit 7479b4ecfc536a5478a9058d458bc031591cf077.

HttpClient 5.6.3 requires HttpCore 5.4.3, but the shared BOM still manages HttpCore 5.2.5. That mixed pair causes RequireUpperBoundDeps to fail and produces six DefaultHttpRequestWriterFactory NoSuchMethodError failures in BigQueryJdbcProxyUtilityTest across the tested JDK matrix. This aligns the HttpCore property with the version independently proposed in #14056.

Validation:
- Exact bot baseline: BigQueryJdbcProxyUtilityTest ran 24 tests with 6 errors.
- Candidate: the same focused command passes all 24 tests.
- BigQuery JDBC RequireUpperBoundDeps and duplicate-class enforcement pass.
- Clean BigQuery JDBC verify passes all 1,121 tests (1 skipped) and builds the shaded artifact.
- Resolved versions are httpclient5 5.6.3 and httpcore5 5.4.3.