### PR TITLE
test(spanner): unflake OpenTelemetryBuiltInMetricsTracerTest#testMetricsSingleUseQuery

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/OpenTelemetryBuiltInMetricsTracerTest.java
@@ -60,7 +60,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -162,7 +161,6 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
     client = spanner.getDatabaseClient(DatabaseId.of("test-project", "i", "d"));
   }
 
-  @Ignore("Flaky test: b/510147927")
   @Test
   public void testMetricsSingleUseQuery() {
     Stopwatch stopwatch = Stopwatch.createStarted();
@@ -171,7 +169,7 @@ public class OpenTelemetryBuiltInMetricsTracerTest extends AbstractNettyMockServ
       assertFalse(resultSet.next());
     }
 
-    double elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+    double elapsed = stopwatch.elapsed(TimeUnit.NANOSECONDS) / 1_000_000.0;
     Attributes expectedAttributes =
         expectedCommonBaseAttributes.toBuilder()
             .put(BuiltInMetricsConstant.STATUS_KEY, "OK")


### PR DESCRIPTION
In `testMetricsSingleUseQuery`, the upper-bound `elapsed` was computed using `stopwatch.elapsed(TimeUnit.MILLISECONDS)`.

Guava's `Stopwatch.elapsed(TimeUnit.MILLISECONDS)` uses integer division (`nanos / 1_000_000L`), which truncates the sub-millisecond remainder to a whole `long` (e.g. 5,182,148 ns -> 5.0 ms). In contrast, OpenTelemetry's `MetricsTracer` records operation latency with floating-point precision via `nanos / 1_000_000.0` (e.g. 5.1821489... ms).

Whenever the operation latency included a fractional millisecond remainder, the test stopwatch's truncated upper bound was smaller than the metric's recorded latency, causing `Range.closed(MIN_LATENCY, elapsed)` to fail.

Fix this by computing `elapsed` using
`stopwatch.elapsed(TimeUnit.NANOSECONDS) / 1_000_000.0` to preserve fractional millisecond precision, and re-enable the test by removing `@Ignore`.