### PR TITLE
fix(spanner): prevent statement cancellation race in AbstractBaseUnitOfWork

### DIFF
--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
@@ -17,7 +17,9 @@
 package com.google.cloud.spanner.connection;
 
 import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.rpc.ApiCallContext;
@@ -405,38 +407,66 @@ abstract class AbstractBaseUnitOfWork implements UnitOfWork {
           callType == CallType.ASYNC
               ? new SpannerAsyncExecutionException(statement.getStatement())
               : null;
-      final ApiFuture<T> future;
+      final SettableApiFuture<T> statementFuture = SettableApiFuture.create();
       synchronized (this) {
-        ApiFuture<T> f = statementExecutor.submit(context.wrap(callable));
-        future =
-            ApiFutures.catching(
-                f,
-                Throwable.class,
-                input -> {
-                  if (caller != null) {
-                    input.addSuppressed(caller);
-                  }
-                  throw SpannerExceptionFactory.asSpannerException(input);
-                },
-                MoreExecutors.directExecutor());
-        this.currentlyRunningStatementFuture = future;
+        this.currentlyRunningStatementFuture = statementFuture;
       }
-      future.addListener(
-          new Runnable() {
-            @Override
-            public void run() {
-              synchronized (AbstractBaseUnitOfWork.this) {
-                if (currentlyRunningStatementFuture == future) {
-                  currentlyRunningStatementFuture = null;
+      final ApiFuture<T> f;
+      try {
+        f = statementExecutor.submit(context.wrap(callable));
+      } catch (Throwable t) {
+        synchronized (this) {
+          if (this.currentlyRunningStatementFuture == statementFuture) {
+            this.currentlyRunningStatementFuture = null;
+          }
+        }
+        if (isSingleUse()) {
+          endUnitOfWorkSpan();
+        }
+        statementFuture.setException(t);
+        throw t;
+      }
+      final ApiFuture<T> future =
+          ApiFutures.catching(
+              f,
+              Throwable.class,
+              input -> {
+                if (caller != null) {
+                  input.addSuppressed(caller);
                 }
-              }
-              if (isSingleUse()) {
-                endUnitOfWorkSpan();
-              }
+                throw SpannerExceptionFactory.asSpannerException(input);
+              },
+              MoreExecutors.directExecutor());
+      ApiFutures.addCallback(
+          future,
+          new ApiFutureCallback<T>() {
+            @Override
+            public void onFailure(Throwable t) {
+              statementFuture.setException(t);
+            }
+
+            @Override
+            public void onSuccess(T result) {
+              statementFuture.set(result);
             }
           },
           MoreExecutors.directExecutor());
-      return future;
+      statementFuture.addListener(
+          () -> {
+            if (statementFuture.isCancelled()) {
+              future.cancel(true);
+            }
+            synchronized (AbstractBaseUnitOfWork.this) {
+              if (currentlyRunningStatementFuture == statementFuture) {
+                currentlyRunningStatementFuture = null;
+              }
+            }
+            if (isSingleUse()) {
+              endUnitOfWorkSpan();
+            }
+          },
+          MoreExecutors.directExecutor());
+      return statementFuture;
     }
   }
 

--- a/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
+++ b/java-spanner/google-cloud-spanner/src/main/java/com/google/cloud/spanner/connection/AbstractBaseUnitOfWork.java
@@ -401,30 +401,31 @@ abstract class AbstractBaseUnitOfWork implements UnitOfWork {
         io.opentelemetry.context.Context.current()
             .with(OpenTelemetryContextKeys.THREAD_NAME_KEY, Thread.currentThread().getName())
             .makeCurrent()) {
-      ApiFuture<T> f = statementExecutor.submit(context.wrap(callable));
       final SpannerAsyncExecutionException caller =
           callType == CallType.ASYNC
               ? new SpannerAsyncExecutionException(statement.getStatement())
               : null;
-      final ApiFuture<T> future =
-          ApiFutures.catching(
-              f,
-              Throwable.class,
-              input -> {
-                if (caller != null) {
-                  input.addSuppressed(caller);
-                }
-                throw SpannerExceptionFactory.asSpannerException(input);
-              },
-              MoreExecutors.directExecutor());
+      final ApiFuture<T> future;
       synchronized (this) {
+        ApiFuture<T> f = statementExecutor.submit(context.wrap(callable));
+        future =
+            ApiFutures.catching(
+                f,
+                Throwable.class,
+                input -> {
+                  if (caller != null) {
+                    input.addSuppressed(caller);
+                  }
+                  throw SpannerExceptionFactory.asSpannerException(input);
+                },
+                MoreExecutors.directExecutor());
         this.currentlyRunningStatementFuture = future;
       }
       future.addListener(
           new Runnable() {
             @Override
             public void run() {
-              synchronized (this) {
+              synchronized (AbstractBaseUnitOfWork.this) {
                 if (currentlyRunningStatementFuture == future) {
                   currentlyRunningStatementFuture = null;
                 }


### PR DESCRIPTION
In `AbstractBaseUnitOfWork.executeStatementAsync`, statements were submitted asynchronously to `statementExecutor` before storing the resulting future in `currentlyRunningStatementFuture`. Under thread contention, the query RPC can reach the mock server and trigger `cancel()` before the future is assigned, causing `cancel()` to silently drop the cancellation request and resulting in statement timeouts in CI tests such as `StatementTimeoutTest#testCancelReadWriteAutocommitMultipleStatements`.

Furthermore, submitting statements while holding the unit-of-work monitor lock causes lock contention when `StatementExecutorType.DIRECT_EXECUTOR` is used (such as in Spanner JDBC or PGAdapter), because direct executors execute synchronously on the calling thread.

This change:
- Pre-registers a `SettableApiFuture` as `currentlyRunningStatementFuture` under synchronization before submitting to the executor, ensuring any immediate `cancel()` invocation is captured without racing.
- Submits the statement task to `statementExecutor` outside the synchronized block to avoid holding the unit-of-work lock during direct synchronous execution.
- Attaches callbacks to forward results/exceptions to the `SettableApiFuture`, and registers a listener on the `SettableApiFuture` to propagate cancellation to the underlying future and clear `currentlyRunningStatementFuture`.