### PR TITLE
refactor(ci): idiomatic bash cleanup, IFS array joins, and case pattern matching

### DIFF
--- a/.cloud/helpers/common.sh
+++ b/.cloud/helpers/common.sh
@@ -27,9 +27,14 @@ function listAllModules() {
   popd >/dev/null
 }
 
-# Replaces '-' with '_' to get a Terraform output-friendly label
+# Replaces '-' with '_' to get a Terraform output-friendly label.
+# Uses Bash parameter expansion '${parameter//pattern/replacement}':
+# - '$1': The input module name string.
+# - '//': Global pattern replacement operator (matches all occurrences).
+# - '-': Search pattern to match (hyphen).
+# - '_': Replacement character (underscore).
 function getFriendlyOutputName() {
-  echo "$1" | tr '-' _
+  echo "${1//-/_}"
 }
 
 # Get the output object in JSON format for the given module.
@@ -48,9 +53,13 @@ function getModuleOutput() {
   getOutput "$1" | parseJson "$2"
 }
 
+# Checks if whitespace-delimited or newline-delimited list $1 contains entry $2.
 # @returns exit code 0 if list $1 contains entry $2.
 function contains() {
-  echo "$1" | grep -w -q "$2"
+  # Normalize newlines and carriage returns into spaces with boundary padding:
+  local list=" ${1//[$'\r\n']/ } "
+  # Use native glob pattern matching '*" $2 "*' with boundary spaces to ensure exact token match:
+  [[ -n "$2" && "${list}" == *" $2 "* ]]
 }
 
 # @returns a "new line"-delimited list of active terraform modules

--- a/.kokoro/common.sh
+++ b/.kokoro/common.sh
@@ -149,11 +149,13 @@ function parse_submodules() {
     exit 1
   fi
 
-  # Convert from array to comma-delimited string
-  submodules=$(
-    IFS=,
-    echo "${submodules_array[*]}"
-  )
+  # Convert array to a comma-delimited string:
+  # Declaring 'local IFS=,' restricts delimiter changes to this function's scope,
+  # preventing global IFS pollution (which breaks word splitting in subsequent code).
+  # Expanding "${submodules_array[*]}" joins elements using IFS entirely in-memory
+  # without spawning a subshell process.
+  local IFS=,
+  submodules="${submodules_array[*]}"
   export submodules
 }
 
@@ -172,11 +174,9 @@ function parse_all_submodules() {
     all_submodules_array+=("$submodules")
   done
 
-  # Convert from array to comma-delimited string
-  all_submodules=$(
-    IFS=,
-    echo "${all_submodules_array[*]}"
-  )
+  # 'local IFS=,' safely joins array elements within function scope without subshells:
+  local IFS=,
+  all_submodules="${all_submodules_array[*]}"
   export all_submodules
 }
 
@@ -466,10 +466,9 @@ function generate_graalvm_presubmit_modules_list() {
   generate_modified_modules_list
   if [[ ${#modified_module_list[@]} -gt 0 && ${#modified_module_list[@]} -lt 5 ]]; then
     # If only a few modules have been modified, focus presubmit testing only on them.
-    module_list=$(
-      IFS=,
-      echo "${modified_module_list[*]}"
-    )
+    # Join array into comma-delimited string without subshell:
+    local IFS=,
+    module_list="${modified_module_list[*]}"
   else
     # If no modules have been modified or if too many have been modified, just test the modules
     # specified in the MAVEN_MODULES env var.
@@ -510,10 +509,9 @@ function generate_graalvm_modules_list() {
       fi
     done
   fi
-  module_list=$(
-    IFS=,
-    echo "${modules_assigned_list[*]}"
-  )
+  # Join array into comma-delimited string without subshell:
+  local IFS=,
+  module_list="${modules_assigned_list[*]}"
 }
 
 function install_modules() {
@@ -574,10 +572,9 @@ function install_modules() {
       'sdk-platform-java/gax-java/gax-grpc'
       'sdk-platform-java/gax-java/gax-httpjson'
     )
-    always_install_deps=$(
-      IFS=,
-      echo "${always_install_deps_list[*]}"
-    )
+    # Join dependencies into comma-delimited string without subshell:
+    local IFS=,
+    always_install_deps="${always_install_deps_list[*]}"
     printf "with always_install_deps:\n%s\n" "$all_submodules,$always_install_deps"
 
     # When working with a maven multi-module project containing other multi-module projects,

--- a/generation/check_non_release_please_versions.sh
+++ b/generation/check_non_release_please_versions.sh
@@ -4,46 +4,48 @@ set -e
 
 violations=0
 for pomFile in $(find . -mindepth 2 -name pom.xml | sort ); do
-  if [[ "${pomFile}" =~ .*google-cloud-jar-parent.* ]] || \
-      [[ "${pomFile}" =~ .*google-cloud-pom-parent.* ]] || \
-      [[ "${pomFile}" =~ .*CoverageAggregator.* ]] || \
-      [[ "${pomFile}" =~ .*java-shared-dependencies*. ]] || \
-      [[ "${pomFile}" =~ .*java-bigquerystorage.* ]] || \
-      [[ "${pomFile}" =~ .*java-datastore.* ]] || \
-      [[ "${pomFile}" =~ .*java-logging-logback.* ]] || \
-      [[ "${pomFile}" =~ .*java-bigquery.* ]] || \
-      [[ "${pomFile}" =~ .*sdk-platform-java.* ]] || \
-      [[ "${pomFile}" =~ .*java-common-protos.* ]] || \
-      [[ "${pomFile}" =~ .*java-showcase.* ]] || \
-      [[ "${pomFile}" =~ .*java-iam.* ]] || \
-      [[ "${pomFile}" =~ .*java-spanner.* ]] || \
-      [[ "${pomFile}" =~ .*java-spanner-jdbc.* ]] || \
-      [[ "${pomFile}" =~ .*google-auth-library-java.* ]] || \
-      [[ "${pomFile}" =~ .*grpc-gcp.* ]] || \
-      [[ "${pomFile}" =~ .*java-storage.* ]] || \
-      [[ "${pomFile}" =~ .*java-storage-nio.* ]] || \
-      [[ "${pomFile}" =~ .*java-pubsub.* ]] || \
-      [[ "${pomFile}" =~ .*java-bigtable.* ]] || \
-      [[ "${pomFile}" =~ .*java-firestore.* ]] || \
-      [[ "${pomFile}" =~ .*java-cloud-bom.* ]] || \
-      [[ "${pomFile}" =~ .*java-shared-config.* ]] || \
-      [[ "${pomFile}" =~ .*java-vertexai.* ]] || \
-      [[ "${pomFile}" =~ .*java-compute.* ]] || \
-      [[ "${pomFile}" =~ .*.github*. ]]; then
-    continue
-  fi
-  if [[ "${pomFile}" =~ .*owl-bot-postprocessor.* ]]; then
-    # Skip the template files
-    continue
-  fi
-  if [[ "${pomFile}" =~ .*java-samples.* ]]; then
-    echo "Skipping version check for java-samples directory"
-    continue
-  fi
-  if [[ "${pomFile}" =~ .*/samples/.* ]]; then
-    echo "Skipping version check for samples directory"
-    continue
-  fi
+  # Filter out exempt modules and directories using native Bash pattern matching.
+  # Shell glob patterns (*pattern*) evaluate directly in-memory without invoking
+  # an external regex engine.
+  case "${pomFile}" in
+    *google-cloud-jar-parent* | \
+    *google-cloud-pom-parent* | \
+    *CoverageAggregator* | \
+    *java-shared-dependencies* | \
+    *java-bigquerystorage* | \
+    *java-datastore* | \
+    *java-logging-logback* | \
+    *java-bigquery* | \
+    *sdk-platform-java* | \
+    *java-common-protos* | \
+    *java-showcase* | \
+    *java-iam* | \
+    *java-spanner* | \
+    *java-spanner-jdbc* | \
+    *google-auth-library-java* | \
+    *grpc-gcp* | \
+    *java-storage* | \
+    *java-storage-nio* | \
+    *java-pubsub* | \
+    *java-bigtable* | \
+    *java-firestore* | \
+    *java-cloud-bom* | \
+    *java-shared-config* | \
+    *java-vertexai* | \
+    *java-compute* | \
+    *.github* | \
+    *owl-bot-postprocessor*)
+      continue
+      ;;
+    *java-samples*)
+      echo "Skipping version check for java-samples directory"
+      continue
+      ;;
+    */samples/*)
+      echo "Skipping version check for samples directory"
+      continue
+      ;;
+  esac
 
   if grep -n '<version>.*</version>' "$pomFile" | grep -v 'x-version-update'; then
     echo "Found version declaration(s) without x-version-update in: $pomFile"


### PR DESCRIPTION
## Summary
Refactors CI bash scripts for cleaner syntax, better performance, and standard bash idioms:

1. **Remove Subshells on Array Joins (`.kokoro/common.sh`)**:
   - Replaced `$(IFS=,; echo "${arr[*]}")` subshells across 5 functions (`parse_submodules`, `parse_all_submodules`, `generate_graalvm_presubmit_modules_list`, `generate_graalvm_modules_list`, `install_modules`) with scoped in-process joins: `local IFS=,; var="${arr[*]}"`.

2. **Case Statement Pattern Matching (`generation/check_non_release_please_versions.sh`)**:
   - Replaced 26 chained `[[ "${pomFile}" =~ ... ]]` regex conditions and regex typos (such as `dependencies*.` and `.*.github*.`) with a clean, fast `case "${pomFile}" in ... esac`.

3. **Pure-Bash Built-ins (`.cloud/helpers/common.sh`)**:
   - In `getFriendlyOutputName`: replaced `echo "$1" | tr '-' _` with pure parameter expansion `${1//-/_}`.
   - In `contains`: replaced `echo "$1" | grep -w -q "$2"` with bash pattern matching `[[ " $1 " == *" $2 "* ]]`.

## Verification
- `bash -n .kokoro/common.sh generation/check_non_release_please_versions.sh .cloud/helpers/common.sh`
- `git diff --check`
- `bash .kokoro/common_test.sh`
- `bash generation/check_non_release_please_versions.sh`