### PR TITLE
test(spanner): deflake CloseSpannerWithOpenResultSetTest

### DIFF
--- a/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
+++ b/java-spanner/google-cloud-spanner/src/test/java/com/google/cloud/spanner/CloseSpannerWithOpenResultSetTest.java
@@ -61,7 +61,7 @@ public class CloseSpannerWithOpenResultSetTest extends AbstractMockServerTest {
 
   @BeforeClass
   public static void setWatchdogTimeout() {
-    System.setProperty("com.google.cloud.spanner.watchdogTimeoutSeconds", "1");
+    System.setProperty("com.google.cloud.spanner.watchdogTimeoutSeconds", "5");
   }
 
   @AfterClass


### PR DESCRIPTION
CloseSpannerWithOpenResultSetTest sets
com.google.cloud.spanner.watchdogTimeoutSeconds to 1 second in @BeforeClass.

During testStreamsAreCleanedUp, 16 threads concurrently execute 32 queries against a freshly created Spanner client. Under high CPU load in CI, thread contention during cold-start initialization can cause stream chunk delivery to exceed 1 second, intermittently triggering DEADLINE_EXCEEDED: stream wait timeout.

Increase the stream watchdog timeout from 1 second to 5 seconds to provide sufficient headroom under multi-threaded CI load while retaining fail-fast behavior if a mock stream hangs.