### PR TITLE
test(spanner): unflake DynamicChannelPoolPrimeSessionTest

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DynamicChannelPoolPrimeSessionTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/DynamicChannelPoolPrimeSessionTest.java
@@ -379,6 +379,7 @@ public class DynamicChannelPoolPrimeSessionTest {
     // arrives.
     assertThat(waitingRpc.getPrimeSessionSourceCount()).isEqualTo(0);
 
+    awaitCondition(() -> mockSpanner.arrivedCreateSessions.get() >= 1);
     int arrivedBeforeRelease = mockSpanner.arrivedCreateSessions.get();
     mockSpanner.releaseCreateSessions();
     awaitCondition(() -> waitingRpc.getCompletedMultiplexedCreateSessions() >= 1);


### PR DESCRIPTION
In `sessionArrivingAfterFailedClientConstructionNeverBecomesPrimeSession`, `arrivedBeforeRelease` was sampled immediately after `getDatabaseClient` timed out from waiting for multiplexed session creation (200ms).

Under thread scheduling contention or high CI load, the asynchronous `CreateSession` gRPC call dispatched by `SessionClient` could take longer than 200ms to reach the mock server. As a result, `arrivedBeforeRelease` sampled 0 instead of 1. When the gate was later released, the delayed RPC finally arrived at `mockSpanner.createSession()`, incrementing the count and causing `assertEquals(arrivedBeforeRelease, mockSpanner.arrivedCreateSessions.get())` to fail with `AssertionError: expected:<0> but was:<1>`.

Fix this race condition by explicitly waiting for the in-flight `CreateSession` RPC to arrive at `mockSpanner` before sampling `arrivedBeforeRelease` and releasing the gate.