### PR TITLE
test(spanner): use nam6 instance config for CreateInstancePartitionSampleIT

### DIFF
--- a/java-spanner/samples/snippets/src/test/java/com/example/spanner/CreateInstancePartitionSampleIT.java
+++ b/java-spanner/samples/snippets/src/test/java/com/example/spanner/CreateInstancePartitionSampleIT.java
@@ -36,8 +36,8 @@ public class CreateInstancePartitionSampleIT extends SampleTestBaseV2 {
         .createInstance(
             InstanceInfo.newBuilder(InstanceId.of(projectId, instanceId))
                 .setEdition(Edition.ENTERPRISE_PLUS)
-                .setDisplayName("Geo-partitioning test instance")
-                .setInstanceConfigId(InstanceConfigId.of(projectId, "regional-us-central1"))
+                .setDisplayName("Partition test instance")
+                .setInstanceConfigId(InstanceConfigId.of(projectId, "nam6"))
                 .setNodeCount(1)
                 .build())
         .get();


### PR DESCRIPTION
CreateInstancePartitionSample creates an instance partition with config 'nam3'. Creating instance partitions on single-region instances ('regional-us-central1') fails with:
  FAILED_PRECONDITION: Cannot create an instance partition in a single region instance.

Additionally, Cloud Spanner prohibits an instance partition from sharing the exact base config of the parent instance (DuplicatedBaseInstancePartitionConfigs).

Update CreateInstancePartitionSampleIT to create the parent instance in 'nam6' with display name "Partition test instance". This satisfies the multi-region requirement while avoiding a base config collision with 'nam3'.