### PR TITLE
test(firestore): revert `skipUnitTests` changes 

### DIFF
--- a/java-firestore/google-cloud-firestore-admin/pom.xml
+++ b/java-firestore/google-cloud-firestore-admin/pom.xml
@@ -150,6 +150,12 @@
 
   <profiles>
     <profile>
+      <id>native</id>
+      <properties>
+        <skipUnitTests>false</skipUnitTests>
+      </properties>
+    </profile>
+    <profile>
       <id>java9</id>
       <activation>
         <jdk>[9,)</jdk>

--- a/java-firestore/google-cloud-firestore-admin/pom.xml
+++ b/java-firestore/google-cloud-firestore-admin/pom.xml
@@ -15,9 +15,6 @@
     <artifactId>google-cloud-firestore-parent</artifactId>
     <version>3.47.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore:current} -->
   </parent>
-  <properties>
-    <skipUnitTests>true</skipUnitTests>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -149,12 +146,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>native</id>
-      <properties>
-        <skipUnitTests>false</skipUnitTests>
-      </properties>
-    </profile>
     <profile>
       <id>java9</id>
       <activation>

--- a/java-firestore/google-cloud-firestore/pom.xml
+++ b/java-firestore/google-cloud-firestore/pom.xml
@@ -14,6 +14,7 @@
     <version>3.47.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore:current} -->
   </parent>
   <properties>
+    <skipUnitTests>false</skipUnitTests>
     <site.installationModule>google-cloud-firestore</site.installationModule>
   </properties>
   <dependencies>

--- a/java-firestore/pom.xml
+++ b/java-firestore/pom.xml
@@ -139,7 +139,7 @@
   </licenses>
 
   <properties>
-    <skipUnitTests>false</skipUnitTests>
+    <!-- skipUnitTests is intentionally not set here so generated submodules (like admin) inherit true by default. Core handwritten unit tests are enabled in google-cloud-firestore/pom.xml. -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <github.global.server>github</github.global.server>


### PR DESCRIPTION
Reverted manual configs in `google-cloud-firestore/pom.xml` so the
generated client stays untouched and inherits parent profile settings.
Moved `<skipUnitTests>false</skipUnitTests>` exclusively into
`google-cloud-firestore/pom.xml` so handwritten unit tests run while the
generated tests are skipped.

Fixes GraalVM native build image failure. When running native image
builds, `google-cloud-jar-parent` activates the `native` profile and
set `skipUnitTests` to `false`. But `google-cloud-firestore-admin`
overwrites this to `true`, so Surefire doesn't run and doesn't
generate metadata required by the GraalVM tests, so we got the fatal build
error 
```
Test configuration file wasn't found. Make sure that test
execution wasn't skipped.
```  
By removing the hard-coded property the
metadata for GraalVM tests can be generated, and they run.

Failure on main: https://btx.cloud.google.com/invocations/970423a5-2c74-406c-b4a2-8f3cfcac3eda