### PR TITLE
fix(spanner): re-enable ITInstanceAdminTest on cloud-devel and cloud-staging

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/IntegrationTestEnv.java
@@ -69,6 +69,8 @@ public class IntegrationTestEnv extends ExternalResource {
    */
   public static final String TEST_INSTANCE_PROPERTY = "spanner.testenv.instance";
 
+  public static final String TEST_INSTANCE_CONFIG_PROPERTY = "spanner.testenv.instance_config";
+
   public static final String MAX_CREATE_INSTANCE_ATTEMPTS =
       "spanner.testenv.max_create_instance_attempts";
 
@@ -130,7 +132,6 @@ public class IntegrationTestEnv extends ExternalResource {
   @Override
   protected void before() throws Throwable {
     this.initializeConfig();
-    assumeFalse(alwaysCreateNewInstance && isCloudDevel());
     assumeFalse(
         "Creating instances is not supported in Spanner Omni",
         alwaysCreateNewInstance && isSpannerOmni());
@@ -211,9 +212,11 @@ public class IntegrationTestEnv extends ExternalResource {
   }
 
   private void initializeInstance(InstanceId instanceId) throws Exception {
+    String instanceConfigName =
+        System.getProperty(TEST_INSTANCE_CONFIG_PROPERTY, "regional-us-east4");
     InstanceConfig instanceConfig;
     try {
-      instanceConfig = instanceAdminClient.getInstanceConfig("regional-us-east4");
+      instanceConfig = instanceAdminClient.getInstanceConfig(instanceConfigName);
     } catch (Throwable ignore) {
       instanceConfig =
           Iterators.get(instanceAdminClient.listInstanceConfigs().iterateAll().iterator(), 0, null);

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITInstanceAdminTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/it/ITInstanceAdminTest.java
@@ -48,17 +48,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ITInstanceAdminTest {
 
-  @ClassRule
-  public static IntegrationTestEnv env =
-      new IntegrationTestEnv(true) {
-        @Override
-        protected void before() throws Throwable {
-          assumeFalse(
-              "ITInstanceAdminTest is disabled when running against cloud-devel or cloud-staging",
-              isRunningOnCloudDevelOrStaging());
-          super.before();
-        }
-      };
+  @ClassRule public static IntegrationTestEnv env = new IntegrationTestEnv(true);
 
   static InstanceAdminClient instanceClient;
 
@@ -67,12 +57,6 @@ public class ITInstanceAdminTest {
     assumeFalse(
         "instance / instanceConfig operations are not supported on Spanner Omni", isSpannerOmni());
     instanceClient = env.getTestHelper().getClient().getInstanceAdminClient();
-  }
-
-  private static boolean isRunningOnCloudDevelOrStaging() {
-    String jobType = System.getenv("JOB_TYPE");
-    return jobType != null
-        && (jobType.contains("cloud-devel") || jobType.contains("cloud-staging"));
   }
 
   @Test


### PR DESCRIPTION
ITInstanceAdminTest was previously disabled on cloud-devel and cloud-staging due to instance creation failures and quota issues.

This change:
1. Re-enables instance creation on cloud-devel in IntegrationTestEnv.
2. Allows configuring the instance configuration via 'spanner.testenv.instance_config', defaulting to 'regional-us-east4', allowing environments like cloud-staging to specify configs with available quota (e.g., 'regional-us-central1').
3. Removes the environment skip in ITInstanceAdminTest so tests run in both staging environments.