### PR TITLE
feat(bigquery-jdbc): add `EnableTimestampPicos` connection property and its plumbing

### DIFF
--- a/java-bigquery-jdbc/docs/USER_GUIDE.md
+++ b/java-bigquery-jdbc/docs/USER_GUIDE.md
@@ -207,6 +207,12 @@ String url = "jdbc:bigquery://https://bigquery.googleapis.com:443"
 | :--- | :---: | :--- |
 | `EnableSession` | `false` | Enables multi-statement session creation and transaction support (`BEGIN`, `COMMIT`, `ROLLBACK`). |
 
+### Data Types & Extended Precision Properties
+
+| Property Name | Default Value | Description |
+| :--- | :---: | :--- |
+| `EnableTimestampPicos` | `false` | Enables 12-digit picosecond precision for `TIMESTAMP(12)` data types. When enabled, `TIMESTAMP(12)` columns are retrieved with 12 fractional digits formatted in UTC (`YYYY-MM-DD HH:MM:SS.ffffffffffff`) via `getString()` and `getObject()`, typed as `Types.VARCHAR` (`12`) with type name `"TIMESTAMP_PICOSECONDS"`. Picosecond precision is incompatible with Legacy SQL (`QueryDialect=BIG_QUERY`). |
+
 ### High-Throughput Storage & Write API Properties
 
 | Property Name | Default Value | Description |

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryConnection.java
@@ -104,6 +104,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
               BigQueryJdbcUrlUtility.KMS_KEY_NAME_PROPERTY_NAME,
               BigQueryJdbcUrlUtility.QUERY_PROPERTIES_NAME,
               BigQueryJdbcUrlUtility.ENABLE_SESSION_PROPERTY_NAME,
+              BigQueryJdbcUrlUtility.ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME,
               BigQueryJdbcUrlUtility.LOG_LEVEL_PROPERTY_NAME,
               BigQueryJdbcUrlUtility.LOG_PATH_PROPERTY_NAME,
               BigQueryJdbcUrlUtility.OAUTH_TYPE_PROPERTY_NAME,
@@ -186,6 +187,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
   int highThroughputMinTableSize;
   int highThroughputActivationRatio;
   boolean enableSession;
+  boolean enableTimestampPicos;
   boolean enableProjectDiscovery;
   private List<String> discoveredProjectsCache;
   boolean unsupportedHTAPIFallback;
@@ -357,6 +359,7 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
               this.sslTrustStoreProvider,
               this.connectionClassName);
       this.enableSession = ds.getEnableSession();
+      this.enableTimestampPicos = ds.getEnableTimestampPicos();
       this.unsupportedHTAPIFallback = ds.getUnsupportedHTAPIFallback();
       this.maxResults = ds.getMaxResults();
       Map<String, String> queryPropertiesMap = ds.getQueryProperties();
@@ -717,6 +720,10 @@ public class BigQueryConnection extends BigQueryNoOpsConnection {
 
   boolean isSessionEnabled() {
     return this.enableSession;
+  }
+
+  boolean isEnableTimestampPicos() {
+    return this.enableTimestampPicos;
   }
 
   boolean isUnsupportedHTAPIFallback() {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtility.java
@@ -123,6 +123,8 @@ final class BigQueryJdbcUrlUtility {
   static final String LOG_LEVEL_ENV_VAR = "BIGQUERY_JDBC_LOG_LEVEL";
   static final String LOG_PATH_ENV_VAR = "BIGQUERY_JDBC_LOG_PATH";
   static final String ENABLE_SESSION_PROPERTY_NAME = "EnableSession";
+  static final String ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME = "EnableTimestampPicos";
+  static final boolean DEFAULT_ENABLE_TIMESTAMP_PICOS_VALUE = false;
   static final String DEFAULT_LOG_PATH = "";
   static final String USE_QUERY_CACHE_PROPERTY_NAME = "UseQueryCache";
   static final boolean DEFAULT_USE_QUERY_CACHE = true;
@@ -445,6 +447,14 @@ final class BigQueryJdbcUrlUtility {
                           "Enable to capture your SQL activities or enable multi statement"
                               + " transactions. Disabled by default.")
                       .setDefaultValue(String.valueOf(DEFAULT_ENABLE_SESSION_VALUE))
+                      .build(),
+                  BigQueryConnectionProperty.newBuilder()
+                      .setName(ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME)
+                      .setDescription(
+                          "Enables picosecond precision for TIMESTAMP data types. When enabled,"
+                              + " TIMESTAMP(12) columns are retrieved with 12-digit picosecond"
+                              + " precision formatted in UTC. Disabled by default.")
+                      .setDefaultValue(String.valueOf(DEFAULT_ENABLE_TIMESTAMP_PICOS_VALUE))
                       .build(),
                   BigQueryConnectionProperty.newBuilder()
                       .setName(LOG_LEVEL_PROPERTY_NAME)

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQuerySettings.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQuerySettings.java
@@ -43,6 +43,7 @@ class BigQuerySettings {
   private final boolean unsupportedHTAPIFallback;
 
   private final boolean enableSession;
+  private final boolean enableTimestampPicos;
 
   private final ConnectionProperty sessionInfoConnectionProperty;
 
@@ -120,6 +121,7 @@ class BigQuerySettings {
     this.maxResultPerPage = builder.maxResultPerPage;
     this.defaultDataset = builder.defaultDataset;
     this.enableSession = builder.enableSession;
+    this.enableTimestampPicos = builder.enableTimestampPicos;
     this.unsupportedHTAPIFallback = builder.unsupportedHTAPIFallback;
     this.sessionInfoConnectionProperty = builder.sessionInfoConnectionProperty;
     this.useWriteAPI = builder.useWriteAPI;
@@ -169,6 +171,15 @@ class BigQuerySettings {
    */
   boolean isEnableSession() {
     return enableSession;
+  }
+
+  /**
+   * Returns whether picosecond precision is enabled for TIMESTAMP data types.
+   *
+   * @return true if picosecond precision is enabled, false otherwise.
+   */
+  boolean isEnableTimestampPicos() {
+    return enableTimestampPicos;
   }
 
   /**
@@ -476,6 +487,7 @@ class BigQuerySettings {
     private int highThroughputMinTableSize;
     private int highThroughputActivationRatio;
     private boolean enableSession;
+    private boolean enableTimestampPicos;
     private boolean unsupportedHTAPIFallback;
     private ConnectionProperty sessionInfoConnectionProperty;
     private boolean useQueryCache;
@@ -516,6 +528,7 @@ class BigQuerySettings {
       this.highThroughputMinTableSize = querySettings.getHighThroughputMinTableSize();
       this.highThroughputActivationRatio = querySettings.getHighThroughputActivationRatio();
       this.enableSession = querySettings.isEnableSession();
+      this.enableTimestampPicos = querySettings.isEnableTimestampPicos();
       this.unsupportedHTAPIFallback = querySettings.isUnsupportedHTAPIFallback();
       this.sessionInfoConnectionProperty = querySettings.getSessionInfoConnectionProperty();
       this.useQueryCache = querySettings.getUseQueryCache();
@@ -605,6 +618,15 @@ class BigQuerySettings {
      */
     Builder setEnableSession(boolean enableSession) {
       this.enableSession = enableSession;
+      return this;
+    }
+
+    /**
+     * Setting true enables 12-digit picosecond precision for TIMESTAMP(12) columns. Disabled by
+     * default.
+     */
+    Builder setEnableTimestampPicos(boolean enableTimestampPicos) {
+      this.enableTimestampPicos = enableTimestampPicos;
       return this;
     }
 

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -662,11 +662,6 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     } catch (InterruptedException ex) {
       throw new BigQueryJdbcRuntimeException("Interrupted during runQuery", ex);
     } catch (BigQueryException ex) {
-      if (isEnableTimestampPicos() && getUseLegacySql()) {
-        throw new BigQueryJdbcException(
-            "Picosecond data is incompatible with Legacy SQL. To query your Picosecond data, please set QueryDialect to SQL and restructure your query as a Standard SQL query.",
-            ex);
-      }
       if (ex.getMessage().contains("Syntax error")) {
         throw new BigQueryJdbcSqlSyntaxErrorException("BigQueryException during runQuery", ex);
       }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -216,6 +216,7 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     querySettings.setUseWriteAPI(this.connection.isEnableWriteAPI());
     querySettings.setWriteAPIActivationRowCount(this.connection.getWriteAPIActivationRowCount());
     querySettings.setWriteAPIAppendRowCount(this.connection.getWriteAPIAppendRowCount());
+    querySettings.setEnableTimestampPicos(this.connection.isEnableTimestampPicos());
 
     return querySettings.build();
   }
@@ -661,6 +662,11 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
     } catch (InterruptedException ex) {
       throw new BigQueryJdbcRuntimeException("Interrupted during runQuery", ex);
     } catch (BigQueryException ex) {
+      if (isEnableTimestampPicos() && getUseLegacySql()) {
+        throw new BigQueryJdbcException(
+            "Picosecond data is incompatible with Legacy SQL. To query your Picosecond data, please set QueryDialect to SQL and restructure your query as a Standard SQL query.",
+            ex);
+      }
       if (ex.getMessage().contains("Syntax error")) {
         throw new BigQueryJdbcSqlSyntaxErrorException("BigQueryException during runQuery", ex);
       }
@@ -1532,6 +1538,10 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
   private boolean getUseLegacySql() {
     return QueryDialectType.BIG_QUERY.equals(
         QueryDialectType.valueOf(this.querySettings.getQueryDialect()));
+  }
+
+  boolean isEnableTimestampPicos() {
+    return this.querySettings.isEnableTimestampPicos();
   }
 
   private void checkIfDatasetExistElseCreate(String datasetName) {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/DataSource.java
@@ -58,6 +58,7 @@ public class DataSource implements javax.sql.DataSource {
   private Map<String, String> queryProperties;
   private String logLevel;
   private Boolean enableSession;
+  private Boolean enableTimestampPicos;
   private String logPath;
   private String gcpTelemetryProjectId;
   private String gcpTelemetryCredentials;
@@ -180,6 +181,12 @@ public class DataSource implements javax.sql.DataSource {
                   ds.setEnableSession(
                       BigQueryJdbcUrlUtility.convertIntToBoolean(
                           val, BigQueryJdbcUrlUtility.ENABLE_SESSION_PROPERTY_NAME)))
+          .put(
+              BigQueryJdbcUrlUtility.ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME,
+              (ds, val) ->
+                  ds.setEnableTimestampPicos(
+                      BigQueryJdbcUrlUtility.convertIntToBoolean(
+                          val, BigQueryJdbcUrlUtility.ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME)))
           .put(BigQueryJdbcUrlUtility.LOG_LEVEL_PROPERTY_NAME, DataSource::setLogLevel)
           .put(BigQueryJdbcUrlUtility.LOG_PATH_PROPERTY_NAME, DataSource::setLogPath)
           .put(
@@ -489,6 +496,11 @@ public class DataSource implements javax.sql.DataSource {
     if (this.enableSession != null) {
       connectionProperties.setProperty(
           BigQueryJdbcUrlUtility.ENABLE_SESSION_PROPERTY_NAME, String.valueOf(this.enableSession));
+    }
+    if (this.enableTimestampPicos != null) {
+      connectionProperties.setProperty(
+          BigQueryJdbcUrlUtility.ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME,
+          String.valueOf(this.enableTimestampPicos));
     }
     if (this.logLevel != null) {
       connectionProperties.setProperty(
@@ -933,6 +945,16 @@ public class DataSource implements javax.sql.DataSource {
 
   public void setEnableSession(Boolean enableSession) {
     this.enableSession = enableSession;
+  }
+
+  public Boolean getEnableTimestampPicos() {
+    return enableTimestampPicos != null
+        ? enableTimestampPicos
+        : BigQueryJdbcUrlUtility.DEFAULT_ENABLE_TIMESTAMP_PICOS_VALUE;
+  }
+
+  public void setEnableTimestampPicos(Boolean enableTimestampPicos) {
+    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   public String getLogLevel() {

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryConnectionTest.java
@@ -819,4 +819,19 @@ public class BigQueryConnectionTest extends BigQueryJdbcLoggingBaseTest {
           "user_supplied_session_999", connection.getSessionInfoConnectionProperty().getValue());
     }
   }
+
+  @Test
+  public void testEnableTimestampPicosDefault() throws Exception {
+    try (BigQueryConnection connection = new BigQueryConnection(BASE_URL)) {
+      assertFalse(connection.isEnableTimestampPicos());
+    }
+  }
+
+  @Test
+  public void testEnableTimestampPicosConfigured() throws Exception {
+    String url = BASE_URL + "EnableTimestampPicos=1;";
+    try (BigQueryConnection connection = new BigQueryConnection(url)) {
+      assertTrue(connection.isEnableTimestampPicos());
+    }
+  }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtilityTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcUrlUtilityTest.java
@@ -348,4 +348,23 @@ public class BigQueryJdbcUrlUtilityTest extends BigQueryJdbcLoggingBaseTest {
         BigQueryJdbcRuntimeException.class,
         () -> BigQueryJdbcUrlUtility.parseDefaultDataset("   :   "));
   }
+
+  @Test
+  public void testParseEnableTimestampPicos() {
+    String url =
+        "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;"
+            + "ProjectId=MyBigQueryProject;"
+            + "EnableTimestampPicos=1";
+
+    String result = BigQueryJdbcUrlUtility.parseUriProperty(url, "EnableTimestampPicos");
+    assertThat(result).isEqualTo("1");
+
+    String url2 =
+        "jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;"
+            + "ProjectId=MyBigQueryProject;"
+            + "EnableTimestampPicos=0";
+
+    String result2 = BigQueryJdbcUrlUtility.parseUriProperty(url2, "EnableTimestampPicos");
+    assertThat(result2).isEqualTo("0");
+  }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -1162,21 +1161,9 @@ public class BigQueryStatementTest {
   }
 
   @Test
-  public void testLegacySqlWithEnableTimestampPicosTranslatesBackendException() throws Exception {
-    doReturn(BigQueryStatement.QueryDialectType.BIG_QUERY.name())
-        .when(bigQueryConnection)
-        .getQueryDialect();
+  public void testEnableTimestampPicosPropagation() {
     doReturn(true).when(bigQueryConnection).isEnableTimestampPicos();
-    BigQueryException backendException = new BigQueryException(400, "Backend error");
-    Mockito.doThrow(backendException)
-        .when(bigquery)
-        .queryWithTimeout(Mockito.any(QueryJobConfiguration.class), Mockito.any(), Mockito.any());
-
     BigQueryStatement statement = new BigQueryStatement(bigQueryConnection);
-
-    BigQueryJdbcException ex =
-        assertThrows(BigQueryJdbcException.class, () -> statement.executeQuery("SELECT 1"));
-    assertThat(ex.getMessage()).contains("Picosecond data is incompatible with Legacy SQL");
-    assertThat(ex.getCause()).isSameInstanceAs(backendException);
+    assertTrue(statement.isEnableTimestampPicos());
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -1158,5 +1159,24 @@ public class BigQueryStatementTest {
     assertNull(bigQueryStatement.getResultSet());
     verify(bigquery, Mockito.times(1)).getJob(eq(this.jobId));
     verify(bigquery, Mockito.never()).create(any(JobInfo.class));
+  }
+
+  @Test
+  public void testLegacySqlWithEnableTimestampPicosTranslatesBackendException() throws Exception {
+    doReturn(BigQueryStatement.QueryDialectType.BIG_QUERY.name())
+        .when(bigQueryConnection)
+        .getQueryDialect();
+    doReturn(true).when(bigQueryConnection).isEnableTimestampPicos();
+    BigQueryException backendException = new BigQueryException(400, "Backend error");
+    Mockito.doThrow(backendException)
+        .when(bigquery)
+        .queryWithTimeout(Mockito.any(QueryJobConfiguration.class), Mockito.any(), Mockito.any());
+
+    BigQueryStatement statement = new BigQueryStatement(bigQueryConnection);
+
+    BigQueryJdbcException ex =
+        assertThrows(BigQueryJdbcException.class, () -> statement.executeQuery("SELECT 1"));
+    assertThat(ex.getMessage()).contains("Picosecond data is incompatible with Legacy SQL");
+    assertThat(ex.getCause()).isSameInstanceAs(backendException);
   }
 }


### PR DESCRIPTION
b/544843125

This PR introduces the `EnableTimestampPicos` connection property to configure 12-digit picosecond precision for BigQuery `TIMESTAMP(12)` data, establishing the configuration foundation across the driver pipeline.

#### Key Changes
- **Configuration & URL Plumbing**:
  - Defined `ENABLE_TIMESTAMP_PICOS_PROPERTY_NAME = "EnableTimestampPicos"` (default: `false`) in `BigQueryJdbcUrlUtility.java`
  - Added standard getters/setters in `DataSource.java` and registered the setter in `PROPERTY_SETTERS` via `convertIntToBoolean` (supporting `1`, `0`, `true`, `false`)
  - Propagated the flag through `BigQueryConnection.java` (registered in `SAFE_TO_LOG_PROPERTIES`) and into immutable `BigQuerySettings.java`
- **Documentation**:
  - Documented the configuration property and precision behavior in `docs/USER_GUIDE.md`
  
#### Testing
- `BigQueryJdbcUrlUtilityTest.java`: Verified parsing of `EnableTimestampPicos` (`1` and `0`).
- `BigQueryConnectionTest.java`: Verified default (`false`) and URL-configured (`true`) states.
