### PR TITLE
feat(gax): add ResumableUploadStatus and progress tracking support

### DIFF
--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ResumableUploadProgressListener.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ResumableUploadProgressListener.java
@@ -27,43 +27,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.google.api.gax.rpc;
+package com.google.api.gax.resumable;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
-import com.google.api.gax.resumable.ResumableUploadProgressListener;
-import com.google.api.gax.resumable.ResumableUploadStatus;
-import java.util.concurrent.Executor;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
-/**
- * A specialized {@link ApiFuture} for tracking and controlling an in-flight resumable upload.
- *
- * @param <ResponseT> response type
- */
+/** A callback listener for observing the progress and state transitions of a resumable upload. */
 @BetaApi
+@FunctionalInterface
 @NullMarked
-public interface ResumableUploadFuture<ResponseT> extends ApiFuture<ResponseT> {
-
-  /** Returns the upload session URL, or {@code null} if session initiation is in progress. */
-  @Nullable String getUploadSessionUrl();
-
-  /** Returns the current status snapshot of the upload. */
-  ResumableUploadStatus getStatus();
+public interface ResumableUploadProgressListener {
 
   /**
-   * Registers a listener for progress updates on the direct executor.
+   * Invoked when upload progress or state changes.
    *
-   * @param listener the listener to receive progress updates
+   * @param status the current status snapshot of the upload
    */
-  void addProgressListener(ResumableUploadProgressListener listener);
-
-  /**
-   * Registers a listener for progress updates on the specified executor.
-   *
-   * @param listener the listener to receive progress updates
-   * @param executor the executor on which to run the listener
-   */
-  void addProgressListener(ResumableUploadProgressListener listener, Executor executor);
+  void onProgress(ResumableUploadStatus status);
 }

--- a/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ResumableUploadStatus.java
+++ b/sdk-platform-java/gax-java/gax/src/main/java/com/google/api/gax/resumable/ResumableUploadStatus.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.resumable;
+
+import com.google.api.core.BetaApi;
+import com.google.auto.value.AutoValue;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/** Status snapshot of an ongoing or completed resumable upload session. */
+@BetaApi
+@NullMarked
+@AutoValue
+public abstract class ResumableUploadStatus {
+
+  /** The state of the resumable upload session. */
+  public enum State {
+    /** Session initiation is in progress (acquiring upload session URL). */
+    STARTING,
+
+    /** Transmitting chunk payloads to the server. */
+    UPLOADING,
+
+    /** A recoverable error occurred; querying server status and resynchronizing offset. */
+    RECOVERING,
+
+    /** The server query status succeeded and the committed offset was received. */
+    OFFSET_RECEIVED,
+
+    /** The upload was successfully finalized by the server. */
+    FINALIZED,
+
+    /** The upload failed unrecoverably or was cancelled. */
+    FAILED
+  }
+
+  /**
+   * Returns the negotiated upload session URI, or {@code null} if session initiation is pending.
+   */
+  public abstract @Nullable String getUploadUrl();
+
+  /** Returns the number of bytes successfully uploaded to the server so far. */
+  public abstract long getBytesUploaded();
+
+  /** Returns the current state of the upload session. */
+  public abstract State getState();
+
+  /** Returns the exception that triggered recovery or caused failure, if any. */
+  public abstract @Nullable Throwable getException();
+
+  public abstract Builder toBuilder();
+
+  public static Builder newBuilder() {
+    return new AutoValue_ResumableUploadStatus.Builder()
+        .setBytesUploaded(0L)
+        .setState(State.STARTING);
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setUploadUrl(@Nullable String uploadUrl);
+
+    public abstract Builder setBytesUploaded(long bytesUploaded);
+
+    public abstract Builder setState(State state);
+
+    public abstract Builder setException(@Nullable Throwable exception);
+
+    public abstract ResumableUploadStatus build();
+  }
+}

--- a/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/resumable/ResumableUploadStatusTest.java
+++ b/sdk-platform-java/gax-java/gax/src/test/java/com/google/api/gax/resumable/ResumableUploadStatusTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.api.gax.resumable;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ResumableUploadStatusTest {
+
+  @Test
+  void builder_defaults() {
+    ResumableUploadStatus status = ResumableUploadStatus.newBuilder().build();
+    assertThat(status.getUploadUrl()).isNull();
+    assertThat(status.getBytesUploaded()).isEqualTo(0L);
+    assertThat(status.getState()).isEqualTo(ResumableUploadStatus.State.STARTING);
+    assertThat(status.getException()).isNull();
+  }
+
+  @Test
+  void builder_explicitValuesAndToBuilder() {
+    Exception ex = new RuntimeException("test error");
+    ResumableUploadStatus status =
+        ResumableUploadStatus.newBuilder()
+            .setUploadUrl("https://upload.url/session-1")
+            .setBytesUploaded(1024L)
+            .setState(ResumableUploadStatus.State.UPLOADING)
+            .setException(ex)
+            .build();
+
+    assertThat(status.getUploadUrl()).isEqualTo("https://upload.url/session-1");
+    assertThat(status.getBytesUploaded()).isEqualTo(1024L);
+    assertThat(status.getState()).isEqualTo(ResumableUploadStatus.State.UPLOADING);
+    assertThat(status.getException()).isSameInstanceAs(ex);
+
+    ResumableUploadStatus modified =
+        status.toBuilder()
+            .setState(ResumableUploadStatus.State.FINALIZED)
+            .setBytesUploaded(2048L)
+            .build();
+
+    assertThat(modified.getState()).isEqualTo(ResumableUploadStatus.State.FINALIZED);
+    assertThat(modified.getBytesUploaded()).isEqualTo(2048L);
+    assertThat(modified.getUploadUrl()).isEqualTo("https://upload.url/session-1");
+  }
+}


### PR DESCRIPTION
Adds `ResumableUploadStatus` and `ResumableUploadProgressListener` to track upload state transitions and byte counts. Also adds `getStatus()` and `addProgressListener()` to `ResumableUploadFuture` so callers can monitor progress, optionally on a caller-supplied `Executor`.