### PR TITLE
feat(grpc-gcp): prime scaled channels before publish

### DIFF
--- a/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpChannelPrimeController.java
+++ b/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpChannelPrimeController.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.grpc.ManagedChannel;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeoutException;
+import java.util.function.LongUnaryOperator;
+import javax.annotation.Nullable;
+
+/**
+ * Primes channels built by dynamic scale-up before they are published to the pool: each channel
+ * gets a bounded number of {@link GcpChannelPrimer#prime} attempts, each under a timeout and with
+ * backoff between them, and joins the pool only once an attempt succeeds.
+ *
+ * <p>All state is guarded by the pool's own monitor, passed in as {@code lock}, so publishing a
+ * primed channel and shutting the pool down cannot race each other.
+ */
+final class GcpChannelPrimeController {
+
+  /** The pool-side operations priming needs but cannot own. */
+  interface Pool {
+    /** Whether the pool has started shutting down. Called with the pool lock held. */
+    boolean isShuttingDown();
+
+    /**
+     * Whether the pool already holds its maximum number of channels. Called with the pool lock
+     * held.
+     */
+    boolean isFull();
+
+    /** Publishes a successfully primed channel. Called with the pool lock held. */
+    void addPrimedChannel(ManagedChannel channel);
+
+    /** Records a channel rejected because priming failed. Called without the pool lock. */
+    void reportPrimeFailure(Throwable failure);
+
+    /**
+     * Reports a prime abandoned without retry because its {@code prime()} call was still blocked at
+     * the timeout: the channel is closed, but the call keeps occupying a primer thread and a
+     * scale-up slot until it returns. Called without the pool lock, before {@link
+     * #reportPrimeFailure} for the same channel.
+     */
+    void reportPrimeAbandoned();
+  }
+
+  static final class PendingPrime {
+    private final ManagedChannel channel;
+    private int attempt = -1;
+    // The attempt is in its invocation phase: prime() has been dispatched and its returned future,
+    // if any, has not been recorded yet.
+    private boolean invoking;
+    // The primer thread is inside primer.prime() right now. Set by that thread under the lock as
+    // the last step before the call, once it has confirmed the attempt is still live, and cleared
+    // without the lock as soon as the call returns, so the timeout can tell a call that has
+    // already returned (recorded under the lock only later) from one that is still blocked.
+    private volatile boolean insidePrime;
+    private boolean finished;
+    @Nullable private ListenableFuture<Void> future;
+    @Nullable private ScheduledFuture<?> timeoutTask;
+    @Nullable private ScheduledFuture<?> retryTask;
+
+    private PendingPrime(ManagedChannel channel) {
+      this.channel = channel;
+    }
+  }
+
+  // Primer invocations run here so a primer that blocks inside prime() occupies a thread of its
+  // own instead of starving the shared scheduler that drives scale-up, draining, and timeouts.
+  private static final ExecutorService SHARED_PRIME_SERVICE =
+      Executors.newCachedThreadPool(GcpThreadFactory.newThreadFactory("gcp-mc-prime-%d"));
+
+  // The owning pool instance: every mutation below is made while synchronized on it.
+  private final Object lock;
+  private final Pool pool;
+  private final GcpChannelPrimer primer;
+  private final long timeoutNanos;
+  private final int maxAttempts;
+  private final ScheduledExecutorService scheduler;
+
+  @GuardedBy("lock")
+  private final Set<PendingPrime> pendingPrimes = new HashSet<>();
+
+  // Primes whose prime() call was still blocked at its timeout. Each one still holds a primer
+  // thread and its closed delegate until the call returns, so it keeps occupying a scale-up slot:
+  // a primer that never returns can pin at most maxSize slots, never one thread per event.
+  @GuardedBy("lock")
+  private final Set<PendingPrime> abandonedPrimes = new HashSet<>();
+
+  /**
+   * @param lock the pool instance whose monitor guards this controller's state
+   * @param pool the pool operations priming needs
+   * @param scheduler runs timeouts, retries, and future callbacks
+   */
+  GcpChannelPrimeController(
+      Object lock,
+      Pool pool,
+      GcpChannelPrimer primer,
+      long timeoutNanos,
+      int maxAttempts,
+      ScheduledExecutorService scheduler) {
+    this.lock = lock;
+    this.pool = pool;
+    this.primer = primer;
+    this.timeoutNanos = timeoutNanos;
+    this.maxAttempts = maxAttempts;
+    this.scheduler = scheduler;
+  }
+
+  /**
+   * The number of scale-up slots priming still occupies: channels being primed plus abandoned
+   * primes whose blocked prime() call has not returned yet.
+   */
+  @GuardedBy("lock")
+  int primingCount() {
+    return pendingPrimes.size() + abandonedPrimes.size();
+  }
+
+  @GuardedBy("lock")
+  int inFlightCount() {
+    return pendingPrimes.size();
+  }
+
+  @GuardedBy("lock")
+  int abandonedCount() {
+    return abandonedPrimes.size();
+  }
+
+  /** Starts bounded asynchronous priming without holding the scale-up worker. */
+  void startPrime(ManagedChannel channel) {
+    PendingPrime pendingPrime = new PendingPrime(channel);
+    synchronized (lock) {
+      if (pool.isShuttingDown()) {
+        channel.shutdownNow();
+        return;
+      }
+      pendingPrimes.add(pendingPrime);
+    }
+    submitPrimeAttempt(pendingPrime, 0);
+  }
+
+  /**
+   * Finishes every pending prime and releases the abandoned slots as part of pool shutdown. The
+   * returned primes are still running; pass them to {@link #cancel} once the pool lock is released.
+   */
+  @GuardedBy("lock")
+  List<PendingPrime> detachAll() {
+    List<PendingPrime> primesToCancel = new ArrayList<>(pendingPrimes);
+    primesToCancel.forEach(this::finishPendingPrime);
+    // Abandoned delegates are already closed; no further scale-up can consult their slots.
+    abandonedPrimes.clear();
+    return primesToCancel;
+  }
+
+  /** Stops the work of primes returned by {@link #detachAll} and closes their channels. */
+  void cancel(List<PendingPrime> pendingPrimes, boolean force) {
+    for (PendingPrime pendingPrime : pendingPrimes) {
+      if (pendingPrime.future != null) {
+        pendingPrime.future.cancel(true);
+      }
+      if (pendingPrime.timeoutTask != null) {
+        pendingPrime.timeoutTask.cancel(false);
+      }
+      if (pendingPrime.retryTask != null) {
+        pendingPrime.retryTask.cancel(false);
+      }
+      if (force) {
+        pendingPrime.channel.shutdownNow();
+      } else {
+        pendingPrime.channel.shutdown();
+      }
+    }
+  }
+
+  private void submitPrimeAttempt(PendingPrime pendingPrime, int attempt) {
+    try {
+      SHARED_PRIME_SERVICE.execute(() -> startPrimeAttempt(pendingPrime, attempt));
+    } catch (RejectedExecutionException failure) {
+      rejectPendingPrime(pendingPrime, failure);
+    }
+  }
+
+  private void startPrimeAttempt(PendingPrime pendingPrime, int attempt) {
+    Throwable schedulingFailure = null;
+    synchronized (lock) {
+      if (pendingPrime.finished) {
+        return;
+      }
+      if (pool.isShuttingDown()) {
+        finishPendingPrime(pendingPrime);
+        pendingPrime.channel.shutdownNow();
+        return;
+      }
+      pendingPrime.attempt = attempt;
+      pendingPrime.invoking = true;
+      pendingPrime.future = null;
+      pendingPrime.retryTask = null;
+      // The timeout is armed before prime() runs so it bounds the whole attempt, including a
+      // primer that blocks instead of returning a future.
+      try {
+        pendingPrime.timeoutTask =
+            scheduler.schedule(
+                () ->
+                    finishPrimeFailure(
+                        pendingPrime,
+                        attempt,
+                        null,
+                        new TimeoutException("Channel priming timed out"),
+                        true),
+                timeoutNanos,
+                NANOSECONDS);
+      } catch (RejectedExecutionException failure) {
+        schedulingFailure = failure;
+      }
+    }
+    if (schedulingFailure != null) {
+      finishPrimeFailure(pendingPrime, attempt, null, schedulingFailure, false);
+      return;
+    }
+
+    // The lock was released between arming the timeout and getting here, so the timeout (or a
+    // shutdown) may already have finished this attempt and released its slot. Such a prime() call
+    // would run untracked, so confirm the attempt is still live and mark it as inside prime()
+    // under the same lock hold: a timeout that fires from now on sees insidePrime and abandons.
+    synchronized (lock) {
+      if (!isCurrentPrimeAttempt(pendingPrime, attempt, null)) {
+        // Whoever finished the attempt owns the channel and the outcome.
+        return;
+      }
+      pendingPrime.insidePrime = true;
+    }
+
+    ListenableFuture<Void> future;
+    try {
+      try {
+        future = primer.prime(pendingPrime.channel);
+      } finally {
+        pendingPrime.insidePrime = false;
+      }
+      if (future == null) {
+        throw new NullPointerException("Channel primer returned null");
+      }
+    } catch (Throwable failure) {
+      synchronized (lock) {
+        abandonedPrimes.remove(pendingPrime);
+      }
+      finishPrimeFailure(pendingPrime, attempt, null, failure, false);
+      return;
+    }
+
+    boolean cancelFuture = false;
+    boolean closeChannel = false;
+    synchronized (lock) {
+      abandonedPrimes.remove(pendingPrime);
+      if (pendingPrime.finished
+          || pendingPrime.attempt != attempt
+          || !pendingPrime.invoking
+          || pool.isShuttingDown()) {
+        // The attempt timed out or the pool shut down while prime() was still running.
+        cancelFuture = true;
+        closeChannel = pendingPrime.finished || pool.isShuttingDown();
+      } else {
+        pendingPrime.invoking = false;
+        pendingPrime.future = future;
+      }
+    }
+    if (cancelFuture) {
+      future.cancel(true);
+      if (closeChannel) {
+        pendingPrime.channel.shutdownNow();
+      }
+      return;
+    }
+
+    Futures.addCallback(
+        future,
+        new FutureCallback<Void>() {
+          @Override
+          public void onSuccess(@Nullable Void unused) {
+            finishPrimeSuccess(pendingPrime, attempt, future);
+          }
+
+          @Override
+          public void onFailure(Throwable failure) {
+            finishPrimeFailure(pendingPrime, attempt, future, failure, false);
+          }
+        },
+        scheduler);
+  }
+
+  private void finishPrimeSuccess(
+      PendingPrime pendingPrime, int attempt, ListenableFuture<Void> future) {
+    boolean surplus;
+    synchronized (lock) {
+      if (!isCurrentPrimeAttempt(pendingPrime, attempt, future)) {
+        return;
+      }
+      cancelPrimeTimeout(pendingPrime);
+      pendingPrime.future = null;
+      finishPendingPrime(pendingPrime);
+      surplus = pool.isShuttingDown() || pool.isFull();
+      if (!surplus) {
+        pool.addPrimedChannel(pendingPrime.channel);
+      }
+    }
+    if (surplus) {
+      pendingPrime.channel.shutdownNow();
+    }
+  }
+
+  /**
+   * Records a failed attempt. {@code future} identifies the attempt when the failure came from the
+   * primer's future; {@code null} matches whichever phase the attempt is in, which is what the
+   * timeout, a thrown {@code prime()}, and a scheduling rejection need. {@code timedOut} cancels a
+   * still-running future and, when the primer is still blocked inside {@code prime()}, ends the
+   * prime without a retry: nothing can stop that call and a fresh attempt would overlap it. A
+   * timeout that fires before the primer thread entered {@code prime()} is an ordinary timed-out
+   * attempt as well: the thread then sees the attempt is no longer live and never calls {@code
+   * prime()} for it. A timeout that fires after {@code prime()} returned but before its future was
+   * recorded is likewise ordinary: the worker cancels the late future and the attempt is retried.
+   */
+  private void finishPrimeFailure(
+      PendingPrime pendingPrime,
+      int attempt,
+      @Nullable ListenableFuture<Void> future,
+      Throwable failure,
+      boolean timedOut) {
+    boolean finalFailure = false;
+    boolean publishFailure = false;
+    boolean reportAbandoned = false;
+    ListenableFuture<Void> futureToCancel = null;
+    synchronized (lock) {
+      if (!isCurrentPrimeAttempt(pendingPrime, attempt, future)) {
+        return;
+      }
+      boolean shuttingDown = pool.isShuttingDown();
+      boolean blockedInPrimer = timedOut && pendingPrime.invoking && pendingPrime.insidePrime;
+      futureToCancel = timedOut ? pendingPrime.future : null;
+      pendingPrime.invoking = false;
+      pendingPrime.future = null;
+      cancelPrimeTimeout(pendingPrime);
+      if (blockedInPrimer || shuttingDown || attempt + 1 >= maxAttempts) {
+        finishPendingPrime(pendingPrime);
+        if (blockedInPrimer && !shuttingDown) {
+          abandonedPrimes.add(pendingPrime);
+          reportAbandoned = true;
+        }
+        finalFailure = true;
+        publishFailure = !shuttingDown;
+      } else {
+        long delayMillis = backoffMillis(attempt);
+        try {
+          pendingPrime.retryTask =
+              scheduler.schedule(
+                  () -> submitPrimeAttempt(pendingPrime, attempt + 1), delayMillis, MILLISECONDS);
+        } catch (RejectedExecutionException rejected) {
+          failure.addSuppressed(rejected);
+          finishPendingPrime(pendingPrime);
+          finalFailure = true;
+          publishFailure = true;
+        }
+      }
+    }
+    if (futureToCancel != null) {
+      futureToCancel.cancel(true);
+    }
+    if (finalFailure) {
+      pendingPrime.channel.shutdownNow();
+      if (reportAbandoned) {
+        pool.reportPrimeAbandoned();
+      }
+      if (publishFailure) {
+        pool.reportPrimeFailure(failure);
+      }
+    }
+  }
+
+  private void rejectPendingPrime(PendingPrime pendingPrime, Throwable failure) {
+    boolean publishFailure;
+    synchronized (lock) {
+      if (pendingPrime.finished) {
+        return;
+      }
+      finishPendingPrime(pendingPrime);
+      publishFailure = !pool.isShuttingDown();
+    }
+    pendingPrime.channel.shutdownNow();
+    if (publishFailure) {
+      pool.reportPrimeFailure(failure);
+    }
+  }
+
+  @GuardedBy("lock")
+  private boolean isCurrentPrimeAttempt(
+      PendingPrime pendingPrime, int attempt, @Nullable ListenableFuture<Void> future) {
+    if (pendingPrime.finished || pendingPrime.attempt != attempt) {
+      return false;
+    }
+    if (future == null) {
+      // Any live phase of this attempt: still inside prime(), or waiting on its future.
+      return pendingPrime.invoking || pendingPrime.future != null;
+    }
+    return pendingPrime.future == future;
+  }
+
+  @GuardedBy("lock")
+  private void cancelPrimeTimeout(PendingPrime pendingPrime) {
+    if (pendingPrime.timeoutTask != null) {
+      pendingPrime.timeoutTask.cancel(false);
+      pendingPrime.timeoutTask = null;
+    }
+  }
+
+  @GuardedBy("lock")
+  private void finishPendingPrime(PendingPrime pendingPrime) {
+    if (!pendingPrime.finished) {
+      pendingPrime.finished = true;
+      pendingPrimes.remove(pendingPrime);
+    }
+  }
+
+  private static final long MAX_BACKOFF_MILLIS = 5000L;
+
+  /**
+   * Exponential backoff base for the given retry attempt, capped at {@link #MAX_BACKOFF_MILLIS}.
+   */
+  @VisibleForTesting
+  static long baseBackoffMillis(int attempt) {
+    return Math.min(100L << Math.min(attempt, 12), MAX_BACKOFF_MILLIS);
+  }
+
+  /**
+   * Retry delay with equal jitter: half the exponential base plus a random share of the other half,
+   * so concurrent prime retries across channels do not fire in lockstep.
+   */
+  static long backoffMillis(int attempt) {
+    return backoffMillis(attempt, bound -> ThreadLocalRandom.current().nextLong(bound));
+  }
+
+  /**
+   * @param random returns a uniformly distributed value in {@code [0, bound)} for a positive bound
+   */
+  @VisibleForTesting
+  static long backoffMillis(int attempt, LongUnaryOperator random) {
+    long base = baseBackoffMillis(attempt);
+    long half = base / 2;
+    long jitter = half > 0 ? random.applyAsLong(half) : 0L;
+    return Math.min(half + jitter, MAX_BACKOFF_MILLIS);
+  }
+}

--- a/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpChannelPrimer.java
+++ b/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpChannelPrimer.java
@@ -27,18 +27,46 @@ import io.grpc.ManagedChannel;
 public interface GcpChannelPrimer {
 
   /**
-   * Issues a cheap end-to-end RPC on {@code channel} so its connection is warm before real traffic.
-   * Scale-up batches invoke this method concurrently across channels and publish each channel as
-   * soon as its own future succeeds. For example, a Cloud Spanner implementation can execute {@code
-   * SELECT 1}. Return a failed future to reject the attempt; the pool retries up to the configured
-   * attempt count and closes the channel when they are exhausted.
+   * Issues a cheap, read-only end-to-end RPC on {@code channel} so its transport, TLS session, and
+   * server-side connection are established before the channel serves live traffic. Scale-up batches
+   * invoke this method concurrently across channels and publish each channel as soon as its own
+   * future succeeds. For example, a Cloud Spanner implementation can execute {@code SELECT 1}.
+   * Return a failed future to reject the attempt; the pool retries up to the configured attempt
+   * count and closes the channel when they are exhausted.
    *
-   * <p>Return promptly and do the work inside the future. The configured prime timeout bounds each
-   * attempt as a whole: a future still pending at the timeout is cancelled and the attempt retried,
-   * while a call that is still blocked inside this method at the timeout fails the channel with no
-   * retry, because nothing can stop it. A retry may overlap work from a cancelled future if that
-   * work does not promptly honor cancellation, so implementations must tolerate concurrent calls
-   * for one channel.
+   * <p>Implementations must observe the following:
+   *
+   * <ul>
+   *   <li><b>Return promptly and do the work inside the future.</b> Do not block in this method (no
+   *       blocking stub, {@code ResultSet.next()}, {@code Future.get()}, or waiting on other
+   *       threads). The configured prime timeout bounds each attempt as a whole: a future still
+   *       pending at the timeout is cancelled and the attempt retried, while a call that is still
+   *       blocked inside this method at the timeout fails the channel with no retry, because
+   *       nothing can stop it. Such a call keeps occupying its primer thread and a scale-up slot
+   *       until it returns.
+   *   <li><b>Set an explicit, short deadline on the RPC</b>, for example {@code
+   *       stub.withDeadlineAfter(5, SECONDS)}. Do not rely on the default deadline: many Google
+   *       Cloud APIs default to very long ones, such as one hour for Cloud Spanner's {@code
+   *       ExecuteStreamingSql}, so an unresponsive backend would leave the call lingering on the
+   *       server long after the pool has given up on it.
+   *   <li><b>Propagate cancellation to the gRPC call.</b> The pool calls {@code
+   *       future.cancel(true)} on the returned future when the attempt times out or the pool shuts
+   *       down. Cancelling the future must cancel the underlying {@link io.grpc.ClientCall} or
+   *       {@link io.grpc.Context.CancellableContext} so the stream and its server-side resources
+   *       are released promptly.
+   *   <li><b>Expect the channel to be shut down under a running call.</b> The pool may call {@code
+   *       shutdownNow()} on {@code channel} while this method is still running: when the call is
+   *       still blocked at the timeout, or when the pool shuts down. A channel-shutdown status from
+   *       an RPC on {@code channel} is then expected and is not a backend outage.
+   *   <li><b>Tolerate concurrent calls for one channel.</b> A retry may overlap work from a
+   *       cancelled future if that work does not promptly honor cancellation, so the implementation
+   *       must be safe for multiple invocations on the same channel at once.
+   *   <li><b>Keep the RPC trivial and side-effect free.</b> It should be strictly read-only and
+   *       need minimal server work, such as {@code SELECT 1} or a lightweight ping.
+   * </ul>
+   *
+   * @param channel the newly built, not yet published delegate channel to prime
+   * @return a future that succeeds when the priming RPC succeeds, or fails to reject the attempt
    */
   ListenableFuture<Void> prime(ManagedChannel channel);
 }

--- a/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpChannelPrimer.java
+++ b/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpChannelPrimer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.grpc.ManagedChannel;
+
+/**
+ * Primes delegate channels built by dynamic scale-up before they are published to the pool. The
+ * initial pool and non-dynamic growth are not primed.
+ */
+@FunctionalInterface
+public interface GcpChannelPrimer {
+
+  /**
+   * Issues a cheap end-to-end RPC on {@code channel} so its connection is warm before real traffic.
+   * Scale-up batches invoke this method concurrently across channels and publish each channel as
+   * soon as its own future succeeds. For example, a Cloud Spanner implementation can execute {@code
+   * SELECT 1}. Return a failed future to reject the attempt; the pool retries up to the configured
+   * attempt count and closes the channel when they are exhausted.
+   *
+   * <p>Return promptly and do the work inside the future. The configured prime timeout bounds each
+   * attempt as a whole: a future still pending at the timeout is cancelled and the attempt retried,
+   * while a call that is still blocked inside this method at the timeout fails the channel with no
+   * retry, because nothing can stop it. A retry may overlap work from a cancelled future if that
+   * work does not promptly honor cancellation, so implementations must tolerate concurrent calls
+   * for one channel.
+   */
+  ListenableFuture<Void> prime(ManagedChannel channel);
+}

--- a/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -28,6 +28,9 @@ import com.google.cloud.grpc.proto.ApiConfig;
 import com.google.cloud.grpc.proto.MethodConfig;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.MessageOrBuilder;
@@ -56,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.LongSummaryStatistics;
@@ -71,6 +75,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -84,6 +89,21 @@ import javax.annotation.Nullable;
 
 /** A channel management factory that implements grpc.Channel APIs. */
 public class GcpManagedChannel extends ManagedChannel {
+
+  private static final class PendingPrime {
+    private final ManagedChannel channel;
+    private int attempt = -1;
+    private boolean invoking;
+    private boolean finished;
+    @Nullable private ListenableFuture<Void> future;
+    @Nullable private ScheduledFuture<?> timeoutTask;
+    @Nullable private ScheduledFuture<?> retryTask;
+
+    private PendingPrime(ManagedChannel channel) {
+      this.channel = channel;
+    }
+  }
+
   private static final Logger logger = Logger.getLogger(GcpManagedChannel.class.getName());
   static final AtomicInteger channelPoolIndex = new AtomicInteger();
 
@@ -181,6 +201,9 @@ public class GcpManagedChannel extends ManagedChannel {
   private int errorPenaltyStep = 5;
   private Duration errorPenaltyDuration = Duration.ofSeconds(5);
   private long errorPenaltyDurationNanos = Duration.ofSeconds(5).toNanos();
+  @Nullable private GcpChannelPrimer channelPrimer;
+  private long channelPrimeTimeoutNanos = Duration.ofSeconds(10).toNanos();
+  private int channelPrimeMaxAttempts = 3;
   private boolean isDynamicScalingEnabled = false;
   private int maxConcurrentStreamsLowWatermark = DEFAULT_MAX_STREAM;
   private GcpManagedChannelOptions.ChannelPickStrategy channelPickStrategy =
@@ -211,6 +234,16 @@ public class GcpManagedChannel extends ManagedChannel {
   private final AtomicBoolean scaleUpSignalPending = new AtomicBoolean();
   private final AtomicBoolean scaleUpWorkerRunning = new AtomicBoolean();
   private final AtomicLong totalErrorPenaltyLoad = new AtomicLong();
+  private final AtomicInteger inFlightPrimeCount = new AtomicInteger();
+
+  @GuardedBy("this")
+  private final Set<PendingPrime> pendingPrimes = new HashSet<>();
+
+  // Primes whose prime() call was still blocked at its timeout. Each one still holds a primer
+  // thread and its closed delegate until the call returns, so it keeps occupying a scale-up slot:
+  // a primer that never returns can pin at most maxSize slots, never one thread per event.
+  @GuardedBy("this")
+  private final Set<PendingPrime> abandonedPrimes = new HashSet<>();
 
   private volatile long lastScaleUpNanos = Long.MIN_VALUE;
   private int consecutiveLowLoadChecks;
@@ -257,6 +290,10 @@ public class GcpManagedChannel extends ManagedChannel {
   private final Map<String, Long> cumulativeMetricValues = new ConcurrentHashMap<>();
   private static final ScheduledThreadPoolExecutor SHARED_BACKGROUND_SERVICE =
       createSharedBackgroundService();
+  // Primer invocations run here so a primer that blocks inside prime() occupies a thread of its
+  // own instead of starving the shared scheduler that drives scale-up, draining, and timeouts.
+  private static final ExecutorService SHARED_PRIME_SERVICE =
+      Executors.newCachedThreadPool(GcpThreadFactory.newThreadFactory("gcp-mc-prime-%d"));
 
   private ScheduledFuture<?> cleanupTask;
   private ScheduledFuture<?> scaleDownTask;
@@ -302,6 +339,7 @@ public class GcpManagedChannel extends ManagedChannel {
   private AtomicLong maxUnresponsiveDrops = new AtomicLong();
   private AtomicLong scaleUpCount = new AtomicLong();
   private AtomicLong scaleDownCount = new AtomicLong();
+  private final AtomicLong scaleUpPrimeFailures = new AtomicLong();
 
   // Clock supplier for nanoTime, injectable for testing.
   private NanoClock nanoClock = System::nanoTime;
@@ -352,6 +390,31 @@ public class GcpManagedChannel extends ManagedChannel {
   @VisibleForTesting
   int readyChannelCountForTest() {
     return readyChannels.get();
+  }
+
+  @VisibleForTesting
+  long scaleUpPrimeFailuresForTest() {
+    return scaleUpPrimeFailures.get();
+  }
+
+  @VisibleForTesting
+  boolean scaleUpWorkerRunningForTest() {
+    return scaleUpWorkerRunning.get();
+  }
+
+  @VisibleForTesting
+  int inFlightPrimeCountForTest() {
+    return inFlightPrimeCount.get();
+  }
+
+  @VisibleForTesting
+  synchronized int abandonedPrimeCountForTest() {
+    return abandonedPrimes.size();
+  }
+
+  @VisibleForTesting
+  static long primeBackoffMillisForTest(int attempt) {
+    return primeBackoffMillis(attempt);
   }
 
   @VisibleForTesting
@@ -742,6 +805,9 @@ public class GcpManagedChannel extends ManagedChannel {
       errorPenaltyStep = poolOptions.getErrorPenaltyStep();
       errorPenaltyDuration = poolOptions.getErrorPenaltyDuration();
       errorPenaltyDurationNanos = errorPenaltyDuration.toNanos();
+      channelPrimer = poolOptions.getChannelPrimer();
+      channelPrimeTimeoutNanos = poolOptions.getChannelPrimeTimeout().toNanos();
+      channelPrimeMaxAttempts = poolOptions.getChannelPrimeMaxAttempts();
       isDynamicScalingEnabled =
           minRpcPerChannel > 0 && maxRpcPerChannel > 0 && !scaleDownInterval.isZero();
       channelPickStrategy = poolOptions.getChannelPickStrategy();
@@ -1060,6 +1126,13 @@ public class GcpManagedChannel extends ManagedChannel {
         this,
         GcpManagedChannel::reportScaleUp,
         GcpManagedChannel::reportScaleDown);
+
+    createDerivedLongCumulativeTimeSeries(
+        GcpMetricsConstants.METRIC_SCALE_UP_PRIME_FAILURES,
+        "The number of scaled-up channels rejected because priming failed or timed out.",
+        GcpMetricsConstants.COUNT,
+        this,
+        GcpManagedChannel::reportScaleUpPrimeFailures);
   }
 
   private void setupOtelCommonAttributes(GcpMetricsOptions metricsOptions) {
@@ -1315,6 +1388,14 @@ public class GcpManagedChannel extends ManagedChannel {
               m.record(reportScaleUp(), withDirection(GcpMetricsConstants.DIRECTION_UP));
               m.record(reportScaleDown(), withDirection(GcpMetricsConstants.DIRECTION_DOWN));
             });
+
+    meter
+        .gaugeBuilder(metricPrefix + GcpMetricsConstants.METRIC_SCALE_UP_PRIME_FAILURES)
+        .ofLongs()
+        .setDescription(
+            "The number of scaled-up channels rejected because priming failed or timed out.")
+        .setUnit(GcpMetricsConstants.COUNT)
+        .buildWithCallback(m -> m.record(reportScaleUpPrimeFailures(), otelCommonAttributes));
   }
 
   private void logGauge(String key, long value) {
@@ -1343,6 +1424,7 @@ public class GcpManagedChannel extends ManagedChannel {
     reportMaxAllowedChannels();
     reportScaleUp();
     reportScaleDown();
+    reportScaleUpPrimeFailures();
     reportNumChannelDisconnect();
     reportNumChannelConnect();
     reportMinReadinessTime();
@@ -1704,6 +1786,12 @@ public class GcpManagedChannel extends ManagedChannel {
   private long reportScaleDown() {
     long value = scaleDownCount.get();
     logCumulative(GcpMetricsConstants.METRIC_CHANNEL_POOL_SCALING + "_down", value);
+    return value;
+  }
+
+  private long reportScaleUpPrimeFailures() {
+    long value = scaleUpPrimeFailures.get();
+    logCumulative(GcpMetricsConstants.METRIC_SCALE_UP_PRIME_FAILURES, value);
     return value;
   }
 
@@ -2234,7 +2322,11 @@ public class GcpManagedChannel extends ManagedChannel {
     }
     final int channelsToBuild;
     synchronized (this) {
-      if (!isDynamicScalingEnabled || shuttingDown || channelRefs.size() >= maxSize) {
+      // Channels still priming are capacity already on its way: they count toward the size cap
+      // and the desired size, so overlapping scale-ups cannot build the same shortfall twice.
+      // Abandoned primes keep their slot until their blocked prime() call returns.
+      int priming = pendingPrimes.size() + abandonedPrimes.size();
+      if (!isDynamicScalingEnabled || shuttingDown || channelRefs.size() + priming >= maxSize) {
         return;
       }
       if (lastScaleUpNanos != Long.MIN_VALUE
@@ -2248,11 +2340,11 @@ public class GcpManagedChannel extends ManagedChannel {
         return;
       }
       int desired = ceilDiv(pickerLoad(activeChannels, now), targetRpcPerChannel());
-      int add = desired - active;
+      int add = desired - active - priming;
       // Small pools may add two channels per event before percentage growth dominates.
       int percentCap = Math.max(2, ceilDiv((long) active * maxScaleUpPercent, 100));
       add = Math.min(add, percentCap);
-      add = Math.min(add, maxSize - active);
+      add = Math.min(add, maxSize - channelRefs.size() - priming);
       if (add <= 0) {
         return;
       }
@@ -2277,6 +2369,11 @@ public class GcpManagedChannel extends ManagedChannel {
       throw failure;
     }
 
+    if (channelPrimer != null) {
+      builtChannels.forEach(this::startPrime);
+      return;
+    }
+
     int added = 0;
     List<ManagedChannel> surplus = new ArrayList<>();
     synchronized (this) {
@@ -2291,6 +2388,249 @@ public class GcpManagedChannel extends ManagedChannel {
     }
     surplus.forEach(ManagedChannel::shutdownNow);
     scaleUpCount.addAndGet(added);
+  }
+
+  /** Starts bounded asynchronous priming without holding the scale-up worker. */
+  private void startPrime(ManagedChannel channel) {
+    PendingPrime pendingPrime = new PendingPrime(channel);
+    synchronized (this) {
+      if (shuttingDown) {
+        channel.shutdownNow();
+        return;
+      }
+      pendingPrimes.add(pendingPrime);
+      inFlightPrimeCount.incrementAndGet();
+    }
+    submitPrimeAttempt(pendingPrime, 0);
+  }
+
+  private void submitPrimeAttempt(PendingPrime pendingPrime, int attempt) {
+    try {
+      SHARED_PRIME_SERVICE.execute(() -> startPrimeAttempt(pendingPrime, attempt));
+    } catch (RejectedExecutionException failure) {
+      rejectPendingPrime(pendingPrime, failure);
+    }
+  }
+
+  private void startPrimeAttempt(PendingPrime pendingPrime, int attempt) {
+    Throwable schedulingFailure = null;
+    synchronized (this) {
+      if (pendingPrime.finished) {
+        return;
+      }
+      if (shuttingDown) {
+        finishPendingPrime(pendingPrime);
+        pendingPrime.channel.shutdownNow();
+        return;
+      }
+      pendingPrime.attempt = attempt;
+      pendingPrime.invoking = true;
+      pendingPrime.future = null;
+      pendingPrime.retryTask = null;
+      // The timeout is armed before prime() runs so it bounds the whole attempt, including a
+      // primer that blocks instead of returning a future.
+      try {
+        pendingPrime.timeoutTask =
+            SHARED_BACKGROUND_SERVICE.schedule(
+                () ->
+                    finishPrimeFailure(
+                        pendingPrime,
+                        attempt,
+                        null,
+                        new TimeoutException("Channel priming timed out"),
+                        true),
+                channelPrimeTimeoutNanos,
+                NANOSECONDS);
+      } catch (RejectedExecutionException failure) {
+        schedulingFailure = failure;
+      }
+    }
+    if (schedulingFailure != null) {
+      finishPrimeFailure(pendingPrime, attempt, null, schedulingFailure, false);
+      return;
+    }
+
+    ListenableFuture<Void> future;
+    try {
+      future = channelPrimer.prime(pendingPrime.channel);
+      if (future == null) {
+        throw new NullPointerException("Channel primer returned null");
+      }
+    } catch (Throwable failure) {
+      synchronized (this) {
+        abandonedPrimes.remove(pendingPrime);
+      }
+      finishPrimeFailure(pendingPrime, attempt, null, failure, false);
+      return;
+    }
+
+    boolean cancelFuture = false;
+    boolean closeChannel = false;
+    synchronized (this) {
+      abandonedPrimes.remove(pendingPrime);
+      if (pendingPrime.finished
+          || pendingPrime.attempt != attempt
+          || !pendingPrime.invoking
+          || shuttingDown) {
+        // The attempt timed out or the pool shut down while prime() was still running.
+        cancelFuture = true;
+        closeChannel = pendingPrime.finished || shuttingDown;
+      } else {
+        pendingPrime.invoking = false;
+        pendingPrime.future = future;
+      }
+    }
+    if (cancelFuture) {
+      future.cancel(true);
+      if (closeChannel) {
+        pendingPrime.channel.shutdownNow();
+      }
+      return;
+    }
+
+    Futures.addCallback(
+        future,
+        new FutureCallback<Void>() {
+          @Override
+          public void onSuccess(@Nullable Void unused) {
+            finishPrimeSuccess(pendingPrime, attempt, future);
+          }
+
+          @Override
+          public void onFailure(Throwable failure) {
+            finishPrimeFailure(pendingPrime, attempt, future, failure, false);
+          }
+        },
+        SHARED_BACKGROUND_SERVICE);
+  }
+
+  private void finishPrimeSuccess(
+      PendingPrime pendingPrime, int attempt, ListenableFuture<Void> future) {
+    boolean surplus;
+    synchronized (this) {
+      if (!isCurrentPrimeAttempt(pendingPrime, attempt, future)) {
+        return;
+      }
+      cancelPrimeTimeout(pendingPrime);
+      pendingPrime.future = null;
+      finishPendingPrime(pendingPrime);
+      surplus = shuttingDown || channelRefs.size() >= maxSize;
+      if (!surplus) {
+        addBuiltChannel(pendingPrime.channel);
+        scaleUpCount.incrementAndGet();
+      }
+    }
+    if (surplus) {
+      pendingPrime.channel.shutdownNow();
+    }
+  }
+
+  /**
+   * Records a failed attempt. {@code future} identifies the attempt when the failure came from the
+   * primer's future; {@code null} matches whichever phase the attempt is in, which is what the
+   * timeout, a thrown {@code prime()}, and a scheduling rejection need. {@code timedOut} cancels a
+   * still-running future and, when the primer is still blocked inside {@code prime()}, ends the
+   * prime without a retry: nothing can stop that call and a fresh attempt would overlap it.
+   */
+  private void finishPrimeFailure(
+      PendingPrime pendingPrime,
+      int attempt,
+      @Nullable ListenableFuture<Void> future,
+      Throwable failure,
+      boolean timedOut) {
+    boolean finalFailure = false;
+    boolean publishFailure = false;
+    ListenableFuture<Void> futureToCancel = null;
+    synchronized (this) {
+      if (!isCurrentPrimeAttempt(pendingPrime, attempt, future)) {
+        return;
+      }
+      boolean blockedInPrimer = timedOut && pendingPrime.invoking;
+      futureToCancel = timedOut ? pendingPrime.future : null;
+      pendingPrime.invoking = false;
+      pendingPrime.future = null;
+      cancelPrimeTimeout(pendingPrime);
+      if (blockedInPrimer || shuttingDown || attempt + 1 >= channelPrimeMaxAttempts) {
+        finishPendingPrime(pendingPrime);
+        if (blockedInPrimer && !shuttingDown) {
+          abandonedPrimes.add(pendingPrime);
+        }
+        finalFailure = true;
+        publishFailure = !shuttingDown;
+      } else {
+        long delayMillis = primeBackoffMillis(attempt);
+        try {
+          pendingPrime.retryTask =
+              SHARED_BACKGROUND_SERVICE.schedule(
+                  () -> submitPrimeAttempt(pendingPrime, attempt + 1), delayMillis, MILLISECONDS);
+        } catch (RejectedExecutionException rejected) {
+          failure.addSuppressed(rejected);
+          finishPendingPrime(pendingPrime);
+          finalFailure = true;
+          publishFailure = true;
+        }
+      }
+    }
+    if (futureToCancel != null) {
+      futureToCancel.cancel(true);
+    }
+    if (finalFailure) {
+      pendingPrime.channel.shutdownNow();
+      if (publishFailure) {
+        scaleUpPrimeFailures.incrementAndGet();
+        logger.log(Level.WARNING, log("Scaled-up channel priming failed"), failure);
+      }
+    }
+  }
+
+  private void rejectPendingPrime(PendingPrime pendingPrime, Throwable failure) {
+    boolean publishFailure;
+    synchronized (this) {
+      if (pendingPrime.finished) {
+        return;
+      }
+      finishPendingPrime(pendingPrime);
+      publishFailure = !shuttingDown;
+    }
+    pendingPrime.channel.shutdownNow();
+    if (publishFailure) {
+      scaleUpPrimeFailures.incrementAndGet();
+      logger.log(Level.WARNING, log("Scaled-up channel priming failed"), failure);
+    }
+  }
+
+  @GuardedBy("this")
+  private boolean isCurrentPrimeAttempt(
+      PendingPrime pendingPrime, int attempt, @Nullable ListenableFuture<Void> future) {
+    if (pendingPrime.finished || pendingPrime.attempt != attempt) {
+      return false;
+    }
+    if (future == null) {
+      // Any live phase of this attempt: still inside prime(), or waiting on its future.
+      return pendingPrime.invoking || pendingPrime.future != null;
+    }
+    return pendingPrime.future == future;
+  }
+
+  @GuardedBy("this")
+  private void cancelPrimeTimeout(PendingPrime pendingPrime) {
+    if (pendingPrime.timeoutTask != null) {
+      pendingPrime.timeoutTask.cancel(false);
+      pendingPrime.timeoutTask = null;
+    }
+  }
+
+  @GuardedBy("this")
+  private void finishPendingPrime(PendingPrime pendingPrime) {
+    if (!pendingPrime.finished) {
+      pendingPrime.finished = true;
+      pendingPrimes.remove(pendingPrime);
+      inFlightPrimeCount.decrementAndGet();
+    }
+  }
+
+  private static long primeBackoffMillis(int attempt) {
+    return Math.min(100L << Math.min(attempt, 12), 5000L);
   }
 
   // This is pre-dynamic scaling functionality where we only scale up when the minimum number of
@@ -2555,7 +2895,7 @@ public class GcpManagedChannel extends ManagedChannel {
     return key;
   }
 
-  private synchronized void cancelBackgroundTasks() {
+  private synchronized List<PendingPrime> cancelBackgroundTasks() {
     shuttingDown = true;
     scaleUpSignalPending.set(false);
     if (cleanupTask != null) {
@@ -2572,12 +2912,37 @@ public class GcpManagedChannel extends ManagedChannel {
     }
     drainTasks.values().forEach(task -> task.cancel(false));
     drainTasks.clear();
+    List<PendingPrime> primesToCancel = new ArrayList<>(pendingPrimes);
+    primesToCancel.forEach(this::finishPendingPrime);
+    // Abandoned delegates are already closed; no further scale-up can consult their slots.
+    abandonedPrimes.clear();
+    return primesToCancel;
+  }
+
+  private void cancelPendingPrimes(List<PendingPrime> pendingPrimes, boolean force) {
+    for (PendingPrime pendingPrime : pendingPrimes) {
+      if (pendingPrime.future != null) {
+        pendingPrime.future.cancel(true);
+      }
+      if (pendingPrime.timeoutTask != null) {
+        pendingPrime.timeoutTask.cancel(false);
+      }
+      if (pendingPrime.retryTask != null) {
+        pendingPrime.retryTask.cancel(false);
+      }
+      if (force) {
+        pendingPrime.channel.shutdownNow();
+      } else {
+        pendingPrime.channel.shutdown();
+      }
+    }
   }
 
   @Override
   public ManagedChannel shutdownNow() {
     logger.finer(log("Shutdown now started."));
-    cancelBackgroundTasks();
+    List<PendingPrime> primesToCancel = cancelBackgroundTasks();
+    cancelPendingPrimes(primesToCancel, true);
     List<ChannelRef> activeSnapshot = new ArrayList<>(channelRefs);
     List<ChannelRef> removedSnapshot = new ArrayList<>(removedChannelRefs);
     for (ChannelRef channelRef : activeSnapshot) {
@@ -2599,7 +2964,8 @@ public class GcpManagedChannel extends ManagedChannel {
   @Override
   public ManagedChannel shutdown() {
     logger.finer(log("Shutdown started."));
-    cancelBackgroundTasks();
+    List<PendingPrime> primesToCancel = cancelBackgroundTasks();
+    cancelPendingPrimes(primesToCancel, false);
     List<ChannelRef> activeSnapshot = new ArrayList<>(channelRefs);
     List<ChannelRef> removedSnapshot = new ArrayList<>(removedChannelRefs);
     for (ChannelRef channelRef : activeSnapshot) {

--- a/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
+++ b/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpManagedChannel.java
@@ -28,9 +28,6 @@ import com.google.cloud.grpc.proto.ApiConfig;
 import com.google.cloud.grpc.proto.MethodConfig;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.MessageOrBuilder;
@@ -59,7 +56,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.LongSummaryStatistics;
@@ -75,12 +71,12 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.IntUnaryOperator;
+import java.util.function.LongUnaryOperator;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -89,20 +85,6 @@ import javax.annotation.Nullable;
 
 /** A channel management factory that implements grpc.Channel APIs. */
 public class GcpManagedChannel extends ManagedChannel {
-
-  private static final class PendingPrime {
-    private final ManagedChannel channel;
-    private int attempt = -1;
-    private boolean invoking;
-    private boolean finished;
-    @Nullable private ListenableFuture<Void> future;
-    @Nullable private ScheduledFuture<?> timeoutTask;
-    @Nullable private ScheduledFuture<?> retryTask;
-
-    private PendingPrime(ManagedChannel channel) {
-      this.channel = channel;
-    }
-  }
 
   private static final Logger logger = Logger.getLogger(GcpManagedChannel.class.getName());
   static final AtomicInteger channelPoolIndex = new AtomicInteger();
@@ -201,9 +183,7 @@ public class GcpManagedChannel extends ManagedChannel {
   private int errorPenaltyStep = 5;
   private Duration errorPenaltyDuration = Duration.ofSeconds(5);
   private long errorPenaltyDurationNanos = Duration.ofSeconds(5).toNanos();
-  @Nullable private GcpChannelPrimer channelPrimer;
-  private long channelPrimeTimeoutNanos = Duration.ofSeconds(10).toNanos();
-  private int channelPrimeMaxAttempts = 3;
+  @Nullable private GcpChannelPrimeController channelPrimeController;
   private boolean isDynamicScalingEnabled = false;
   private int maxConcurrentStreamsLowWatermark = DEFAULT_MAX_STREAM;
   private GcpManagedChannelOptions.ChannelPickStrategy channelPickStrategy =
@@ -234,16 +214,6 @@ public class GcpManagedChannel extends ManagedChannel {
   private final AtomicBoolean scaleUpSignalPending = new AtomicBoolean();
   private final AtomicBoolean scaleUpWorkerRunning = new AtomicBoolean();
   private final AtomicLong totalErrorPenaltyLoad = new AtomicLong();
-  private final AtomicInteger inFlightPrimeCount = new AtomicInteger();
-
-  @GuardedBy("this")
-  private final Set<PendingPrime> pendingPrimes = new HashSet<>();
-
-  // Primes whose prime() call was still blocked at its timeout. Each one still holds a primer
-  // thread and its closed delegate until the call returns, so it keeps occupying a scale-up slot:
-  // a primer that never returns can pin at most maxSize slots, never one thread per event.
-  @GuardedBy("this")
-  private final Set<PendingPrime> abandonedPrimes = new HashSet<>();
 
   private volatile long lastScaleUpNanos = Long.MIN_VALUE;
   private int consecutiveLowLoadChecks;
@@ -290,10 +260,6 @@ public class GcpManagedChannel extends ManagedChannel {
   private final Map<String, Long> cumulativeMetricValues = new ConcurrentHashMap<>();
   private static final ScheduledThreadPoolExecutor SHARED_BACKGROUND_SERVICE =
       createSharedBackgroundService();
-  // Primer invocations run here so a primer that blocks inside prime() occupies a thread of its
-  // own instead of starving the shared scheduler that drives scale-up, draining, and timeouts.
-  private static final ExecutorService SHARED_PRIME_SERVICE =
-      Executors.newCachedThreadPool(GcpThreadFactory.newThreadFactory("gcp-mc-prime-%d"));
 
   private ScheduledFuture<?> cleanupTask;
   private ScheduledFuture<?> scaleDownTask;
@@ -403,18 +369,28 @@ public class GcpManagedChannel extends ManagedChannel {
   }
 
   @VisibleForTesting
-  int inFlightPrimeCountForTest() {
-    return inFlightPrimeCount.get();
+  synchronized int inFlightPrimeCountForTest() {
+    return channelPrimeController == null ? 0 : channelPrimeController.inFlightCount();
   }
 
   @VisibleForTesting
   synchronized int abandonedPrimeCountForTest() {
-    return abandonedPrimes.size();
+    return channelPrimeController == null ? 0 : channelPrimeController.abandonedCount();
   }
 
   @VisibleForTesting
   static long primeBackoffMillisForTest(int attempt) {
-    return primeBackoffMillis(attempt);
+    return GcpChannelPrimeController.backoffMillis(attempt);
+  }
+
+  @VisibleForTesting
+  static long primeBackoffMillisForTest(int attempt, LongUnaryOperator random) {
+    return GcpChannelPrimeController.backoffMillis(attempt, random);
+  }
+
+  @VisibleForTesting
+  static long primeBaseBackoffMillisForTest(int attempt) {
+    return GcpChannelPrimeController.baseBackoffMillis(attempt);
   }
 
   @VisibleForTesting
@@ -805,14 +781,62 @@ public class GcpManagedChannel extends ManagedChannel {
       errorPenaltyStep = poolOptions.getErrorPenaltyStep();
       errorPenaltyDuration = poolOptions.getErrorPenaltyDuration();
       errorPenaltyDurationNanos = errorPenaltyDuration.toNanos();
-      channelPrimer = poolOptions.getChannelPrimer();
-      channelPrimeTimeoutNanos = poolOptions.getChannelPrimeTimeout().toNanos();
-      channelPrimeMaxAttempts = poolOptions.getChannelPrimeMaxAttempts();
+      channelPrimeController = createChannelPrimeController(poolOptions);
       isDynamicScalingEnabled =
           minRpcPerChannel > 0 && maxRpcPerChannel > 0 && !scaleDownInterval.isZero();
       channelPickStrategy = poolOptions.getChannelPickStrategy();
     }
     initMetrics();
+  }
+
+  @Nullable
+  private GcpChannelPrimeController createChannelPrimeController(
+      GcpManagedChannelOptions.GcpChannelPoolOptions poolOptions) {
+    GcpChannelPrimer primer = poolOptions.getChannelPrimer();
+    if (primer == null) {
+      return null;
+    }
+    GcpChannelPrimeController.Pool pool =
+        new GcpChannelPrimeController.Pool() {
+          @Override
+          public boolean isShuttingDown() {
+            return shuttingDown;
+          }
+
+          @Override
+          public boolean isFull() {
+            return channelRefs.size() >= maxSize;
+          }
+
+          @Override
+          public void addPrimedChannel(ManagedChannel channel) {
+            addBuiltChannel(channel);
+            scaleUpCount.incrementAndGet();
+          }
+
+          @Override
+          public void reportPrimeFailure(Throwable failure) {
+            scaleUpPrimeFailures.incrementAndGet();
+            logger.log(Level.WARNING, log("Scaled-up channel priming failed"), failure);
+          }
+
+          @Override
+          public void reportPrimeAbandoned() {
+            logger.warning(
+                log(
+                    "Channel priming abandoned without retry: prime() was still blocked at the"
+                        + " timeout and nothing can stop it. The channel is closed and the blocked"
+                        + " call keeps occupying a primer thread and a scale-up slot until it"
+                        + " returns."));
+          }
+        };
+    return new GcpChannelPrimeController(
+        this,
+        pool,
+        primer,
+        poolOptions.getChannelPrimeTimeout().toNanos(),
+        poolOptions.getChannelPrimeMaxAttempts(),
+        SHARED_BACKGROUND_SERVICE);
   }
 
   private synchronized void initCleanupTask(Duration cleanupInterval) {
@@ -2325,7 +2349,7 @@ public class GcpManagedChannel extends ManagedChannel {
       // Channels still priming are capacity already on its way: they count toward the size cap
       // and the desired size, so overlapping scale-ups cannot build the same shortfall twice.
       // Abandoned primes keep their slot until their blocked prime() call returns.
-      int priming = pendingPrimes.size() + abandonedPrimes.size();
+      int priming = channelPrimeController == null ? 0 : channelPrimeController.primingCount();
       if (!isDynamicScalingEnabled || shuttingDown || channelRefs.size() + priming >= maxSize) {
         return;
       }
@@ -2369,8 +2393,8 @@ public class GcpManagedChannel extends ManagedChannel {
       throw failure;
     }
 
-    if (channelPrimer != null) {
-      builtChannels.forEach(this::startPrime);
+    if (channelPrimeController != null) {
+      builtChannels.forEach(channelPrimeController::startPrime);
       return;
     }
 
@@ -2388,249 +2412,6 @@ public class GcpManagedChannel extends ManagedChannel {
     }
     surplus.forEach(ManagedChannel::shutdownNow);
     scaleUpCount.addAndGet(added);
-  }
-
-  /** Starts bounded asynchronous priming without holding the scale-up worker. */
-  private void startPrime(ManagedChannel channel) {
-    PendingPrime pendingPrime = new PendingPrime(channel);
-    synchronized (this) {
-      if (shuttingDown) {
-        channel.shutdownNow();
-        return;
-      }
-      pendingPrimes.add(pendingPrime);
-      inFlightPrimeCount.incrementAndGet();
-    }
-    submitPrimeAttempt(pendingPrime, 0);
-  }
-
-  private void submitPrimeAttempt(PendingPrime pendingPrime, int attempt) {
-    try {
-      SHARED_PRIME_SERVICE.execute(() -> startPrimeAttempt(pendingPrime, attempt));
-    } catch (RejectedExecutionException failure) {
-      rejectPendingPrime(pendingPrime, failure);
-    }
-  }
-
-  private void startPrimeAttempt(PendingPrime pendingPrime, int attempt) {
-    Throwable schedulingFailure = null;
-    synchronized (this) {
-      if (pendingPrime.finished) {
-        return;
-      }
-      if (shuttingDown) {
-        finishPendingPrime(pendingPrime);
-        pendingPrime.channel.shutdownNow();
-        return;
-      }
-      pendingPrime.attempt = attempt;
-      pendingPrime.invoking = true;
-      pendingPrime.future = null;
-      pendingPrime.retryTask = null;
-      // The timeout is armed before prime() runs so it bounds the whole attempt, including a
-      // primer that blocks instead of returning a future.
-      try {
-        pendingPrime.timeoutTask =
-            SHARED_BACKGROUND_SERVICE.schedule(
-                () ->
-                    finishPrimeFailure(
-                        pendingPrime,
-                        attempt,
-                        null,
-                        new TimeoutException("Channel priming timed out"),
-                        true),
-                channelPrimeTimeoutNanos,
-                NANOSECONDS);
-      } catch (RejectedExecutionException failure) {
-        schedulingFailure = failure;
-      }
-    }
-    if (schedulingFailure != null) {
-      finishPrimeFailure(pendingPrime, attempt, null, schedulingFailure, false);
-      return;
-    }
-
-    ListenableFuture<Void> future;
-    try {
-      future = channelPrimer.prime(pendingPrime.channel);
-      if (future == null) {
-        throw new NullPointerException("Channel primer returned null");
-      }
-    } catch (Throwable failure) {
-      synchronized (this) {
-        abandonedPrimes.remove(pendingPrime);
-      }
-      finishPrimeFailure(pendingPrime, attempt, null, failure, false);
-      return;
-    }
-
-    boolean cancelFuture = false;
-    boolean closeChannel = false;
-    synchronized (this) {
-      abandonedPrimes.remove(pendingPrime);
-      if (pendingPrime.finished
-          || pendingPrime.attempt != attempt
-          || !pendingPrime.invoking
-          || shuttingDown) {
-        // The attempt timed out or the pool shut down while prime() was still running.
-        cancelFuture = true;
-        closeChannel = pendingPrime.finished || shuttingDown;
-      } else {
-        pendingPrime.invoking = false;
-        pendingPrime.future = future;
-      }
-    }
-    if (cancelFuture) {
-      future.cancel(true);
-      if (closeChannel) {
-        pendingPrime.channel.shutdownNow();
-      }
-      return;
-    }
-
-    Futures.addCallback(
-        future,
-        new FutureCallback<Void>() {
-          @Override
-          public void onSuccess(@Nullable Void unused) {
-            finishPrimeSuccess(pendingPrime, attempt, future);
-          }
-
-          @Override
-          public void onFailure(Throwable failure) {
-            finishPrimeFailure(pendingPrime, attempt, future, failure, false);
-          }
-        },
-        SHARED_BACKGROUND_SERVICE);
-  }
-
-  private void finishPrimeSuccess(
-      PendingPrime pendingPrime, int attempt, ListenableFuture<Void> future) {
-    boolean surplus;
-    synchronized (this) {
-      if (!isCurrentPrimeAttempt(pendingPrime, attempt, future)) {
-        return;
-      }
-      cancelPrimeTimeout(pendingPrime);
-      pendingPrime.future = null;
-      finishPendingPrime(pendingPrime);
-      surplus = shuttingDown || channelRefs.size() >= maxSize;
-      if (!surplus) {
-        addBuiltChannel(pendingPrime.channel);
-        scaleUpCount.incrementAndGet();
-      }
-    }
-    if (surplus) {
-      pendingPrime.channel.shutdownNow();
-    }
-  }
-
-  /**
-   * Records a failed attempt. {@code future} identifies the attempt when the failure came from the
-   * primer's future; {@code null} matches whichever phase the attempt is in, which is what the
-   * timeout, a thrown {@code prime()}, and a scheduling rejection need. {@code timedOut} cancels a
-   * still-running future and, when the primer is still blocked inside {@code prime()}, ends the
-   * prime without a retry: nothing can stop that call and a fresh attempt would overlap it.
-   */
-  private void finishPrimeFailure(
-      PendingPrime pendingPrime,
-      int attempt,
-      @Nullable ListenableFuture<Void> future,
-      Throwable failure,
-      boolean timedOut) {
-    boolean finalFailure = false;
-    boolean publishFailure = false;
-    ListenableFuture<Void> futureToCancel = null;
-    synchronized (this) {
-      if (!isCurrentPrimeAttempt(pendingPrime, attempt, future)) {
-        return;
-      }
-      boolean blockedInPrimer = timedOut && pendingPrime.invoking;
-      futureToCancel = timedOut ? pendingPrime.future : null;
-      pendingPrime.invoking = false;
-      pendingPrime.future = null;
-      cancelPrimeTimeout(pendingPrime);
-      if (blockedInPrimer || shuttingDown || attempt + 1 >= channelPrimeMaxAttempts) {
-        finishPendingPrime(pendingPrime);
-        if (blockedInPrimer && !shuttingDown) {
-          abandonedPrimes.add(pendingPrime);
-        }
-        finalFailure = true;
-        publishFailure = !shuttingDown;
-      } else {
-        long delayMillis = primeBackoffMillis(attempt);
-        try {
-          pendingPrime.retryTask =
-              SHARED_BACKGROUND_SERVICE.schedule(
-                  () -> submitPrimeAttempt(pendingPrime, attempt + 1), delayMillis, MILLISECONDS);
-        } catch (RejectedExecutionException rejected) {
-          failure.addSuppressed(rejected);
-          finishPendingPrime(pendingPrime);
-          finalFailure = true;
-          publishFailure = true;
-        }
-      }
-    }
-    if (futureToCancel != null) {
-      futureToCancel.cancel(true);
-    }
-    if (finalFailure) {
-      pendingPrime.channel.shutdownNow();
-      if (publishFailure) {
-        scaleUpPrimeFailures.incrementAndGet();
-        logger.log(Level.WARNING, log("Scaled-up channel priming failed"), failure);
-      }
-    }
-  }
-
-  private void rejectPendingPrime(PendingPrime pendingPrime, Throwable failure) {
-    boolean publishFailure;
-    synchronized (this) {
-      if (pendingPrime.finished) {
-        return;
-      }
-      finishPendingPrime(pendingPrime);
-      publishFailure = !shuttingDown;
-    }
-    pendingPrime.channel.shutdownNow();
-    if (publishFailure) {
-      scaleUpPrimeFailures.incrementAndGet();
-      logger.log(Level.WARNING, log("Scaled-up channel priming failed"), failure);
-    }
-  }
-
-  @GuardedBy("this")
-  private boolean isCurrentPrimeAttempt(
-      PendingPrime pendingPrime, int attempt, @Nullable ListenableFuture<Void> future) {
-    if (pendingPrime.finished || pendingPrime.attempt != attempt) {
-      return false;
-    }
-    if (future == null) {
-      // Any live phase of this attempt: still inside prime(), or waiting on its future.
-      return pendingPrime.invoking || pendingPrime.future != null;
-    }
-    return pendingPrime.future == future;
-  }
-
-  @GuardedBy("this")
-  private void cancelPrimeTimeout(PendingPrime pendingPrime) {
-    if (pendingPrime.timeoutTask != null) {
-      pendingPrime.timeoutTask.cancel(false);
-      pendingPrime.timeoutTask = null;
-    }
-  }
-
-  @GuardedBy("this")
-  private void finishPendingPrime(PendingPrime pendingPrime) {
-    if (!pendingPrime.finished) {
-      pendingPrime.finished = true;
-      pendingPrimes.remove(pendingPrime);
-      inFlightPrimeCount.decrementAndGet();
-    }
-  }
-
-  private static long primeBackoffMillis(int attempt) {
-    return Math.min(100L << Math.min(attempt, 12), 5000L);
   }
 
   // This is pre-dynamic scaling functionality where we only scale up when the minimum number of
@@ -2895,7 +2676,7 @@ public class GcpManagedChannel extends ManagedChannel {
     return key;
   }
 
-  private synchronized List<PendingPrime> cancelBackgroundTasks() {
+  private synchronized List<GcpChannelPrimeController.PendingPrime> cancelBackgroundTasks() {
     shuttingDown = true;
     scaleUpSignalPending.set(false);
     if (cleanupTask != null) {
@@ -2912,37 +2693,18 @@ public class GcpManagedChannel extends ManagedChannel {
     }
     drainTasks.values().forEach(task -> task.cancel(false));
     drainTasks.clear();
-    List<PendingPrime> primesToCancel = new ArrayList<>(pendingPrimes);
-    primesToCancel.forEach(this::finishPendingPrime);
-    // Abandoned delegates are already closed; no further scale-up can consult their slots.
-    abandonedPrimes.clear();
-    return primesToCancel;
-  }
-
-  private void cancelPendingPrimes(List<PendingPrime> pendingPrimes, boolean force) {
-    for (PendingPrime pendingPrime : pendingPrimes) {
-      if (pendingPrime.future != null) {
-        pendingPrime.future.cancel(true);
-      }
-      if (pendingPrime.timeoutTask != null) {
-        pendingPrime.timeoutTask.cancel(false);
-      }
-      if (pendingPrime.retryTask != null) {
-        pendingPrime.retryTask.cancel(false);
-      }
-      if (force) {
-        pendingPrime.channel.shutdownNow();
-      } else {
-        pendingPrime.channel.shutdown();
-      }
-    }
+    return channelPrimeController == null
+        ? Collections.emptyList()
+        : channelPrimeController.detachAll();
   }
 
   @Override
   public ManagedChannel shutdownNow() {
     logger.finer(log("Shutdown now started."));
-    List<PendingPrime> primesToCancel = cancelBackgroundTasks();
-    cancelPendingPrimes(primesToCancel, true);
+    List<GcpChannelPrimeController.PendingPrime> primesToCancel = cancelBackgroundTasks();
+    if (channelPrimeController != null) {
+      channelPrimeController.cancel(primesToCancel, true);
+    }
     List<ChannelRef> activeSnapshot = new ArrayList<>(channelRefs);
     List<ChannelRef> removedSnapshot = new ArrayList<>(removedChannelRefs);
     for (ChannelRef channelRef : activeSnapshot) {
@@ -2964,8 +2726,10 @@ public class GcpManagedChannel extends ManagedChannel {
   @Override
   public ManagedChannel shutdown() {
     logger.finer(log("Shutdown started."));
-    List<PendingPrime> primesToCancel = cancelBackgroundTasks();
-    cancelPendingPrimes(primesToCancel, false);
+    List<GcpChannelPrimeController.PendingPrime> primesToCancel = cancelBackgroundTasks();
+    if (channelPrimeController != null) {
+      channelPrimeController.cancel(primesToCancel, false);
+    }
     List<ChannelRef> activeSnapshot = new ArrayList<>(channelRefs);
     List<ChannelRef> removedSnapshot = new ArrayList<>(removedChannelRefs);
     for (ChannelRef channelRef : activeSnapshot) {

--- a/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpManagedChannelOptions.java
+++ b/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpManagedChannelOptions.java
@@ -224,6 +224,12 @@ public class GcpManagedChannelOptions {
     private final Duration drainIdleGrace;
     private final int errorPenaltyStep;
     private final Duration errorPenaltyDuration;
+    // Optional hook that warms a scaled-up channel before publication.
+    @Nullable private final GcpChannelPrimer channelPrimer;
+    // Maximum time to wait for one channel-primer future.
+    private final Duration channelPrimeTimeout;
+    // Maximum number of channel-primer attempts before rejecting a channel.
+    private final int channelPrimeMaxAttempts;
 
     // Use round-robin channel selection for affinity binding calls.
     private final boolean useRoundRobinOnBind;
@@ -248,6 +254,9 @@ public class GcpManagedChannelOptions {
       drainIdleGrace = builder.drainIdleGrace;
       errorPenaltyStep = builder.errorPenaltyStep;
       errorPenaltyDuration = builder.errorPenaltyDuration;
+      channelPrimer = builder.channelPrimer;
+      channelPrimeTimeout = builder.channelPrimeTimeout;
+      channelPrimeMaxAttempts = builder.channelPrimeMaxAttempts;
       concurrentStreamsLowWatermark = builder.concurrentStreamsLowWatermark;
       useRoundRobinOnBind = builder.useRoundRobinOnBind;
       affinityKeyLifetime = builder.affinityKeyLifetime;
@@ -307,6 +316,19 @@ public class GcpManagedChannelOptions {
       return errorPenaltyDuration;
     }
 
+    @Nullable
+    public GcpChannelPrimer getChannelPrimer() {
+      return channelPrimer;
+    }
+
+    public Duration getChannelPrimeTimeout() {
+      return channelPrimeTimeout;
+    }
+
+    public int getChannelPrimeMaxAttempts() {
+      return channelPrimeMaxAttempts;
+    }
+
     public int getConcurrentStreamsLowWatermark() {
       return concurrentStreamsLowWatermark;
     }
@@ -344,9 +366,10 @@ public class GcpManagedChannelOptions {
               + "maxRpcPerChannel: %d, scaleDownInterval: %s, scaleUpCooldown: %s, "
               + "scaleDownConsecutiveLowLoadChecks: %d, maxScaleUpPercent: %d, "
               + "maxScaleDownChannels: %d, drainIdleGrace: %s, errorPenaltyStep: %d, "
-              + "errorPenaltyDuration: %s, "
-              + "concurrentStreamsLowWatermark: %d, useRoundRobinOnBind: %s, "
-              + "affinityKeyLifetime: %s, cleanupInterval: %s, channelPickStrategy: %s}",
+              + "errorPenaltyDuration: %s, concurrentStreamsLowWatermark: %d, "
+              + "useRoundRobinOnBind: %s, affinityKeyLifetime: %s, cleanupInterval: %s, "
+              + "channelPickStrategy: %s, channelPrimer: %s, channelPrimeTimeout: %s, "
+              + "channelPrimeMaxAttempts: %d}",
           getMaxSize(),
           getMinSize(),
           getInitSize(),
@@ -364,7 +387,10 @@ public class GcpManagedChannelOptions {
           isUseRoundRobinOnBind(),
           getAffinityKeyLifetime(),
           getCleanupInterval(),
-          getChannelPickStrategy());
+          getChannelPickStrategy(),
+          getChannelPrimer(),
+          getChannelPrimeTimeout(),
+          getChannelPrimeMaxAttempts());
     }
 
     public static class Builder {
@@ -381,6 +407,9 @@ public class GcpManagedChannelOptions {
       private Duration drainIdleGrace = Duration.ofMinutes(1);
       private int errorPenaltyStep = 5;
       private Duration errorPenaltyDuration = Duration.ofSeconds(5);
+      @Nullable private GcpChannelPrimer channelPrimer;
+      private Duration channelPrimeTimeout = Duration.ofSeconds(10);
+      private int channelPrimeMaxAttempts = 3;
       private int concurrentStreamsLowWatermark = GcpManagedChannel.DEFAULT_MAX_STREAM;
       private boolean useRoundRobinOnBind = false;
       private Duration affinityKeyLifetime = Duration.ZERO;
@@ -407,6 +436,9 @@ public class GcpManagedChannelOptions {
         this.drainIdleGrace = options.getDrainIdleGrace();
         this.errorPenaltyStep = options.getErrorPenaltyStep();
         this.errorPenaltyDuration = options.getErrorPenaltyDuration();
+        this.channelPrimer = options.getChannelPrimer();
+        this.channelPrimeTimeout = options.getChannelPrimeTimeout();
+        this.channelPrimeMaxAttempts = options.getChannelPrimeMaxAttempts();
         this.concurrentStreamsLowWatermark = options.getConcurrentStreamsLowWatermark();
         this.useRoundRobinOnBind = options.isUseRoundRobinOnBind();
         this.affinityKeyLifetime = options.getAffinityKeyLifetime();
@@ -578,6 +610,49 @@ public class GcpManagedChannelOptions {
               "Error penalty duration must fit in nanoseconds.", failure);
         }
         this.errorPenaltyDuration = errorPenaltyDuration;
+        return this;
+      }
+
+      /**
+       * Sets the optional hook that primes newly built scale-up channels concurrently. Only
+       * channels added by dynamic scale-up are primed; the initial pool and non-dynamic growth are
+       * published as soon as they are built. Each scale-up channel is published individually when
+       * its own primer future succeeds. A {@code null} primer disables priming and preserves the
+       * existing scale-up path.
+       */
+      public Builder setChannelPrimer(@Nullable GcpChannelPrimer channelPrimer) {
+        this.channelPrimer = channelPrimer;
+        return this;
+      }
+
+      /**
+       * Sets the maximum time allowed for each channel-primer attempt, including the synchronous
+       * call to the primer. Zero uses the 10-second default.
+       */
+      public Builder setChannelPrimeTimeout(Duration channelPrimeTimeout) {
+        Preconditions.checkNotNull(channelPrimeTimeout, "Channel prime timeout must not be null.");
+        Preconditions.checkArgument(
+            !channelPrimeTimeout.isNegative(), "Channel prime timeout must not be negative.");
+        Duration timeout =
+            channelPrimeTimeout.isZero() ? Duration.ofSeconds(10) : channelPrimeTimeout;
+        try {
+          timeout.toNanos();
+        } catch (ArithmeticException failure) {
+          throw new IllegalArgumentException(
+              "Channel prime timeout must fit in nanoseconds.", failure);
+        }
+        this.channelPrimeTimeout = timeout;
+        return this;
+      }
+
+      /**
+       * Sets the maximum number of attempts to prime one scaled-up channel. Zero uses the default
+       * of 3. Retry backoff is exponential from 100 ms and capped at 5 s.
+       */
+      public Builder setChannelPrimeMaxAttempts(int channelPrimeMaxAttempts) {
+        Preconditions.checkArgument(
+            channelPrimeMaxAttempts >= 0, "Channel prime max attempts must not be negative.");
+        this.channelPrimeMaxAttempts = channelPrimeMaxAttempts == 0 ? 3 : channelPrimeMaxAttempts;
         return this;
       }
 

--- a/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpMetricsConstants.java
+++ b/grpc-gcp-java/src/main/java/com/google/cloud/grpc/GcpMetricsConstants.java
@@ -77,4 +77,5 @@ class GcpMetricsConstants {
   public static String METRIC_ENDPOINT_SWITCH = "endpoint_switch";
   public static String METRIC_CURRENT_ENDPOINT = "current_endpoint";
   public static String METRIC_CHANNEL_POOL_SCALING = "channel_pool_scaling";
+  public static String METRIC_SCALE_UP_PRIME_FAILURES = "scale_up_prime_failures";
 }

--- a/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpChannelPrimeControllerTest.java
+++ b/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpChannelPrimeControllerTest.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.ManagedChannel;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Direct {@link GcpChannelPrimeController} tests for the interleavings a pool-level test cannot
+ * force: they hand the controller a scheduler whose timers never fire on their own, so a test can
+ * run the timeout of an attempt at a moment of its choosing.
+ */
+@RunWith(JUnit4.class)
+public final class GcpChannelPrimeControllerTest {
+  private final ExecutorService stateExecutor = Executors.newSingleThreadExecutor();
+  private final RecordingScheduler scheduler = new RecordingScheduler();
+  private final Object lock = new Object();
+  private final FakePool pool = new FakePool(lock);
+
+  @After
+  public void tearDown() {
+    scheduler.shutdownNow();
+    stateExecutor.shutdownNow();
+  }
+
+  @Test
+  public void poolCallbacksObserveTheLockContract() throws Exception {
+    AtomicInteger primeCalls = new AtomicInteger();
+    GcpChannelPrimer primer =
+        channel ->
+            primeCalls.incrementAndGet() == 1
+                ? Futures.immediateFailedFuture(new IllegalStateException("prime failed"))
+                : Futures.immediateVoidFuture();
+    GcpChannelPrimeController controller = newController(primer, 1);
+
+    controller.startPrime(newChannel());
+    awaitCondition(() -> pool.failures.size() == 1);
+    controller.startPrime(newChannel());
+    awaitCondition(() -> pool.published.size() == 1);
+
+    assertThat(pool.lockViolations).isEmpty();
+    assertThat(pool.abandonReports.get()).isEqualTo(0);
+    synchronized (lock) {
+      assertThat(controller.inFlightCount()).isEqualTo(0);
+    }
+  }
+
+  @Test
+  public void timeoutAfterPrimeReturnsCancelsTheLateFutureAndRetries() throws Exception {
+    CountDownLatch primerEntered = new CountDownLatch(1);
+    CountDownLatch releasePrimer = new CountDownLatch(1);
+    SettableFuture<Void> lateFuture = SettableFuture.create();
+    AtomicInteger primeCalls = new AtomicInteger();
+    AtomicReference<Thread> primerThread = new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          if (primeCalls.incrementAndGet() > 1) {
+            return Futures.immediateVoidFuture();
+          }
+          primerThread.set(Thread.currentThread());
+          primerEntered.countDown();
+          awaitUninterruptibly(releasePrimer);
+          return lateFuture;
+        };
+    GcpChannelPrimeController controller = newController(primer, 3);
+    FakeChannel channel = newChannel();
+
+    controller.startPrime(channel);
+    assertThat(primerEntered.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(scheduler.tasks).hasSize(1);
+    Runnable timeout = scheduler.tasks.get(0);
+
+    try {
+      synchronized (lock) {
+        // prime() returns while this thread holds the pool lock, so the primer thread parks on
+        // the monitor before it can record the returned future.
+        releasePrimer.countDown();
+        awaitCondition(() -> primerThread.get().getState() == Thread.State.BLOCKED);
+        // The timeout wins that race. prime() has returned, so this is an ordinary timed-out
+        // attempt: it must not be abandoned without a retry.
+        timeout.run();
+        assertThat(controller.abandonedCount()).isEqualTo(0);
+        assertThat(controller.inFlightCount()).isEqualTo(1);
+      }
+    } finally {
+      releasePrimer.countDown();
+    }
+
+    // The primer thread then sees the attempt has moved on and cancels the late future.
+    awaitCondition(lateFuture::isCancelled);
+    assertThat(pool.abandonReports.get()).isEqualTo(0);
+    assertThat(pool.failures).isEmpty();
+    assertThat(channel.isShutdown()).isFalse();
+    awaitCondition(() -> scheduler.tasks.size() == 2);
+    Runnable retry = scheduler.tasks.get(1);
+
+    retry.run();
+
+    awaitCondition(() -> pool.published.size() == 1);
+    assertThat(pool.published.get(0)).isSameInstanceAs(channel);
+    assertThat(primeCalls.get()).isEqualTo(2);
+    assertThat(pool.lockViolations).isEmpty();
+  }
+
+  @Test
+  public void timeoutBeforePrimeEntryRefusesTheExpiredAttempt() throws Exception {
+    CountDownLatch timeoutArmed = new CountDownLatch(1);
+    AtomicInteger primeCalls = new AtomicInteger();
+    AtomicReference<Thread> primerThread = new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          primeCalls.incrementAndGet();
+          return Futures.immediateVoidFuture();
+        };
+    GcpChannelPrimeController controller = newController(primer, 1);
+    FakeChannel channel = newChannel();
+    // Arming the timeout is the primer thread's last step under the pool lock before it enters
+    // prime(). Park it there with the lock released, exactly as if it had been descheduled between
+    // dropping the lock and entering prime(), until the test lets it go.
+    scheduler.onSchedule =
+        () -> {
+          primerThread.set(Thread.currentThread());
+          timeoutArmed.countDown();
+          synchronized (lock) {
+            while (!scheduler.releaseParkedThread) {
+              awaitUninterruptibly(lock);
+            }
+          }
+        };
+
+    controller.startPrime(channel);
+    assertThat(timeoutArmed.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(scheduler.tasks).hasSize(1);
+    // The timeout wins that race: it runs to completion, releasing the slot and closing the
+    // channel, before the primer thread gets to move on.
+    scheduler.execute(scheduler.tasks.get(0));
+    awaitCondition(() -> pool.failures.size() == 1);
+    assertThat(channel.isShutdown()).isTrue();
+    synchronized (lock) {
+      assertThat(controller.inFlightCount()).isEqualTo(0);
+      assertThat(controller.abandonedCount()).isEqualTo(0);
+      scheduler.releaseParkedThread = true;
+      lock.notifyAll();
+    }
+
+    // The primer thread then finds its attempt expired and returns to the pool without ever
+    // calling prime(): idle pool threads wait on a timed poll, unlike a parked or blocked primer.
+    awaitCondition(
+        () -> {
+          Thread.State state = primerThread.get().getState();
+          return state == Thread.State.TIMED_WAITING || state == Thread.State.TERMINATED;
+        });
+    assertThat(primeCalls.get()).isEqualTo(0);
+    assertThat(pool.failures).hasSize(1);
+    assertThat(pool.abandonReports.get()).isEqualTo(0);
+    assertThat(pool.published).isEmpty();
+    assertThat(scheduler.tasks).hasSize(1);
+    synchronized (lock) {
+      assertThat(controller.primingCount()).isEqualTo(0);
+    }
+    assertThat(pool.lockViolations).isEmpty();
+  }
+
+  @Test
+  public void timeoutWhileBlockedInPrimeAbandonsAndReportsOutsideTheLock() throws Exception {
+    CountDownLatch primerEntered = new CountDownLatch(1);
+    CountDownLatch releasePrimer = new CountDownLatch(1);
+    SettableFuture<Void> lateFuture = SettableFuture.create();
+    GcpChannelPrimer primer =
+        channel -> {
+          primerEntered.countDown();
+          awaitUninterruptibly(releasePrimer);
+          return lateFuture;
+        };
+    GcpChannelPrimeController controller = newController(primer, 3);
+    FakeChannel channel = newChannel();
+
+    controller.startPrime(channel);
+    assertThat(primerEntered.await(5, TimeUnit.SECONDS)).isTrue();
+    try {
+      scheduler.tasks.get(0).run();
+
+      assertThat(pool.abandonReports.get()).isEqualTo(1);
+      assertThat(pool.failures).hasSize(1);
+      assertThat(channel.isShutdown()).isTrue();
+      assertThat(scheduler.tasks).hasSize(1);
+      synchronized (lock) {
+        assertThat(controller.abandonedCount()).isEqualTo(1);
+        assertThat(controller.inFlightCount()).isEqualTo(0);
+      }
+    } finally {
+      releasePrimer.countDown();
+    }
+    awaitCondition(lateFuture::isCancelled);
+    synchronized (lock) {
+      assertThat(controller.abandonedCount()).isEqualTo(0);
+    }
+    assertThat(pool.lockViolations).isEmpty();
+  }
+
+  @Test
+  public void timeoutWhileBlockedInPrimeDuringShutdownDoesNotReportAbandoning() throws Exception {
+    CountDownLatch primerEntered = new CountDownLatch(1);
+    CountDownLatch releasePrimer = new CountDownLatch(1);
+    SettableFuture<Void> lateFuture = SettableFuture.create();
+    GcpChannelPrimer primer =
+        channel -> {
+          primerEntered.countDown();
+          awaitUninterruptibly(releasePrimer);
+          return lateFuture;
+        };
+    GcpChannelPrimeController controller = newController(primer, 3);
+    FakeChannel channel = newChannel();
+
+    controller.startPrime(channel);
+    assertThat(primerEntered.await(5, TimeUnit.SECONDS)).isTrue();
+    try {
+      pool.shuttingDown = true;
+      scheduler.tasks.get(0).run();
+
+      assertThat(pool.abandonReports.get()).isEqualTo(0);
+      assertThat(pool.failures).isEmpty();
+      assertThat(channel.isShutdown()).isTrue();
+      synchronized (lock) {
+        assertThat(controller.abandonedCount()).isEqualTo(0);
+        assertThat(controller.inFlightCount()).isEqualTo(0);
+      }
+    } finally {
+      releasePrimer.countDown();
+    }
+    awaitCondition(lateFuture::isCancelled);
+    assertThat(pool.lockViolations).isEmpty();
+  }
+
+  private GcpChannelPrimeController newController(GcpChannelPrimer primer, int maxAttempts) {
+    return new GcpChannelPrimeController(
+        lock, pool, primer, TimeUnit.SECONDS.toNanos(5), maxAttempts, scheduler);
+  }
+
+  private FakeChannel newChannel() {
+    return new FakeChannel(stateExecutor);
+  }
+
+  private static void awaitCondition(Callable<Boolean> condition) {
+    await().atMost(Duration.ofSeconds(5)).until(condition);
+  }
+
+  private static void awaitUninterruptibly(CountDownLatch latch) {
+    boolean interrupted = false;
+    while (true) {
+      try {
+        latch.await();
+        break;
+      } catch (InterruptedException failure) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * One {@link Object#wait()} on {@code monitor}, which the caller must hold; may wake spuriously.
+   */
+  private static void awaitUninterruptibly(Object monitor) {
+    try {
+      monitor.wait();
+    } catch (InterruptedException failure) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static final class FakeChannel extends GcpManagedChannelTest.FakeManagedChannel {
+    FakeChannel(ExecutorService exec) {
+      super(exec);
+    }
+  }
+
+  /** Records every pool callback together with whether it honored its lock contract. */
+  private static final class FakePool implements GcpChannelPrimeController.Pool {
+    private final Object lock;
+    volatile boolean shuttingDown;
+    volatile boolean full;
+    final List<ManagedChannel> published = new CopyOnWriteArrayList<>();
+    final List<Throwable> failures = new CopyOnWriteArrayList<>();
+    final AtomicInteger abandonReports = new AtomicInteger();
+    final List<String> lockViolations = new CopyOnWriteArrayList<>();
+
+    FakePool(Object lock) {
+      this.lock = lock;
+    }
+
+    @Override
+    public boolean isShuttingDown() {
+      expectLock("isShuttingDown", true);
+      return shuttingDown;
+    }
+
+    @Override
+    public boolean isFull() {
+      expectLock("isFull", true);
+      return full;
+    }
+
+    @Override
+    public void addPrimedChannel(ManagedChannel channel) {
+      expectLock("addPrimedChannel", true);
+      published.add(channel);
+    }
+
+    @Override
+    public void reportPrimeFailure(Throwable failure) {
+      expectLock("reportPrimeFailure", false);
+      failures.add(failure);
+    }
+
+    @Override
+    public void reportPrimeAbandoned() {
+      expectLock("reportPrimeAbandoned", false);
+      abandonReports.incrementAndGet();
+    }
+
+    private void expectLock(String method, boolean held) {
+      if (Thread.holdsLock(lock) != held) {
+        lockViolations.add(
+            method + (held ? " called without the pool lock" : " called under the pool lock"));
+      }
+    }
+  }
+
+  /**
+   * Runs immediate work on a real thread but only records delayed tasks, leaving it to the test to
+   * run a timeout or retry at the moment under test.
+   */
+  private static final class RecordingScheduler implements ScheduledExecutorService {
+    private final ScheduledExecutorService delegate = Executors.newSingleThreadScheduledExecutor();
+    final List<Runnable> tasks = new CopyOnWriteArrayList<>();
+    // Runs on the scheduling thread once a delayed task is recorded, so a test can park that
+    // thread at the moment it arms a timeout.
+    @Nullable volatile Runnable onSchedule;
+    // Guarded by the test's pool lock: set under it and announced with notifyAll().
+    boolean releaseParkedThread;
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+      tasks.add(command);
+      Runnable hook = onSchedule;
+      if (hook != null) {
+        hook.run();
+      }
+      return delegate.schedule(() -> {}, 365, TimeUnit.DAYS);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(
+        Runnable command, long initialDelay, long period, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(
+        Runnable command, long initialDelay, long delay, TimeUnit unit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      delegate.execute(command);
+    }
+
+    @Override
+    public void shutdown() {
+      delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+      return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> java.util.concurrent.Future<T> submit(Callable<T> task) {
+      return delegate.submit(task);
+    }
+
+    @Override
+    public <T> java.util.concurrent.Future<T> submit(Runnable task, T result) {
+      return delegate.submit(task, result);
+    }
+
+    @Override
+    public java.util.concurrent.Future<?> submit(Runnable task) {
+      return delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(
+        java.util.Collection<? extends Callable<T>> tasks) throws InterruptedException {
+      return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<java.util.concurrent.Future<T>> invokeAll(
+        java.util.Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+        throws InterruptedException {
+      return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(java.util.Collection<? extends Callable<T>> tasks)
+        throws InterruptedException, java.util.concurrent.ExecutionException {
+      return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(
+        java.util.Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+        throws InterruptedException,
+            java.util.concurrent.ExecutionException,
+            java.util.concurrent.TimeoutException {
+      return delegate.invokeAny(tasks, timeout, unit);
+    }
+  }
+}

--- a/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelOptionsTest.java
+++ b/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelOptionsTest.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpChannelPoolOptions;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpMetricsOptions;
 import com.google.cloud.grpc.GcpManagedChannelOptions.GcpResiliencyOptions;
+import com.google.common.util.concurrent.Futures;
+import io.grpc.ManagedChannel;
 import io.opencensus.metrics.LabelKey;
 import io.opencensus.metrics.LabelValue;
 import io.opencensus.metrics.MetricRegistry;
@@ -217,11 +219,26 @@ public final class GcpManagedChannelOptionsTest {
     assertThat(defaults.getMaxScaleUpPercent()).isEqualTo(30);
     assertThat(defaults.getErrorPenaltyStep()).isEqualTo(5);
     assertThat(defaults.getErrorPenaltyDuration()).isEqualTo(Duration.ofSeconds(5));
+    assertThat(defaults.getChannelPrimer()).isNull();
+    assertThat(defaults.getChannelPrimeTimeout()).isEqualTo(Duration.ofSeconds(10));
+    assertThat(defaults.getChannelPrimeMaxAttempts()).isEqualTo(3);
 
     GcpChannelPoolOptions copiedDefaults = GcpChannelPoolOptions.newBuilder(defaults).build();
     assertThat(copiedDefaults.getErrorPenaltyStep()).isEqualTo(5);
     assertThat(copiedDefaults.getErrorPenaltyDuration()).isEqualTo(Duration.ofSeconds(5));
     assertThat(copiedDefaults.toString()).contains("errorPenaltyStep: 5");
+    GcpChannelPoolOptions zeroValues =
+        GcpChannelPoolOptions.newBuilder()
+            .setChannelPrimeTimeout(Duration.ZERO)
+            .setChannelPrimeMaxAttempts(0)
+            .build();
+    assertThat(zeroValues.getChannelPrimeTimeout()).isEqualTo(Duration.ofSeconds(10));
+    assertThat(zeroValues.getChannelPrimeMaxAttempts()).isEqualTo(3);
+    GcpChannelPoolOptions copiedZeroValues = GcpChannelPoolOptions.newBuilder(zeroValues).build();
+    assertThat(copiedZeroValues.getChannelPrimeTimeout()).isEqualTo(Duration.ofSeconds(10));
+    assertThat(copiedZeroValues.getChannelPrimeMaxAttempts()).isEqualTo(3);
+    assertThat(copiedZeroValues.toString()).contains("channelPrimeTimeout: PT10S");
+    assertThat(copiedZeroValues.toString()).contains("channelPrimeMaxAttempts: 3");
 
     GcpChannelPoolOptions configured =
         GcpChannelPoolOptions.newBuilder(defaults)
@@ -261,6 +278,17 @@ public final class GcpManagedChannelOptionsTest {
         () ->
             GcpChannelPoolOptions.newBuilder()
                 .setErrorPenaltyDuration(Duration.ofSeconds(Long.MAX_VALUE)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> GcpChannelPoolOptions.newBuilder().setChannelPrimeTimeout(Duration.ofNanos(-1)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            GcpChannelPoolOptions.newBuilder()
+                .setChannelPrimeTimeout(Duration.ofSeconds(Long.MAX_VALUE)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> GcpChannelPoolOptions.newBuilder().setChannelPrimeMaxAttempts(-1));
   }
 
   @Test
@@ -285,6 +313,28 @@ public final class GcpManagedChannelOptionsTest {
     assertThat(options).contains("affinityKeyLifetime:");
     assertThat(options).contains("cleanupInterval:");
     assertThat(options).contains("channelPickStrategy:");
+    assertThat(options).contains("channelPrimer:");
+    assertThat(options).contains("channelPrimeTimeout:");
+    assertThat(options).contains("channelPrimeMaxAttempts:");
+  }
+
+  @Test
+  public void channelPrimerOptionsSurviveCopy() {
+    GcpChannelPrimer primer = (ManagedChannel channel) -> Futures.immediateVoidFuture();
+    GcpChannelPoolOptions configured =
+        GcpChannelPoolOptions.newBuilder()
+            .setChannelPrimer(primer)
+            .setChannelPrimeTimeout(Duration.ofSeconds(7))
+            .setChannelPrimeMaxAttempts(2)
+            .build();
+
+    GcpChannelPoolOptions copied = GcpChannelPoolOptions.newBuilder(configured).build();
+
+    assertThat(copied.getChannelPrimer()).isSameInstanceAs(primer);
+    assertThat(copied.getChannelPrimeTimeout()).isEqualTo(Duration.ofSeconds(7));
+    assertThat(copied.getChannelPrimeMaxAttempts()).isEqualTo(2);
+    assertThat(copied.toString()).contains("channelPrimeTimeout: PT7S");
+    assertThat(copied.toString()).contains("channelPrimeMaxAttempts: 2");
   }
 
   @Test

--- a/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelOtelMetricsTest.java
+++ b/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelOtelMetricsTest.java
@@ -98,5 +98,11 @@ public class GcpManagedChannelOtelMetricsTest {
         names.stream()
             .anyMatch(
                 n -> n.equals("test/grpc-gcp/" + GcpMetricsConstants.METRIC_MAX_READY_CHANNELS)));
+    assertTrue(
+        names.stream()
+            .anyMatch(
+                n ->
+                    n.equals(
+                        "test/grpc-gcp/" + GcpMetricsConstants.METRIC_SCALE_UP_PRIME_FAILURES)));
   }
 }

--- a/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelPrimerTest.java
+++ b/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelPrimerTest.java
@@ -25,8 +25,11 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.ConnectivityState;
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -36,6 +39,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -324,6 +331,7 @@ public final class GcpManagedChannelPrimerTest {
     AtomicInteger primeCalls = new AtomicInteger();
     AtomicReference<String> primerThread = new AtomicReference<>();
     AtomicReference<GcpManagedChannelTest.FakeManagedChannel> rejected = new AtomicReference<>();
+    AbandonWarnings warnings = new AbandonWarnings();
     GcpChannelPrimer primer =
         channel -> {
           if (primeCalls.incrementAndGet() > 1) {
@@ -332,30 +340,19 @@ public final class GcpManagedChannelPrimerTest {
           primerThread.set(Thread.currentThread().getName());
           rejected.set((GcpManagedChannelTest.FakeManagedChannel) channel);
           primerEntered.countDown();
-          boolean interrupted = false;
-          while (true) {
-            try {
-              releasePrimer.await();
-              break;
-            } catch (InterruptedException failure) {
-              interrupted = true;
-            }
-          }
-          if (interrupted) {
-            Thread.currentThread().interrupt();
-          }
+          awaitUninterruptibly(releasePrimer);
           return lateFuture;
         };
-    pool = newPrimedPool(primer, Duration.ofMillis(20), 3, builder());
-    AtomicLong clock = new AtomicLong(1);
-    pool.setNanoClock(clock::get);
-    ChannelRef hot = pool.channelRefs.get(0);
-    hot.setActiveStreamsForTest(6);
-
-    hot.activeStreamsCountIncr();
-
-    assertThat(primerEntered.await(5, TimeUnit.SECONDS)).isTrue();
     try {
+      pool = newPrimedPool(primer, Duration.ofMillis(20), 3, builder());
+      AtomicLong clock = new AtomicLong(1);
+      pool.setNanoClock(clock::get);
+      ChannelRef hot = pool.channelRefs.get(0);
+      hot.setActiveStreamsForTest(6);
+
+      hot.activeStreamsCountIncr();
+
+      assertThat(primerEntered.await(5, TimeUnit.SECONDS)).isTrue();
       // A primer blocked inside prime() fails at the timeout and is not retried: nothing can stop
       // the running call and a fresh attempt would overlap it on the same channel.
       awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
@@ -369,26 +366,103 @@ public final class GcpManagedChannelPrimerTest {
       // While the call is still blocked it keeps its scale-up slot, so the pool (2 of 3) does not
       // build another delegate and hand it to the same stuck primer.
       assertThat(pool.abandonedPrimeCountForTest()).isEqualTo(1);
+      // Abandoning is invisible to the application, so it is also logged as a warning, attributed
+      // to the pool like every other prime warning.
+      assertThat(warnings.messages()).hasSize(1);
+      assertThat(warnings.messages().get(0)).startsWith("pool-");
+      assertThat(warnings.messages().get(0)).contains("still blocked at the timeout");
       clock.incrementAndGet();
       hot.activeStreamsCountIncr();
       awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
       assertThat(primeCalls.get()).isEqualTo(1);
       assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(0);
+      releasePrimer.countDown();
+
+      // Once the blocked call returns, its late future is cancelled without publishing, the slot
+      // is released, and the next scale-up primes a fresh delegate.
+      awaitCondition(lateFuture::isCancelled);
+      awaitCondition(() -> pool.abandonedPrimeCountForTest() == 0);
+      assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+      assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(0);
+      clock.incrementAndGet();
+      hot.activeStreamsCountIncr();
+      awaitCondition(() -> pool.getNumberOfChannels() == 3);
+      assertThat(primeCalls.get()).isEqualTo(2);
+      assertThat(pool.scaleUpPrimeFailuresForTest()).isEqualTo(1);
+      assertThat(warnings.messages()).hasSize(1);
     } finally {
       releasePrimer.countDown();
+      warnings.close();
     }
+  }
 
-    // Once the blocked call returns, its late future is cancelled without publishing, the slot is
-    // released, and the next scale-up primes a fresh delegate.
-    awaitCondition(lateFuture::isCancelled);
-    awaitCondition(() -> pool.abandonedPrimeCountForTest() == 0);
-    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
-    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(0);
-    clock.incrementAndGet();
+  @Test
+  public void shutdownDuringBlockedPrimeDoesNotWarnAboutAbandoning() throws Exception {
+    CountDownLatch primerEntered = new CountDownLatch(1);
+    CountDownLatch releasePrimer = new CountDownLatch(1);
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> primingChannel =
+        new AtomicReference<>();
+    AbandonWarnings warnings = new AbandonWarnings();
+    GcpChannelPrimer primer =
+        channel -> {
+          primingChannel.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+          primerEntered.countDown();
+          awaitUninterruptibly(releasePrimer);
+          return Futures.immediateVoidFuture();
+        };
+    try {
+      pool = newPrimedPool(primer, Duration.ofSeconds(5), 3, builder());
+      ChannelRef hot = pool.channelRefs.get(0);
+      hot.setActiveStreamsForTest(6);
+      hot.activeStreamsCountIncr();
+      assertThat(primerEntered.await(5, TimeUnit.SECONDS)).isTrue();
+
+      pool.shutdownNow();
+
+      awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+      assertThat(primingChannel.get().isShutdown()).isTrue();
+      releasePrimer.countDown();
+      awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+      // Shutdown closes the priming channel without abandoning it: no slot stays occupied and
+      // nothing is logged about a blocked call.
+      assertThat(pool.abandonedPrimeCountForTest()).isEqualTo(0);
+      assertThat(pool.scaleUpPrimeFailuresForTest()).isEqualTo(0);
+      assertThat(warnings.messages()).isEmpty();
+      assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+    } finally {
+      releasePrimer.countDown();
+      warnings.close();
+    }
+  }
+
+  @Test
+  public void primedChannelIsPublishedUnderPoolMonitor() throws Exception {
+    SettableFuture<Void> primeFuture = SettableFuture.create();
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> primingChannel =
+        new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          primingChannel.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+          return primeFuture;
+        };
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
     hot.activeStreamsCountIncr();
+    awaitCondition(() -> primingChannel.get() != null);
+    awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+
+    // The controller guards its state with the pool's own monitor, so while this thread holds
+    // it a completed prime cannot be published or even leave the in-flight set.
+    synchronized (pool) {
+      primeFuture.set(null);
+      Thread.sleep(200);
+      assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(1);
+      assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+    }
     awaitCondition(() -> pool.getNumberOfChannels() == 3);
-    assertThat(primeCalls.get()).isEqualTo(2);
-    assertThat(pool.scaleUpPrimeFailuresForTest()).isEqualTo(1);
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(0);
   }
 
   @Test
@@ -467,35 +541,78 @@ public final class GcpManagedChannelPrimerTest {
   public void primerRetriesExhaustedRejectsChannel() throws Exception {
     AtomicInteger primeCalls = new AtomicInteger();
     AtomicReference<GcpManagedChannelTest.FakeManagedChannel> rejected = new AtomicReference<>();
+    AbandonWarnings warnings = new AbandonWarnings();
     GcpChannelPrimer primer =
         channel -> {
           rejected.set((GcpManagedChannelTest.FakeManagedChannel) channel);
           primeCalls.incrementAndGet();
           return Futures.immediateFailedFuture(new IllegalStateException("prime failed"));
         };
-    pool = newPrimedPool(primer, Duration.ofSeconds(5), 3, builder());
-    ChannelRef hot = pool.channelRefs.get(0);
-    hot.setActiveStreamsForTest(6);
+    try {
+      pool = newPrimedPool(primer, Duration.ofSeconds(5), 3, builder());
+      ChannelRef hot = pool.channelRefs.get(0);
+      hot.setActiveStreamsForTest(6);
 
-    hot.activeStreamsCountIncr();
+      hot.activeStreamsCountIncr();
 
-    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
-    assertThat(primeCalls.get()).isEqualTo(3);
-    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
-    awaitCondition(() -> rejected.get() != null && rejected.get().isShutdown());
+      awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+      assertThat(primeCalls.get()).isEqualTo(3);
+      assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+      awaitCondition(() -> rejected.get() != null && rejected.get().isShutdown());
+      // Exhausting the attempts is an ordinary failure: the slot is released and nothing warns
+      // about a blocked call.
+      assertThat(pool.abandonedPrimeCountForTest()).isEqualTo(0);
+      assertThat(warnings.messages()).isEmpty();
+    } finally {
+      warnings.close();
+    }
   }
 
   @Test
   public void primerBackoffIsCappedForManyAttempts() {
-    List<Long> backoffs = new CopyOnWriteArrayList<>();
+    List<Long> bases = new CopyOnWriteArrayList<>();
+    List<Long> minDelays = new CopyOnWriteArrayList<>();
+    List<Long> maxDelays = new CopyOnWriteArrayList<>();
 
     for (int attempt = 0; attempt < 49; attempt++) {
-      backoffs.add(GcpManagedChannel.primeBackoffMillisForTest(attempt));
+      bases.add(GcpManagedChannel.primeBaseBackoffMillisForTest(attempt));
+      minDelays.add(GcpManagedChannel.primeBackoffMillisForTest(attempt, bound -> 0L));
+      maxDelays.add(GcpManagedChannel.primeBackoffMillisForTest(attempt, bound -> bound - 1));
     }
 
-    assertThat(backoffs).hasSize(49);
-    assertThat(backoffs.stream().mapToLong(Long::longValue).max().orElse(0)).isAtMost(5_000L);
-    assertThat(backoffs.stream().mapToLong(Long::longValue).sum()).isEqualTo(221_300L);
+    assertThat(bases).hasSize(49);
+    assertThat(bases.subList(0, 6))
+        .containsExactly(100L, 200L, 400L, 800L, 1_600L, 3_200L)
+        .inOrder();
+    assertThat(bases.subList(6, 49)).containsExactlyElementsIn(Collections.nCopies(43, 5_000L));
+    assertThat(bases.stream().mapToLong(Long::longValue).sum()).isEqualTo(221_300L);
+    assertThat(minDelays.subList(6, 49)).containsExactlyElementsIn(Collections.nCopies(43, 2_500L));
+    assertThat(maxDelays.subList(6, 49)).containsExactlyElementsIn(Collections.nCopies(43, 4_999L));
+    assertThat(maxDelays.stream().mapToLong(Long::longValue).max().orElse(0)).isAtMost(5_000L);
+  }
+
+  @Test
+  public void primerBackoffAppliesEqualJitter() {
+    for (int attempt = 0; attempt < 20; attempt++) {
+      long base = GcpManagedChannel.primeBaseBackoffMillisForTest(attempt);
+      long half = base / 2;
+      assertThat(GcpManagedChannel.primeBackoffMillisForTest(attempt, bound -> 0L)).isEqualTo(half);
+      assertThat(GcpManagedChannel.primeBackoffMillisForTest(attempt, bound -> 7L))
+          .isEqualTo(half + 7L);
+      assertThat(GcpManagedChannel.primeBackoffMillisForTest(attempt, bound -> bound - 1))
+          .isEqualTo(base - 1);
+      for (int sample = 0; sample < 50; sample++) {
+        long delay = GcpManagedChannel.primeBackoffMillisForTest(attempt);
+        assertThat(delay).isAtLeast(half);
+        assertThat(delay).isLessThan(base);
+      }
+    }
+
+    Set<Long> distinct = new HashSet<>();
+    for (int sample = 0; sample < 200; sample++) {
+      distinct.add(GcpManagedChannel.primeBackoffMillisForTest(10));
+    }
+    assertThat(distinct.size()).isGreaterThan(1);
   }
 
   @Test
@@ -594,5 +711,50 @@ public final class GcpManagedChannelPrimerTest {
 
   private static void awaitCondition(java.util.concurrent.Callable<Boolean> condition) {
     await().atMost(Duration.ofSeconds(5)).until(condition);
+  }
+
+  private static void awaitUninterruptibly(CountDownLatch latch) {
+    boolean interrupted = false;
+    while (true) {
+      try {
+        latch.await();
+        break;
+      } catch (InterruptedException failure) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /** Captures the pool's abandoned-prime warnings for as long as it is open. */
+  private static final class AbandonWarnings extends Handler {
+    private static final Logger poolLogger = Logger.getLogger(GcpManagedChannel.class.getName());
+    private final List<String> messages = new CopyOnWriteArrayList<>();
+
+    AbandonWarnings() {
+      poolLogger.addHandler(this);
+    }
+
+    List<String> messages() {
+      return messages;
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+      if (record.getLevel().intValue() >= Level.WARNING.intValue()
+          && record.getMessage().contains("priming abandoned")) {
+        messages.add(record.getMessage());
+      }
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {
+      poolLogger.removeHandler(this);
+    }
   }
 }

--- a/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelPrimerTest.java
+++ b/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelPrimerTest.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.grpc;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.google.cloud.grpc.GcpManagedChannel.ChannelRef;
+import com.google.cloud.grpc.GcpManagedChannelOptions.GcpChannelPoolOptions;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.ConnectivityState;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Channel-primer behavior tests. */
+@RunWith(JUnit4.class)
+public final class GcpManagedChannelPrimerTest {
+  private final ExecutorService stateExecutor = Executors.newSingleThreadExecutor();
+  private GcpManagedChannel pool;
+
+  @After
+  public void tearDown() {
+    if (pool != null) {
+      pool.shutdownNow();
+    }
+    stateExecutor.shutdownNow();
+  }
+
+  @Test
+  public void successfulPrimerDelaysPublicationAndRunsOnBackgroundWorker() throws Exception {
+    SettableFuture<Void> primeFuture = SettableFuture.create();
+    AtomicReference<String> primerThread = new AtomicReference<>();
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> primingChannel =
+        new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          primerThread.set(Thread.currentThread().getName());
+          primingChannel.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+          return primeFuture;
+        };
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+
+    awaitCondition(() -> primingChannel.get() != null);
+    awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(1);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+    assertThat(primerThread.get()).startsWith("gcp-mc-prime-");
+    primeFuture.set(null);
+    awaitCondition(() -> pool.getNumberOfChannels() == 3);
+  }
+
+  @Test
+  public void scaleUpStartsAllChannelPrimersConcurrently() throws Exception {
+    CountDownLatch allPrimersStarted = new CountDownLatch(3);
+    List<SettableFuture<Void>> primeFutures = new CopyOnWriteArrayList<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          SettableFuture<Void> future = SettableFuture.create();
+          primeFutures.add(future);
+          allPrimersStarted.countDown();
+          return future;
+        };
+    pool = newPrimedPool(10, 13, primer, Duration.ofSeconds(5), 1, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(99);
+
+    hot.activeStreamsCountIncr();
+
+    assertThat(allPrimersStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(3);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(10);
+    primeFutures.forEach(future -> future.set(null));
+    awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+    awaitCondition(() -> pool.getNumberOfChannels() == 13);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(13);
+  }
+
+  @Test
+  public void secondScaleUpCountsChannelsStillPriming() throws Exception {
+    AtomicInteger builtChannels = new AtomicInteger();
+    List<SettableFuture<Void>> primeFutures = new CopyOnWriteArrayList<>();
+    GcpManagedChannelTest.FakeManagedChannelBuilder delegate =
+        new GcpManagedChannelTest.FakeManagedChannelBuilder(
+            () -> {
+              builtChannels.incrementAndGet();
+              return new GcpManagedChannelTest.FakeManagedChannel(stateExecutor);
+            });
+    GcpChannelPrimer primer =
+        channel -> {
+          SettableFuture<Void> future = SettableFuture.create();
+          primeFutures.add(future);
+          return future;
+        };
+    pool = newPrimedPool(2, 4, primer, Duration.ofSeconds(5), 1, delegate);
+    AtomicLong clock = new AtomicLong(1);
+    pool.setNanoClock(clock::get);
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+    awaitCondition(() -> primeFutures.size() == 2);
+    awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(2);
+
+    clock.incrementAndGet();
+    hot.activeStreamsCountIncr();
+    awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+
+    assertThat(builtChannels.get()).isEqualTo(4);
+    assertThat(primeFutures).hasSize(2);
+    assertThat(pool.getNumberOfChannels() + pool.inFlightPrimeCountForTest()).isEqualTo(4);
+    primeFutures.forEach(future -> future.set(null));
+    awaitCondition(() -> pool.getNumberOfChannels() == 4);
+  }
+
+  @Test
+  public void primedChannelIsPublishedBeforeRestOfBatchCompletes() throws Exception {
+    CountDownLatch allPrimersStarted = new CountDownLatch(3);
+    List<SettableFuture<Void>> primeFutures = new CopyOnWriteArrayList<>();
+    Map<SettableFuture<Void>, GcpManagedChannelTest.FakeManagedChannel> primingChannels =
+        new java.util.concurrent.ConcurrentHashMap<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          SettableFuture<Void> future = SettableFuture.create();
+          primingChannels.put(future, (GcpManagedChannelTest.FakeManagedChannel) channel);
+          primeFutures.add(future);
+          allPrimersStarted.countDown();
+          return future;
+        };
+    pool = newPrimedPool(10, 13, primer, Duration.ofSeconds(5), 1, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(99);
+
+    hot.activeStreamsCountIncr();
+
+    assertThat(allPrimersStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    SettableFuture<Void> firstFuture = primeFutures.get(0);
+    GcpManagedChannelTest.FakeManagedChannel firstChannel = primingChannels.get(firstFuture);
+    firstFuture.set(null);
+    awaitCondition(() -> pool.getNumberOfChannels() == 11);
+    assertThat(
+            pool.channelRefs.stream()
+                .anyMatch(channelRef -> channelRef.getChannel() == firstChannel))
+        .isTrue();
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(2);
+    assertThat(primeFutures.get(1).isDone()).isFalse();
+    assertThat(primeFutures.get(2).isDone()).isFalse();
+    primeFutures.get(1).set(null);
+    primeFutures.get(2).set(null);
+    awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+    awaitCondition(() -> pool.getNumberOfChannels() == 13);
+  }
+
+  @Test
+  public void failedPrimeDoesNotDelayOtherChannels() throws Exception {
+    CountDownLatch allPrimersStarted = new CountDownLatch(3);
+    List<SettableFuture<Void>> primeFutures = new CopyOnWriteArrayList<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          SettableFuture<Void> future = SettableFuture.create();
+          primeFutures.add(future);
+          allPrimersStarted.countDown();
+          return future;
+        };
+    pool = newPrimedPool(10, 13, primer, Duration.ofSeconds(5), 1, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(99);
+
+    hot.activeStreamsCountIncr();
+
+    assertThat(allPrimersStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    primeFutures.get(0).setException(new IllegalStateException("prime failed"));
+    primeFutures.get(1).set(null);
+    primeFutures.get(2).set(null);
+    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+    awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+    awaitCondition(() -> pool.getNumberOfChannels() == 12);
+    assertThat(pool.scaleUpPrimeFailuresForTest()).isEqualTo(1);
+  }
+
+  @Test
+  public void timedOutPrimeDoesNotDelayOtherChannels() throws Exception {
+    CountDownLatch allPrimersStarted = new CountDownLatch(3);
+    List<SettableFuture<Void>> primeFutures = new CopyOnWriteArrayList<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          SettableFuture<Void> future = SettableFuture.create();
+          primeFutures.add(future);
+          allPrimersStarted.countDown();
+          return future;
+        };
+    pool = newPrimedPool(10, 13, primer, Duration.ofSeconds(1), 1, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(99);
+
+    hot.activeStreamsCountIncr();
+
+    assertThat(allPrimersStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    primeFutures.get(1).set(null);
+    primeFutures.get(2).set(null);
+    awaitCondition(() -> pool.getNumberOfChannels() == 12);
+    assertThat(primeFutures.get(0).isDone()).isFalse();
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(1);
+    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+    awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+  }
+
+  @Test
+  public void shutdownClosesEveryUnpublishedPrimingChannel() throws Exception {
+    CountDownLatch allPrimersStarted = new CountDownLatch(3);
+    List<GcpManagedChannelTest.FakeManagedChannel> primingChannels = new CopyOnWriteArrayList<>();
+    List<SettableFuture<Void>> primeFutures = new CopyOnWriteArrayList<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          primingChannels.add((GcpManagedChannelTest.FakeManagedChannel) channel);
+          SettableFuture<Void> future = SettableFuture.create();
+          primeFutures.add(future);
+          allPrimersStarted.countDown();
+          return future;
+        };
+    pool = newPrimedPool(10, 13, primer, Duration.ofSeconds(5), 1, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(99);
+    hot.activeStreamsCountIncr();
+    assertThat(allPrimersStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+    pool.shutdownNow();
+
+    awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+    assertThat(primingChannels).hasSize(3);
+    assertThat(primingChannels.stream().allMatch(channel -> channel.isShutdown())).isTrue();
+    assertThat(primeFutures.stream().allMatch(Future::isCancelled)).isTrue();
+    assertThat(pool.getNumberOfChannels()).isEqualTo(10);
+  }
+
+  @Test
+  public void failedPrimerRejectsChannelAndLaterScaleUpStillWorks() throws Exception {
+    AtomicInteger primeCalls = new AtomicInteger();
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> rejected = new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          if (primeCalls.incrementAndGet() == 1) {
+            rejected.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+            return Futures.immediateFailedFuture(new IllegalStateException("prime failed"));
+          }
+          return Futures.immediateVoidFuture();
+        };
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), 1, builder());
+    AtomicLong clock = new AtomicLong(1);
+    pool.setNanoClock(clock::get);
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+
+    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+    awaitCondition(() -> rejected.get() != null && rejected.get().isShutdown());
+    awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+    clock.incrementAndGet();
+    hot.activeStreamsCountIncr();
+    awaitCondition(() -> pool.getNumberOfChannels() == 3);
+    assertThat(primeCalls.get()).isEqualTo(2);
+  }
+
+  @Test
+  public void primerTimeoutRejectsAndClosesChannel() throws Exception {
+    SettableFuture<Void> neverCompletes = SettableFuture.create();
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> rejected = new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          rejected.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+          return neverCompletes;
+        };
+    pool = newPrimedPool(primer, Duration.ofMillis(20), 1, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+
+    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+    awaitCondition(() -> rejected.get() != null && rejected.get().isShutdown());
+  }
+
+  @Test
+  public void primerTimeoutIncludesBlockingInvocation() throws Exception {
+    CountDownLatch primerEntered = new CountDownLatch(1);
+    CountDownLatch releasePrimer = new CountDownLatch(1);
+    SettableFuture<Void> lateFuture = SettableFuture.create();
+    AtomicInteger primeCalls = new AtomicInteger();
+    AtomicReference<String> primerThread = new AtomicReference<>();
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> rejected = new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          if (primeCalls.incrementAndGet() > 1) {
+            return Futures.immediateVoidFuture();
+          }
+          primerThread.set(Thread.currentThread().getName());
+          rejected.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+          primerEntered.countDown();
+          boolean interrupted = false;
+          while (true) {
+            try {
+              releasePrimer.await();
+              break;
+            } catch (InterruptedException failure) {
+              interrupted = true;
+            }
+          }
+          if (interrupted) {
+            Thread.currentThread().interrupt();
+          }
+          return lateFuture;
+        };
+    pool = newPrimedPool(primer, Duration.ofMillis(20), 3, builder());
+    AtomicLong clock = new AtomicLong(1);
+    pool.setNanoClock(clock::get);
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+
+    assertThat(primerEntered.await(5, TimeUnit.SECONDS)).isTrue();
+    try {
+      // A primer blocked inside prime() fails at the timeout and is not retried: nothing can stop
+      // the running call and a fresh attempt would overlap it on the same channel.
+      awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+      awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+      assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+      awaitCondition(() -> rejected.get() != null && rejected.get().isShutdown());
+      assertThat(primeCalls.get()).isEqualTo(1);
+      // The blocked call holds a primer thread, never one of the shared scheduler's threads.
+      assertThat(primerThread.get()).startsWith("gcp-mc-prime-");
+      awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+      // While the call is still blocked it keeps its scale-up slot, so the pool (2 of 3) does not
+      // build another delegate and hand it to the same stuck primer.
+      assertThat(pool.abandonedPrimeCountForTest()).isEqualTo(1);
+      clock.incrementAndGet();
+      hot.activeStreamsCountIncr();
+      awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+      assertThat(primeCalls.get()).isEqualTo(1);
+      assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(0);
+    } finally {
+      releasePrimer.countDown();
+    }
+
+    // Once the blocked call returns, its late future is cancelled without publishing, the slot is
+    // released, and the next scale-up primes a fresh delegate.
+    awaitCondition(lateFuture::isCancelled);
+    awaitCondition(() -> pool.abandonedPrimeCountForTest() == 0);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(0);
+    clock.incrementAndGet();
+    hot.activeStreamsCountIncr();
+    awaitCondition(() -> pool.getNumberOfChannels() == 3);
+    assertThat(primeCalls.get()).isEqualTo(2);
+    assertThat(pool.scaleUpPrimeFailuresForTest()).isEqualTo(1);
+  }
+
+  @Test
+  public void throwingAndNullPrimersRejectChannels() throws Exception {
+    AtomicInteger primeCalls = new AtomicInteger();
+    GcpChannelPrimer primer =
+        channel -> {
+          if (primeCalls.incrementAndGet() == 1) {
+            throw new IllegalStateException("prime threw");
+          }
+          return null;
+        };
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), 1, builder());
+    AtomicLong clock = new AtomicLong(1);
+    pool.setNanoClock(clock::get);
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+    awaitCondition(() -> !pool.scaleUpWorkerRunningForTest());
+    clock.incrementAndGet();
+    hot.activeStreamsCountIncr();
+
+    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 2);
+    assertThat(primeCalls.get()).isEqualTo(2);
+    assertThat(pool.inFlightPrimeCountForTest()).isEqualTo(0);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+  }
+
+  @Test
+  public void successfulPrimeIsDiscardedWhenPoolAlreadyAtMaximum() throws Exception {
+    SettableFuture<Void> primeFuture = SettableFuture.create();
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> primingChannel =
+        new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          primingChannel.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+          return primeFuture;
+        };
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), 1, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+    awaitCondition(() -> primingChannel.get() != null);
+    pool.createNewChannel();
+    assertThat(pool.getNumberOfChannels()).isEqualTo(3);
+    primeFuture.set(null);
+
+    awaitCondition(() -> pool.inFlightPrimeCountForTest() == 0);
+    awaitCondition(() -> primingChannel.get().isShutdown());
+    assertThat(pool.getNumberOfChannels()).isEqualTo(3);
+  }
+
+  @Test
+  public void primerRetriesUntilSuccess() throws Exception {
+    AtomicInteger primeCalls = new AtomicInteger();
+    GcpChannelPrimer primer =
+        channel ->
+            primeCalls.incrementAndGet() < 3
+                ? Futures.immediateFailedFuture(new IllegalStateException("prime failed"))
+                : Futures.immediateVoidFuture();
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), 3, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+
+    awaitCondition(() -> pool.getNumberOfChannels() == 3);
+    assertThat(primeCalls.get()).isEqualTo(3);
+    assertThat(pool.scaleUpPrimeFailuresForTest()).isEqualTo(0);
+  }
+
+  @Test
+  public void primerRetriesExhaustedRejectsChannel() throws Exception {
+    AtomicInteger primeCalls = new AtomicInteger();
+    AtomicReference<GcpManagedChannelTest.FakeManagedChannel> rejected = new AtomicReference<>();
+    GcpChannelPrimer primer =
+        channel -> {
+          rejected.set((GcpManagedChannelTest.FakeManagedChannel) channel);
+          primeCalls.incrementAndGet();
+          return Futures.immediateFailedFuture(new IllegalStateException("prime failed"));
+        };
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), 3, builder());
+    ChannelRef hot = pool.channelRefs.get(0);
+    hot.setActiveStreamsForTest(6);
+
+    hot.activeStreamsCountIncr();
+
+    awaitCondition(() -> pool.scaleUpPrimeFailuresForTest() == 1);
+    assertThat(primeCalls.get()).isEqualTo(3);
+    assertThat(pool.getNumberOfChannels()).isEqualTo(2);
+    awaitCondition(() -> rejected.get() != null && rejected.get().isShutdown());
+  }
+
+  @Test
+  public void primerBackoffIsCappedForManyAttempts() {
+    List<Long> backoffs = new CopyOnWriteArrayList<>();
+
+    for (int attempt = 0; attempt < 49; attempt++) {
+      backoffs.add(GcpManagedChannel.primeBackoffMillisForTest(attempt));
+    }
+
+    assertThat(backoffs).hasSize(49);
+    assertThat(backoffs.stream().mapToLong(Long::longValue).max().orElse(0)).isAtMost(5_000L);
+    assertThat(backoffs.stream().mapToLong(Long::longValue).sum()).isEqualTo(221_300L);
+  }
+
+  @Test
+  public void scaledChannelAfterDrainRunsPrimer() throws Exception {
+    AtomicInteger primeCalls = new AtomicInteger();
+    GcpChannelPrimer primer =
+        channel -> {
+          primeCalls.incrementAndGet();
+          return Futures.immediateVoidFuture();
+        };
+    pool = newPrimedPool(primer, Duration.ofSeconds(5), builder());
+    assertThat(primeCalls.get()).isEqualTo(0);
+    for (ChannelRef ref : pool.channelRefs) {
+      ((GcpManagedChannelTest.FakeManagedChannel) ref.getChannel())
+          .setState(ConnectivityState.READY);
+    }
+    awaitCondition(() -> pool.readyChannelCountForTest() == 2);
+    pool.checkScaleDown();
+    assertThat(pool.getNumberOfChannels()).isEqualTo(1);
+
+    ChannelRef active = pool.channelRefs.get(0);
+    active.setActiveStreamsForTest(3);
+    active.activeStreamsCountIncr();
+
+    awaitCondition(() -> pool.getNumberOfChannels() == 2);
+    assertThat(primeCalls.get()).isEqualTo(1);
+  }
+
+  private GcpManagedChannelTest.FakeManagedChannelBuilder builder() {
+    return new GcpManagedChannelTest.FakeManagedChannelBuilder(
+        () -> new GcpManagedChannelTest.FakeManagedChannel(stateExecutor));
+  }
+
+  private GcpManagedChannel newPrimedPool(
+      int initial,
+      int maximum,
+      GcpChannelPrimer primer,
+      Duration primeTimeout,
+      int primeMaxAttempts,
+      GcpManagedChannelTest.FakeManagedChannelBuilder delegate) {
+    GcpChannelPoolOptions poolOptions =
+        GcpChannelPoolOptions.newBuilder()
+            .setInitSize(initial)
+            .setMinSize(1)
+            .setMaxSize(maximum)
+            .setDynamicScaling(1, 3, Duration.ofSeconds(30))
+            .setScaleUpCooldown(Duration.ofNanos(1))
+            .setScaleDownConsecutiveLowLoadChecks(1)
+            .setMaxScaleUpPercent(30)
+            .setMaxScaleDownChannels(2)
+            .setDrainIdleGrace(Duration.ofMinutes(1))
+            .setChannelPrimer(primer)
+            .setChannelPrimeTimeout(primeTimeout)
+            .setChannelPrimeMaxAttempts(primeMaxAttempts)
+            .build();
+    return (GcpManagedChannel)
+        GcpManagedChannelBuilder.forDelegateBuilder(delegate)
+            .withOptions(
+                GcpManagedChannelOptions.newBuilder().withChannelPoolOptions(poolOptions).build())
+            .build();
+  }
+
+  private GcpManagedChannel newPrimedPool(
+      GcpChannelPrimer primer,
+      Duration primeTimeout,
+      GcpManagedChannelTest.FakeManagedChannelBuilder delegate) {
+    return newPrimedPool(primer, primeTimeout, 3, delegate);
+  }
+
+  private GcpManagedChannel newPrimedPool(
+      GcpChannelPrimer primer,
+      Duration primeTimeout,
+      int primeMaxAttempts,
+      GcpManagedChannelTest.FakeManagedChannelBuilder delegate) {
+    GcpChannelPoolOptions poolOptions =
+        GcpChannelPoolOptions.newBuilder()
+            .setInitSize(2)
+            .setMinSize(1)
+            .setMaxSize(3)
+            .setDynamicScaling(1, 3, Duration.ofSeconds(30))
+            .setScaleUpCooldown(Duration.ofNanos(1))
+            .setScaleDownConsecutiveLowLoadChecks(1)
+            .setMaxScaleUpPercent(30)
+            .setMaxScaleDownChannels(2)
+            .setDrainIdleGrace(Duration.ofMinutes(1))
+            .setChannelPrimer(primer)
+            .setChannelPrimeTimeout(primeTimeout)
+            .setChannelPrimeMaxAttempts(primeMaxAttempts)
+            .build();
+    return (GcpManagedChannel)
+        GcpManagedChannelBuilder.forDelegateBuilder(delegate)
+            .withOptions(
+                GcpManagedChannelOptions.newBuilder().withChannelPoolOptions(poolOptions).build())
+            .build();
+  }
+
+  private static void awaitCondition(java.util.concurrent.Callable<Boolean> condition) {
+    await().atMost(Duration.ofSeconds(5)).until(condition);
+  }
+}

--- a/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
+++ b/grpc-gcp-java/src/test/java/com/google/cloud/grpc/GcpManagedChannelTest.java
@@ -1484,7 +1484,9 @@ public final class GcpManagedChannelTest {
       }
 
       MetricsRecord record = fakeRegistry.pollRecord();
-      assertThat(record.getMetrics().size()).isEqualTo(28);
+      assertThat(record.getMetrics().size()).isEqualTo(29);
+      assertThat(record.getMetrics())
+          .containsKey(prefix + GcpMetricsConstants.METRIC_SCALE_UP_PRIME_FAILURES);
 
       // Initial log messages count.
       int logCount = logRecords.size();
@@ -1770,8 +1772,9 @@ public final class GcpManagedChannelTest {
       assertThat(messages).contains(poolIndex + ": stat: max_unresponsive_dropped_calls = 3");
       assertThat(messages).contains(poolIndex + ": stat: channel_pool_scaling_up = 0");
       assertThat(messages).contains(poolIndex + ": stat: channel_pool_scaling_down = 0");
+      assertThat(messages).contains(poolIndex + ": stat: scale_up_prime_failures = 0");
 
-      assertThat(logRecords.size()).isEqualTo(39);
+      assertThat(logRecords.size()).isEqualTo(40);
       logRecords.forEach(
           logRecord ->
               assertWithMessage(logRecord.getMessage())
@@ -1825,8 +1828,9 @@ public final class GcpManagedChannelTest {
       assertThat(messages).contains(poolIndex + ": stat: max_unresponsive_dropped_calls = 0");
       assertThat(messages).contains(poolIndex + ": stat: channel_pool_scaling_up = 0");
       assertThat(messages).contains(poolIndex + ": stat: channel_pool_scaling_down = 0");
+      assertThat(messages).contains(poolIndex + ": stat: scale_up_prime_failures = 0");
 
-      assertThat(logRecords.size()).isEqualTo(39);
+      assertThat(logRecords.size()).isEqualTo(40);
 
     } finally {
       pool.shutdownNow();


### PR DESCRIPTION
With dynamic scaling enabled, a freshly built channel was published to the pool the moment its delegate was constructed. Its first real RPCs then paid for connection establishment, TLS, and any service-side warm-up, so every scale-up event injected a latency spike into live traffic right when the pool was already under load.

**Change**
- **Optional channel primer.** New `GcpChannelPrimer` hook (`setChannelPrimer`) issues a cheap end-to-end RPC on each newly built scale-up channel before it is published; for Cloud Spanner this can be a `SELECT 1`. Channels in a scale-up batch are primed concurrently and each one is published as soon as its own prime succeeds, so one slow channel never holds back the rest. A `null` primer (the default) keeps the existing publish-on-build path. Only dynamic scale-up channels are primed; the initial pool is not.
- **Bounded attempts.** Each attempt is bounded by `channelPrimeTimeout` (default 10s) and retried up to `channelPrimeMaxAttempts` (default 3) with exponential backoff (100ms doubling, capped at 5s). The timeout covers the whole attempt, including the synchronous `prime()` call. A primer still blocked inside `prime()` at the timeout fails the channel without a retry, since nothing can stop that call; primer invocations run on a dedicated executor so a blocked primer cannot starve the shared scheduler that drives scale-up, draining, and timeouts. Exhausted or timed-out channels are closed and counted in the new `scale_up_prime_failures` metric.
- **Scale-up accounting.** Channels still priming count toward both the pool size cap and the desired size, so a second scale-up during a slow prime batch cannot rebuild the same shortfall or construct delegates past `maxSize`. A prime abandoned because its call never returned keeps its slot until the call does, so a stuck primer can pin at most `maxSize` slots rather than one thread per scale-up event.
- **Lifecycle.** Unpublished priming channels are never visible to pickers; shutdown cancels every pending prime and closes its delegate. Per-RPC pick and stream-accounting paths are unchanged, with no new hot-path allocations.
- **Configuration.** `setChannelPrimeTimeout` rejects negative or non-nanosecond-representable durations (zero uses the default); `setChannelPrimeMaxAttempts` rejects negatives (zero uses the default).
