### PR TITLE
chore(bigquery-jdbc): remove known issue tag from tests

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
@@ -103,6 +103,6 @@ class BigQueryArrowArray extends BigQueryBaseArray {
     return this.arrayOfStruct
         ? new BigQueryArrowStruct(
             schema.getSubFields(), (JsonStringHashMap<?, ?>) value, this.LOG.getArrowStructLogger())
-        : BigQueryTypeRegistry.convert(value, getTargetClass());
+        : BigQueryTypeRegistry.convert(value, this.schema.getType().getStandardType(), null);
   }
 }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -473,7 +473,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         return LocalDate.ofEpochDay(((Integer) element).longValue()).toString();
       case DATETIME:
         // Arrow gives DATETIME as a LocalDateTime
-        Timestamp dtTs = BigQueryTypeRegistry.convert((LocalDateTime) element, Timestamp.class);
+        Timestamp dtTs = Timestamp.valueOf((LocalDateTime) element);
         return BigQueryTypeRegistry.convert(dtTs, String.class);
       case TIMESTAMP:
         // Arrow gives TIMESTAMP as a Long (microseconds since epoch)

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJsonArray.java
@@ -103,6 +103,6 @@ class BigQueryJsonArray extends BigQueryBaseArray {
     return this.arrayOfStruct
         ? new BigQueryJsonStruct(
             this.schema.getSubFields(), fieldValue, this.LOG.getJsonStructLogger())
-        : BigQueryTypeRegistry.convert(fieldValue, getTargetClass());
+        : BigQueryTypeRegistry.convert(fieldValue, this.schema.getType().getStandardType(), null);
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryTypeRegistryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryTypeRegistryTest.java
@@ -123,6 +123,14 @@ public class BigQueryTypeRegistryTest {
   }
 
   @Test
+  public void testDatetimeStringPreservesLocalWallClock() throws Exception {
+    String dtStr = "2023-01-01 01:00:00";
+    Timestamp ts =
+        (Timestamp) BigQueryTypeRegistry.convert(dtStr, StandardSQLTypeName.DATETIME, null);
+    assertThat(ts.toString()).isEqualTo("2023-01-01 01:00:00.0");
+  }
+
+  @Test
   public void testCoercionException() throws Exception {
     assertThrows(
         BigQueryJdbcException.class,

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
@@ -54,7 +54,10 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
+import java.time.Instant;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Properties;
 import java.util.Random;
@@ -130,8 +133,9 @@ public class ITBigQueryJDBCTest extends ITBase {
     assertEquals(123.456789, resultSet.getDouble(5), 0.0);
     assertEquals("testString", resultSet.getString(6));
     assertEquals("Test String", new String(resultSet.getBytes(7), StandardCharsets.UTF_8));
-    assertEquals(Timestamp.valueOf("2020-04-27 18:07:25.356"), resultSet.getObject(10));
-    assertEquals(Timestamp.valueOf("2020-04-27 18:07:25.356"), resultSet.getTimestamp(10));
+    Timestamp expectedTimestamp = Timestamp.from(Instant.parse("2020-04-27T18:07:25.356Z"));
+    assertEquals(expectedTimestamp, resultSet.getObject(10));
+    assertEquals(expectedTimestamp, resultSet.getTimestamp(10));
     assertEquals(Date.valueOf("2019-1-12"), resultSet.getObject(11));
     assertEquals(Date.valueOf("2019-1-12"), resultSet.getDate(11));
     assertEquals(Time.valueOf("14:00:00"), resultSet.getObject(12));
@@ -2509,6 +2513,16 @@ public class ITBigQueryJDBCTest extends ITBase {
 
   @Test
   public void validateGetString() throws Exception {
+    DateTimeFormatter timestampFormatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+    String expectedTimestampString =
+        timestampFormatter.format(
+            Instant.parse("2023-07-28T12:30:00Z").atZone(ZoneId.systemDefault()).toLocalDateTime());
+    String expectedArrayTimestamp =
+        String.format(
+            "[%s, %s]",
+            Timestamp.from(Instant.parse("2023-01-01T01:00:00Z")),
+            Timestamp.from(Instant.parse("2023-01-01T02:00:00Z")));
     final ImmutableMap<String, Object> stringResults =
         new ImmutableMap.Builder<String, Object>()
             .put("stringField", "StringValue")
@@ -2518,7 +2532,7 @@ public class ITBigQueryJDBCTest extends ITBase {
             .put("numericField", "12345.67")
             .put("bigNumericField", "98765432109876543210.123456789")
             .put("booleanField", "true")
-            .put("timestampFiled", "2023-07-28 12:30:00.000000")
+            .put("timestampFiled", expectedTimestampString)
             .put("dateField", "2023-07-28")
             .put("timeField", "12:30:00.000")
             .put("dateTimeField", "2023-07-28 12:30:00.000000")
@@ -2535,7 +2549,7 @@ public class ITBigQueryJDBCTest extends ITBase {
             .put("arrayNumeric", "[10.5, 20.5]")
             .put("arrayBignumeric", "[100.1, 200.2]")
             .put("arrayBoolean", "[true, false]")
-            .put("arrayTimestamp", "[2023-01-01 01:00:00.0, 2023-01-01 02:00:00.0]")
+            .put("arrayTimestamp", expectedArrayTimestamp)
             .put("arrayDate", "[2023-01-01, 2023-01-02]")
             .put("arrayTime", "[01:00:00, 02:00:00]")
             .put("arrayDatetime", "[2023-01-01 01:00:00.0, 2023-01-01 02:00:00.0]")
@@ -2681,11 +2695,13 @@ public class ITBigQueryJDBCTest extends ITBase {
 
   @Test
   public void validateGetTime() throws Exception {
+    LocalTime expectedTimestampLocalTime =
+        Instant.parse("2023-07-28T12:30:00Z").atZone(ZoneId.systemDefault()).toLocalTime();
     final ImmutableMap<String, Object> result =
         new ImmutableMap.Builder<String, Object>()
             .put("timeField", Time.valueOf("12:30:00"))
             .put("dateTimeField", Time.valueOf("12:30:00"))
-            .put("timestampFiled", Time.valueOf("12:30:00"))
+            .put("timestampFiled", Time.valueOf(expectedTimestampLocalTime))
             .build();
     BiFunction<ResultSet, Integer, Object> getter =
         (s, i) -> {
@@ -2724,7 +2740,7 @@ public class ITBigQueryJDBCTest extends ITBase {
             .put("timeField", Timestamp.valueOf("1970-01-01 12:30:00"))
             .put("dateField", Timestamp.valueOf("2023-07-28 00:00:00"))
             .put("dateTimeField", Timestamp.valueOf("2023-07-28 12:30:00"))
-            .put("timestampFiled", Timestamp.valueOf("2023-07-28 12:30:00"))
+            .put("timestampFiled", Timestamp.from(Instant.parse("2023-07-28T12:30:00Z")))
             .build();
     BiFunction<ResultSet, Integer, Object> getter =
         (s, i) -> {

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITBigQueryJDBCTest.java
@@ -103,7 +103,6 @@ public class ITBigQueryJDBCTest extends ITBase {
   }
 
   @Test
-  @Tag("known_issue") // b/539615199
   @Tag("disable_tpc")
   public void testValidAllDataTypesSerializationFromSelectQueryArrowDataset() throws SQLException {
     String DATASET = "JDBC_INTEGRATION_DATASET";
@@ -2509,7 +2508,6 @@ public class ITBigQueryJDBCTest extends ITBase {
   }
 
   @Test
-  @Tag("known_issue") // b/539615199
   public void validateGetString() throws Exception {
     final ImmutableMap<String, Object> stringResults =
         new ImmutableMap.Builder<String, Object>()
@@ -2682,7 +2680,6 @@ public class ITBigQueryJDBCTest extends ITBase {
   }
 
   @Test
-  @Tag("known_issue") // b/539615199
   public void validateGetTime() throws Exception {
     final ImmutableMap<String, Object> result =
         new ImmutableMap.Builder<String, Object>()
@@ -2721,7 +2718,6 @@ public class ITBigQueryJDBCTest extends ITBase {
   }
 
   @Test
-  @Tag("known_issue") // b/539615199
   public void validateGetTimestamp() throws Exception {
     final ImmutableMap<String, Object> result =
         new ImmutableMap.Builder<String, Object>()

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -1041,7 +1041,6 @@ public class ITNightlyBigQueryTest extends ITBase {
   }
 
   @Test
-  @Tag("known_issue") // b/539615199
   @Tag("disable_tpc")
   public void testValidAllDataTypesSerializationFromSelectQuery() throws SQLException {
     String DATASET = "JDBC_INTEGRATION_DATASET";
@@ -1100,7 +1099,6 @@ public class ITNightlyBigQueryTest extends ITBase {
   }
 
   @Test
-  @Tag("known_issue") // b/539615199
   @Tag("disable_tpc")
   public void testValidAllDataTypesSerializationFromSelectQueryArrowDataset() throws SQLException {
     String DATASET = "JDBC_INTEGRATION_DATASET";

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/it/ITNightlyBigQueryTest.java
@@ -46,6 +46,7 @@ import java.sql.Statement;
 import java.sql.Struct;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.Random;
@@ -1064,7 +1065,8 @@ public class ITNightlyBigQueryTest extends ITBase {
     assertArrayEquals(
         new String[] {"one", "two", "three"}, (String[]) resultSet.getArray(9).getArray());
 
-    assertEquals(Timestamp.valueOf("2020-04-27 18:07:25.356456"), resultSet.getObject(10));
+    Timestamp expectedTimestamp = Timestamp.from(Instant.parse("2020-04-27T18:07:25.356456Z"));
+    assertEquals(expectedTimestamp, resultSet.getObject(10));
     assertEquals(Date.valueOf("2019-1-12"), resultSet.getObject(11));
     assertEquals(Time.valueOf("14:00:00"), resultSet.getObject(12));
     assertEquals(Timestamp.valueOf("2019-02-17 11:24:00"), resultSet.getObject(13));


### PR DESCRIPTION
### Summary of Changes

* **Array Element Type Routing**:
  * Updated `BigQueryJsonArray` and `BigQueryArrowArray` to coerce elements using `this.schema.getType().getStandardType()` rather than `getTargetClass()`. This routes `ARRAY<DATETIME>` elements directly to the `DATETIME` descriptor, preserving civil wall-clock semantics without unintended UTC shifts.

* **Arrow Range DATETIME Formatting**:
  * Updated `formatRangeElement` in `BigQueryArrowResultSet` to format `DATETIME` bounds via `Timestamp.valueOf((LocalDateTime) element)`, maintaining local wall-clock representation.

* **Integration Test Hardening & Unblocking**:
  * Removed `@Tag("known_issue")` annotations from `ITBigQueryJDBCTest` and `ITNightlyBigQueryTest`.
  * Refactored static UTC timestamp assertions in `validateGetString`, `validateGetTime`, `validateGetTimestamp`, and serialization tests to use dynamic, timezone-agnostic evaluations (`Instant`, `ZoneId.systemDefault()`, and `Timestamp.from(...)`).
  * Dynamically formatted `arrayTimestamp` string expectations in `validateGetString` to match host JVM timezone output.

* **Unit Test Coverage**:
  * Added `testDatetimeStringPreservesLocalWallClock` in `BigQueryTypeRegistryTest` to verify that `DATETIME` string conversions preserve local wall-clock time across execution environments.
