### PR TITLE
ci: skip enforce-banned-duplicate-classes in non-jar POM modules

### DIFF
--- a/java-cloud-bom/tests/dependency-convergence/pom.xml
+++ b/java-cloud-bom/tests/dependency-convergence/pom.xml
@@ -481,6 +481,12 @@
               <goal>enforce</goal>
             </goals>
           </execution>
+          <execution>
+            <id>enforce-banned-duplicate-classes</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/java-shared-config/native-image-shared-config/pom.xml
+++ b/java-shared-config/native-image-shared-config/pom.xml
@@ -116,6 +116,12 @@
               <skip>true</skip>
             </configuration>
           </execution>
+          <execution>
+            <id>enforce-banned-duplicate-classes</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/java-shared-config/pom.xml
+++ b/java-shared-config/pom.xml
@@ -52,6 +52,12 @@
               <skip>true</skip>
             </configuration>
           </execution>
+          <execution>
+            <id>enforce-banned-duplicate-classes</id>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Summary
Fixes `No rules are configured` errors encountered in the `ban-duplicate-classes` workflow on POM-only modules.

## Background
In #14142, the enforcer was split into:
1. `enforce` (fast metadata rules for PRs)
2. `enforce-banned-duplicate-classes` (runs `banDuplicateClasses` on release branches via `mvn -B -ntp enforcer:enforce@enforce-banned-duplicate-classes -T 1C`)

When invoking a specific Maven execution ID across a multi-module reactor (`plugin:goal@executionId`), Maven creates an empty ad-hoc execution for any module that does not define that execution ID. Because `maven-enforcer-plugin` requires at least one rule (or `skip=true`), this caused the `ban-duplicate-classes` job to fail immediately on:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.3:enforce (enforce-banned-duplicate-classes) on project native-image-shared-config: No rules are configured. Use the skip flag if you want to disable execution.
```

## Changes
Added an explicit `<execution>` for `<id>enforce-banned-duplicate-classes</id>` with `<skip>true</skip>` to:
- `java-shared-config/native-image-shared-config/pom.xml`: configuration-only parent POM
- `java-shared-config/pom.xml`: aggregator parent POM
- `java-cloud-bom/tests/dependency-convergence/pom.xml`: standalone BOM test module (preserving its upper-bound deps check in the `enforce` execution)

## Verification
- Verified `mvn -B -ntp enforcer:enforce@enforce-banned-duplicate-classes` passes in `java-shared-config`.
- Verified `mvn -B -ntp enforcer:enforce@enforce` passes in `java-shared-config`.
- Verified `mvn -B -ntp enforcer:enforce@enforce-banned-duplicate-classes` passes in `java-cloud-bom`.
- Verified `mvn -B -ntp enforcer:enforce@enforce` passes in `java-cloud-bom`.
