### PR TITLE
fix(firestore): enable unit tests in native profile for firestore-admin

### DIFF
--- a/java-firestore/google-cloud-firestore-admin/pom.xml
+++ b/java-firestore/google-cloud-firestore-admin/pom.xml
@@ -150,6 +150,12 @@
 
   <profiles>
     <profile>
+      <id>native</id>
+      <properties>
+        <skipUnitTests>false</skipUnitTests>
+      </properties>
+    </profile>
+    <profile>
       <id>java9</id>
       <activation>
         <jdk>[9,)</jdk>


### PR DESCRIPTION
## Description
Commit `66c9920e938` set `<skipUnitTests>true</skipUnitTests>` directly in `google-cloud-firestore-admin/pom.xml`. Because child POM properties take precedence over profiles in parent POMs, the `native` profile in `google-cloud-jar-parent` could not override `skipUnitTests` to `false`. As a result, Surefire skipped unit tests, and `native-maven-plugin:test` failed with:
`Test configuration file wasn't found. Make sure that test execution wasn't skipped.`

This PR explicitly adds the `native` profile with `<skipUnitTests>false</skipUnitTests>` to `google-cloud-firestore-admin/pom.xml`, ensuring test configuration metadata is generated for GraalVM native image testing.

## PR Checklist
- [x] Code formatted
- [x] Builds and tests pass