### PR TITLE
test(spanner): unflake BuiltInMetricsCustomOpenTelemetryTest and BuiltInMetricsBothSinksTest

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInMetricsBothSinksTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInMetricsBothSinksTest.java
@@ -102,6 +102,7 @@ public class BuiltInMetricsBothSinksTest extends AbstractMockServerTest {
     try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1)) {
       assertThat(resultSet.next()).isTrue();
       assertThat(resultSet.getLong(0)).isEqualTo(1L);
+      assertThat(resultSet.next()).isFalse();
     }
   }
 

--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInMetricsCustomOpenTelemetryTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/BuiltInMetricsCustomOpenTelemetryTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.spanner;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -79,6 +80,7 @@ public class BuiltInMetricsCustomOpenTelemetryTest extends AbstractMockServerTes
     try (ResultSet resultSet = client.singleUse().executeQuery(SELECT1)) {
       assertTrue(resultSet.next());
       assertThat(resultSet.getLong(0)).isEqualTo(1L);
+      assertFalse(resultSet.next());
     }
   }
 


### PR DESCRIPTION
In `executeSelect1()`, `resultSet.next()` was called only once for `SELECT 1`. Closing the `ResultSet` before consuming the stream to EOF invokes `iterator.close()`, which sends `call.cancel("ResultSet closed", null)` to the underlying gRPC stream.

If client cancellation races ahead of the mock server's `onCompleted()`, the stream terminates with `Status.CANCELLED`. As a result, `SpannerTracer.operationSucceeded()` is never invoked, omitting `Spanner.ExecuteStreamingSql` (status `OK`) from
`spanner.googleapis.com/internal/client/operation_count` and causing the test assertion to fail.

Consume the `ResultSet` to EOF (`assertFalse(resultSet.next())`) in both `BuiltInMetricsCustomOpenTelemetryTest` and `BuiltInMetricsBothSinksTest` to guarantee that the stream finishes normally before closing.