### PR TITLE
feat(generator): add model flag and allowlist parser for resumable upload RPCs

### DIFF
--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/model/Method.java
@@ -44,6 +44,8 @@ public abstract class Method {
 
   public abstract boolean isBatching();
 
+  public abstract boolean isResumableUpload();
+
   public boolean isPaged() {
     return pageSizeFieldName() != null;
   }
@@ -137,7 +139,8 @@ public abstract class Method {
         .setIsInternalApi(false)
         .setIsBatching(false)
         .setIsDeprecated(false)
-        .setOperationPollingMethod(false);
+        .setOperationPollingMethod(false)
+        .setIsResumableUpload(false);
   }
 
   public static Stream toStream(boolean isClientStreaming, boolean isServerStreaming) {
@@ -176,6 +179,8 @@ public abstract class Method {
     public abstract Builder setMethodSignatures(List<List<MethodArgument>> methodSignature);
 
     public abstract Builder setIsBatching(boolean isBatching);
+
+    public abstract Builder setIsResumableUpload(boolean isResumableUpload);
 
     public abstract Builder setPageSizeFieldName(String pagedFieldName);
 

--- a/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
+++ b/sdk-platform-java/gapic-generator-java/src/main/java/com/google/api/generator/gapic/protoparser/Parser.java
@@ -88,6 +88,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.jspecify.annotations.NullMarked;
@@ -98,9 +99,10 @@ public class Parser {
   enum SelectiveGapicType {
     // Methods will be generated and exposed externally as usual.
     PUBLIC,
-    // Methods will not be generated.
+    // Method generation will be skipped.
     HIDDEN,
-    // Methods will be generated and tagged @InternalApi (internal use) during generation.
+    // Methods will be marked as BetaApi with InternalApi, this will prevent method from being
+    // exposed externally.
     INTERNAL
   }
 
@@ -133,6 +135,9 @@ public class Parser {
           "google.cloud.bigquery.v2.DatasetService.ListDatasets",
           "google.cloud.bigquery.v2.ModelService.ListModels",
           "google.cloud.bigquery.v2.TableService.ListTables");
+
+  private static final ImmutableList<Pattern> RESUMABLE_UPLOAD_ALLOWLIST_PATTERNS =
+      ImmutableList.of();
 
   // Allow other parsers to access this.
   protected static final SourceCodeInfoParser SOURCE_CODE_INFO_PARSER = new SourceCodeInfoParser();
@@ -872,6 +877,9 @@ public class Parser {
                   .getOptions()
                   .getExtension(ExtendedOperationsProto.operationPollingMethod)
               : false;
+      boolean isResumableUpload =
+          RESUMABLE_UPLOAD_ALLOWLIST_PATTERNS.stream()
+              .anyMatch(pattern -> pattern.matcher(protoMethod.getFullName()).matches());
       RoutingHeaderRule routingHeaderRule =
           RoutingRuleParser.parse(protoMethod, inputMessage, messageTypes);
       methods.add(
@@ -895,6 +903,7 @@ public class Parser {
               .setAutoPopulatedFields(autoPopulatedFields)
               .setRoutingHeaderRule(routingHeaderRule)
               .setIsBatching(isBatching)
+              .setIsResumableUpload(isResumableUpload)
               .setPageSizeFieldName(parsePageSizeFieldName(protoMethod, messageTypes, transport))
               .setIsDeprecated(isDeprecated)
               .setOperationPollingMethod(operationPollingMethod)

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/gapic/protoparser/ParserTest.java
@@ -55,6 +55,7 @@ import com.google.protobuf.Descriptors.ServiceDescriptor;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
 import com.google.selective.generate.v1beta1.SelectiveApiGenerationOuterClass;
 import com.google.showcase.v1beta1.EchoOuterClass;
+import com.google.showcase.v1beta1.ResumableUpload;
 import com.google.showcase.v1beta1.TestingOuterClass;
 import com.google.testgapic.v1beta1.LockerProto;
 import java.nio.file.Path;
@@ -163,6 +164,7 @@ class ParserTest {
     assertEquals(echoMethod.name(), "Echo");
     assertEquals(echoMethod.stream(), Method.Stream.NONE);
     assertEquals(false, echoMethod.hasAutoPopulatedFields());
+    assertFalse(echoMethod.isResumableUpload());
 
     // Detailed method signature parsing tests are in a separate unit test.
     List<List<MethodArgument>> methodSignatures = echoMethod.methodSignatures();
@@ -201,6 +203,32 @@ class ParserTest {
     assertEquals("Chat", chatMethod.name());
     assertEquals(Method.Stream.BIDI, chatMethod.stream());
     assertEquals(false, chatMethod.hasAutoPopulatedFields());
+  }
+
+  @Test
+  void parseMethods_resumableUpload() {
+    FileDescriptor resumableUploadFileDescriptor = ResumableUpload.getDescriptor();
+    ServiceDescriptor resumableUploadService = resumableUploadFileDescriptor.getServices().get(0);
+    Map<String, Message> messageTypes = Parser.parseMessages(resumableUploadFileDescriptor);
+    Map<String, ResourceName> resourceNames =
+        Parser.parseResourceNames(resumableUploadFileDescriptor);
+    Set<ResourceName> outputResourceNames = new HashSet<>();
+    List<Method> methods =
+        Parser.parseMethods(
+            resumableUploadService,
+            ECHO_PACKAGE,
+            ECHO_PACKAGE,
+            messageTypes,
+            resourceNames,
+            Optional.empty(),
+            Optional.empty(),
+            outputResourceNames,
+            Transport.GRPC);
+
+    assertEquals(1, methods.size());
+    Method uploadMethod = methods.get(0);
+    assertEquals("UploadMedia", uploadMethod.name());
+    assertFalse(uploadMethod.isResumableUpload());
   }
 
   @Test

--- a/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
+++ b/sdk-platform-java/gapic-generator-java/src/test/java/com/google/api/generator/test/protoloader/TestProtoLoader.java
@@ -45,6 +45,7 @@ import com.google.selective.generate.v1beta1.SelectiveApiGenerationOuterClass;
 import com.google.showcase.v1beta1.EchoOuterClass;
 import com.google.showcase.v1beta1.IdentityOuterClass;
 import com.google.showcase.v1beta1.MessagingOuterClass;
+import com.google.showcase.v1beta1.ResumableUpload;
 import com.google.showcase.v1beta1.TestingOuterClass;
 import com.google.test.callablenamingtype.CallableNameType;
 import com.google.testdata.v1.DeprecatedServiceOuterClass;
@@ -275,6 +276,44 @@ public class TestProtoLoader {
         .setServices(services)
         .setHelperResourceNames(outputResourceNames)
         .setTransport(transport)
+        .build();
+  }
+
+  public GapicContext parseShowcaseResumableUpload() {
+    FileDescriptor fileDescriptor = ResumableUpload.getDescriptor();
+    ServiceDescriptor serviceDescriptor = fileDescriptor.getServices().get(0);
+    assertEquals("ResumableUploadService", serviceDescriptor.getName());
+
+    Map<String, Message> messageTypes = Parser.parseMessages(fileDescriptor);
+    Map<String, ResourceName> resourceNames = Parser.parseResourceNames(fileDescriptor);
+    Set<ResourceName> outputResourceNames = new HashSet<>();
+    List<Service> services =
+        Parser.parseService(
+            fileDescriptor, messageTypes, resourceNames, Optional.empty(), outputResourceNames);
+
+    List<Service> adaptedServices =
+        services.stream()
+            .map(
+                s ->
+                    s.toBuilder()
+                        .setMethods(
+                            s.methods().stream()
+                                .map(
+                                    m ->
+                                        m.name().equals("UploadMedia")
+                                            ? m.toBuilder().setIsResumableUpload(true).build()
+                                            : m)
+                                .collect(Collectors.toList()))
+                        .build())
+            .collect(Collectors.toList());
+
+    return GapicContext.builder()
+        .setMessages(messageTypes)
+        .setResourceNames(resourceNames)
+        .setServices(adaptedServices)
+        .setHelperResourceNames(outputResourceNames)
+        .setTransport(transport)
+        .setServiceConfig(GapicServiceConfig.create(Optional.empty()))
         .build();
   }
 

--- a/sdk-platform-java/gapic-generator-java/src/test/proto/resumable_upload.proto
+++ b/sdk-platform-java/gapic-generator-java/src/test/proto/resumable_upload.proto
@@ -1,0 +1,47 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.showcase.v1beta1;
+
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+
+option go_package = "github.com/googleapis/gapic-showcase/server/genproto";
+option java_package = "com.google.showcase.v1beta1";
+option java_multiple_files = true;
+option ruby_package = "Google::Showcase::V1beta1";
+
+// A service showcasing universal resumable upload protocol support.
+service ResumableUploadService {
+  option (google.api.default_host) = "localhost:7469";
+
+  // A method with media_upload annotation enabled.
+  rpc UploadMedia(UploadMediaRequest) returns (UploadMediaResponse) {
+    option (google.api.http) = {
+      post: "/v1beta1/files:upload"
+      body: "*"
+    };
+  }
+}
+
+message UploadMediaRequest {
+  string name = 1;
+}
+
+message UploadMediaResponse {
+  string name = 1;
+  int64 size = 2;
+}


### PR DESCRIPTION
Work in progress, not ready for review