### PR TITLE
fix(auth): apply quota project to impersonated ID token requests

### DIFF
--- a/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/google-auth-library-java/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -681,6 +681,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
    *     "ImpersonatedCredentials.INCLUDE_EMAIL" is provided as a list option.<br>
    *     Only one option value is supported: "ImpersonatedCredentials.INCLUDE_EMAIL" If no options
    *     are set, the default excludes the "includeEmail" attribute in the API request.
+   *     If a quota project is configured, it is used for the IAM request.
    * @return IdToken object which includes the raw id_token, expiration, and audience
    * @throws IOException if the attempt to get an ID token failed
    */
@@ -689,9 +690,13 @@ public class ImpersonatedCredentials extends GoogleCredentials
       String targetAudience, @Nullable List<IdTokenProvider.Option> options) throws IOException {
     boolean includeEmail =
         options != null && options.contains(IdTokenProvider.Option.INCLUDE_EMAIL);
+    GoogleCredentials idTokenSourceCredentials = sourceCredentials;
+    if (this.quotaProjectId != null) {
+      idTokenSourceCredentials = sourceCredentials.createWithQuotaProject(this.quotaProjectId);
+    }
     return IamUtils.getIdToken(
         getAccount(),
-        sourceCredentials,
+        idTokenSourceCredentials,
         transportFactory.create(),
         targetAudience,
         includeEmail,

--- a/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/google-auth-library-java/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -906,6 +906,33 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
+  void idTokenWithAudience_quotaProjectIdOverridesSourceCredentials() throws IOException {
+    sourceCredentials = sourceCredentials.createWithQuotaProject("source-quota-project-id");
+    mockTransportFactory.getTransport().setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mockTransportFactory.getTransport().setAccessToken(ACCESS_TOKEN);
+    mockTransportFactory.getTransport().setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.getTransport().addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
+
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            IMMUTABLE_SCOPES_LIST,
+            VALID_LIFETIME,
+            mockTransportFactory,
+            QUOTA_PROJECT_ID);
+
+    mockTransportFactory.getTransport().setIdToken(STANDARD_ID_TOKEN);
+    targetCredentials.idTokenWithAudience("https://foo.bar", null);
+
+    MockLowLevelHttpRequest request = mockTransportFactory.getTransport().getRequest();
+    assertEquals(
+        QUOTA_PROJECT_ID,
+        request.getFirstHeaderValue(GoogleCredentials.QUOTA_PROJECT_ID_HEADER_KEY));
+  }
+
+  @Test
   void idTokenWithAudience_withEmail() throws IOException {
     mockTransportFactory.getTransport().setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.getTransport().setAccessToken(ACCESS_TOKEN);


### PR DESCRIPTION
Apply the quota project configured on `ImpersonatedCredentials` to IAM `generateIdToken` requests.

The ID-token path currently uses the source credentials directly, so an impersonated credential's quota-project override is omitted. Use the existing credential metadata mechanism to send the target quota project in the `x-goog-user-project` header.

Adds a regression test verifying that the impersonated credential's quota project overrides the source credential's project.

Fixes #12604
