### PR TITLE
test(bigtable): disable testDeadlockPrevention to fix CI execution timeout

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/internal/util/ClientConfigurationManagerTest.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -378,6 +379,7 @@ class ClientConfigurationManagerTest {
     assertThat(initialConfig).isEqualTo(service.config.get());
   }
 
+  @Disabled("https://github.com/googleapis/google-cloud-java/issues/13903")
   @Test
   void testDeadlockPrevention() throws Exception {
     // Initialize the manager and fetch the initial config to schedule polling.


### PR DESCRIPTION
## Description
Disables flaky test `ClientConfigurationManagerTest#testDeadlockPrevention` (https://github.com/googleapis/google-cloud-java/issues/13903).

Bigtable unit tests run as part of the main `units` test suite in CI. Under concurrent execution, coordinating lock acquisition across threads in `testDeadlockPrevention` can deadlock or wedge, causing GitHub Actions runner jobs (such as `units (17)`) to hit the ~360-minute execution timeout.