### PR TITLE
feat(bigquery-jdbc): support picosecond timestamps in Arrow Storage Read API and nested types

### DIFF
--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
+import org.apache.arrow.vector.util.Text;
 
 /**
  * An implementation of {@link BigQueryBaseArray} used to represent Array values from Arrow data.
@@ -30,15 +31,20 @@ import org.apache.arrow.vector.util.JsonStringHashMap;
 class BigQueryArrowArray extends BigQueryBaseArray {
 
   private JsonStringArrayList<?> values;
+  private final boolean enableTimestampPicos;
 
-  public BigQueryArrowArray(Field schema, JsonStringArrayList<?> values) {
-    this(schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class));
+  BigQueryArrowArray(Field schema, JsonStringArrayList<?> values) {
+    this(schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class), false);
   }
 
-  public BigQueryArrowArray(
-      Field schema, JsonStringArrayList<?> values, BigQueryJdbcResultSetLogger log) {
+  BigQueryArrowArray(
+      Field schema,
+      JsonStringArrayList<?> values,
+      BigQueryJdbcResultSetLogger log,
+      boolean enableTimestampPicos) {
     super(schema, log);
     this.values = values;
+    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   @Override
@@ -72,7 +78,11 @@ class BigQueryArrowArray extends BigQueryBaseArray {
     BigQueryArrowBatchWrapper arrowBatchWrapper =
         BigQueryArrowBatchWrapper.getNestedFieldValueListWrapper(values);
     return BigQueryArrowResultSet.getNestedResultSet(
-        Schema.of(singleElementSchema()), arrowBatchWrapper, 0, this.values.size());
+        Schema.of(singleElementSchema()),
+        arrowBatchWrapper,
+        0,
+        this.values.size(),
+        this.enableTimestampPicos);
   }
 
   @Override
@@ -86,7 +96,11 @@ class BigQueryArrowArray extends BigQueryBaseArray {
     BigQueryArrowBatchWrapper arrowBatchWrapper =
         BigQueryArrowBatchWrapper.getNestedFieldValueListWrapper(values);
     return BigQueryArrowResultSet.getNestedResultSet(
-        Schema.of(singleElementSchema()), arrowBatchWrapper, range.x(), range.y());
+        Schema.of(singleElementSchema()),
+        arrowBatchWrapper,
+        range.x(),
+        range.y(),
+        this.enableTimestampPicos);
   }
 
   @Override
@@ -97,12 +111,31 @@ class BigQueryArrowArray extends BigQueryBaseArray {
   }
 
   @Override
+  protected Class<?> getTargetClass() {
+    LOG.finestTrace("getTargetClass");
+    if (this.enableTimestampPicos && BigQueryArrowResultSet.isPicosecondTimestamp(this.schema)) {
+      return String.class;
+    }
+    return super.getTargetClass();
+  }
+
+  @Override
   Object getCoercedValue(int index) throws SQLException {
     LOG.finestTrace("getCoercedValue");
     Object value = this.values.get(index);
-    return this.arrayOfStruct
-        ? new BigQueryArrowStruct(
-            schema.getSubFields(), (JsonStringHashMap<?, ?>) value, this.LOG.getArrowStructLogger())
-        : BigQueryTypeRegistry.convert(value, this.schema.getType().getStandardType(), null);
+    if (value instanceof Text) {
+      value = value.toString();
+    }
+    if (this.arrayOfStruct) {
+      return new BigQueryArrowStruct(
+          schema.getSubFields(),
+          (JsonStringHashMap<?, ?>) value,
+          this.LOG.getArrowStructLogger(),
+          this.enableTimestampPicos);
+    }
+    if (this.enableTimestampPicos && BigQueryArrowResultSet.isPicosecondTimestamp(this.schema)) {
+      return BigQueryTemporalUtility.formatTimestampValue(value, true);
+    }
+    return BigQueryTypeRegistry.convert(value, this.schema.getType().getStandardType(), null);
   }
 }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
@@ -31,20 +31,18 @@ import org.apache.arrow.vector.util.Text;
 class BigQueryArrowArray extends BigQueryBaseArray {
 
   private JsonStringArrayList<?> values;
-  private final boolean enableTimestampPicos;
 
   BigQueryArrowArray(Field schema, JsonStringArrayList<?> values) {
-    this(schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class), false);
+    this(schema, values, false, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class));
   }
 
   BigQueryArrowArray(
       Field schema,
       JsonStringArrayList<?> values,
-      BigQueryJdbcResultSetLogger log,
-      boolean enableTimestampPicos) {
-    super(schema, log);
+      boolean enableTimestampPicos,
+      BigQueryJdbcResultSetLogger log) {
+    super(schema, enableTimestampPicos, log);
     this.values = values;
-    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   @Override
@@ -111,15 +109,6 @@ class BigQueryArrowArray extends BigQueryBaseArray {
   }
 
   @Override
-  protected Class<?> getTargetClass() {
-    LOG.finestTrace("getTargetClass");
-    if (this.enableTimestampPicos && BigQueryArrowResultSet.isPicosecondTimestamp(this.schema)) {
-      return String.class;
-    }
-    return super.getTargetClass();
-  }
-
-  @Override
   Object getCoercedValue(int index) throws SQLException {
     LOG.finestTrace("getCoercedValue");
     Object value = this.values.get(index);
@@ -130,10 +119,10 @@ class BigQueryArrowArray extends BigQueryBaseArray {
       return new BigQueryArrowStruct(
           schema.getSubFields(),
           (JsonStringHashMap<?, ?>) value,
-          this.LOG.getArrowStructLogger(),
-          this.enableTimestampPicos);
+          this.enableTimestampPicos,
+          this.LOG.getArrowStructLogger());
     }
-    if (this.enableTimestampPicos && BigQueryArrowResultSet.isPicosecondTimestamp(this.schema)) {
+    if (this.enableTimestampPicos && BigQueryTemporalUtility.isPicosecondTimestamp(this.schema)) {
       return BigQueryTemporalUtility.formatTimestampValue(value, true);
     }
     return BigQueryTypeRegistry.convert(value, this.schema.getType().getStandardType(), null);

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -112,8 +112,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     this.toIndexExclusive = toIndexExclusive;
     this.nestedRowIndex = fromIndex - 1;
     this.ownedTask = ownedTask;
-    this.enableTimestampPicos =
-        statement != null ? statement.isEnableTimestampPicos() : enableTimestampPicos;
+    this.enableTimestampPicos = enableTimestampPicos;
     if (!isNested && arrowSchema != null) {
       try {
         this.arrowDeserializer = new ArrowDeserializer(arrowSchema);
@@ -164,7 +163,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         ownedTask,
         bigQuery,
         job,
-        false);
+        statement != null && statement.isEnableTimestampPicos());
   }
 
   BigQueryArrowResultSet() throws SQLException {
@@ -364,13 +363,6 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     return value;
   }
 
-  static boolean isPicosecondTimestamp(Field field) {
-    return field != null
-        && field.getType().getStandardType() == StandardSQLTypeName.TIMESTAMP
-        && field.getTimestampPrecision() != null
-        && field.getTimestampPrecision() > 6;
-  }
-
   @Override
   public Object getObject(int columnIndex) throws SQLException {
 
@@ -392,14 +384,14 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         return new BigQueryArrowStruct(
             arrayField.getSubFields(),
             (JsonStringHashMap<?, ?>) value,
-            this.LOG.getArrowStructLogger(),
-            this.enableTimestampPicos);
+            this.enableTimestampPicos,
+            this.LOG.getArrowStructLogger());
       }
       if (value instanceof Integer
           && arrayField.getType().getStandardType() == StandardSQLTypeName.DATE) {
         value = LocalDate.ofEpochDay(((Integer) value).longValue());
       }
-      if (this.enableTimestampPicos && isPicosecondTimestamp(arrayField)) {
+      if (this.enableTimestampPicos && BigQueryTemporalUtility.isPicosecondTimestamp(arrayField)) {
         return BigQueryTemporalUtility.formatTimestampValue(value, true);
       }
       return BigQueryTypeRegistry.convert(value, arrayField.getType().getStandardType(), null);
@@ -421,7 +413,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
           newList.add(((BigDecimal) item).stripTrailingZeros());
         }
         return new BigQueryArrowArray(
-            fieldSchema, newList, this.LOG.getArrowArrayLogger(), this.enableTimestampPicos);
+            fieldSchema, newList, this.enableTimestampPicos, this.LOG.getArrowArrayLogger());
       }
       if (elementTypeName == StandardSQLTypeName.RANGE) {
         JsonStringArrayList<String> newList = new JsonStringArrayList<>();
@@ -444,18 +436,18 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
           newList.add(String.format("[%s, %s)", formattedStart, formattedEnd));
         }
         return new BigQueryArrowArray(
-            fieldSchema, newList, this.LOG.getArrowArrayLogger(), this.enableTimestampPicos);
+            fieldSchema, newList, this.enableTimestampPicos, this.LOG.getArrowArrayLogger());
       }
       return new BigQueryArrowArray(
-          fieldSchema, originalList, this.LOG.getArrowArrayLogger(), this.enableTimestampPicos);
+          fieldSchema, originalList, this.enableTimestampPicos, this.LOG.getArrowArrayLogger());
     }
 
     if (isStruct(fieldSchema)) {
       return new BigQueryArrowStruct(
           fieldSchema.getSubFields(),
           (JsonStringHashMap<?, ?>) value,
-          this.LOG.getArrowStructLogger(),
-          this.enableTimestampPicos);
+          this.enableTimestampPicos,
+          this.LOG.getArrowStructLogger());
     }
 
     if (fieldSchema.getType().getStandardType() == StandardSQLTypeName.RANGE) {
@@ -479,7 +471,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
       // Strip trailing zeros to match JSON API and CLI output
       return ((BigDecimal) value).stripTrailingZeros();
     }
-    if (this.enableTimestampPicos && isPicosecondTimestamp(fieldSchema)) {
+    if (this.enableTimestampPicos && BigQueryTemporalUtility.isPicosecondTimestamp(fieldSchema)) {
       return BigQueryTemporalUtility.formatTimestampValue(value, true);
     }
     return BigQueryTypeRegistry.convert(value, fieldSchema.getType().getStandardType(), null);

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
@@ -51,6 +51,7 @@ import org.apache.arrow.vector.ipc.message.MessageSerializer;
 import org.apache.arrow.vector.util.ByteArrayReadableSeekableByteChannel;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
+import org.apache.arrow.vector.util.Text;
 
 /** {@link ResultSet} Implementation for Arrow datasource (Using Storage Read APIs) */
 class BigQueryArrowResultSet extends BigQueryBaseResultSet {
@@ -85,6 +86,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
   private VectorLoader vectorLoader;
   // producer task's reference
   private final Future<?> ownedTask;
+  private final boolean enableTimestampPicos;
 
   private BigQueryArrowResultSet(
       Schema schema,
@@ -98,7 +100,8 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
       int toIndexExclusive,
       Future<?> ownedTask,
       BigQuery bigQuery,
-      Job job)
+      Job job,
+      boolean enableTimestampPicos)
       throws SQLException {
     super(bigQuery, statement, schema, isNested, job);
     LOG.finestTrace("<init>");
@@ -109,6 +112,8 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     this.toIndexExclusive = toIndexExclusive;
     this.nestedRowIndex = fromIndex - 1;
     this.ownedTask = ownedTask;
+    this.enableTimestampPicos =
+        statement != null ? statement.isEnableTimestampPicos() : enableTimestampPicos;
     if (!isNested && arrowSchema != null) {
       try {
         this.arrowDeserializer = new ArrowDeserializer(arrowSchema);
@@ -158,7 +163,8 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         -1,
         ownedTask,
         bigQuery,
-        job);
+        job,
+        false);
   }
 
   BigQueryArrowResultSet() throws SQLException {
@@ -172,10 +178,15 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     this.arrowDeserializer = null;
     this.vectorSchemaRoot = null;
     this.vectorLoader = null;
+    this.enableTimestampPicos = false;
   }
 
   static BigQueryArrowResultSet getNestedResultSet(
-      Schema schema, BigQueryArrowBatchWrapper nestedBatch, int fromIndex, int toIndexExclusive)
+      Schema schema,
+      BigQueryArrowBatchWrapper nestedBatch,
+      int fromIndex,
+      int toIndexExclusive,
+      boolean enableTimestampPicos)
       throws SQLException {
     return new BigQueryArrowResultSet(
         schema,
@@ -189,7 +200,8 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         toIndexExclusive,
         null,
         null,
-        null);
+        null,
+        enableTimestampPicos);
   }
 
   private class ArrowDeserializer implements AutoCloseable {
@@ -345,8 +357,18 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         value = LocalDate.ofEpochDay(((Integer) value).longValue());
       }
     }
+    if (value instanceof Text) {
+      value = value.toString();
+    }
     setWasNull(value);
     return value;
+  }
+
+  static boolean isPicosecondTimestamp(Field field) {
+    return field != null
+        && field.getType().getStandardType() == StandardSQLTypeName.TIMESTAMP
+        && field.getTimestampPrecision() != null
+        && field.getTimestampPrecision() > 6;
   }
 
   @Override
@@ -370,11 +392,15 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         return new BigQueryArrowStruct(
             arrayField.getSubFields(),
             (JsonStringHashMap<?, ?>) value,
-            this.LOG.getArrowStructLogger());
+            this.LOG.getArrowStructLogger(),
+            this.enableTimestampPicos);
       }
       if (value instanceof Integer
           && arrayField.getType().getStandardType() == StandardSQLTypeName.DATE) {
         value = LocalDate.ofEpochDay(((Integer) value).longValue());
+      }
+      if (this.enableTimestampPicos && isPicosecondTimestamp(arrayField)) {
+        return BigQueryTemporalUtility.formatTimestampValue(value, true);
       }
       return BigQueryTypeRegistry.convert(value, arrayField.getType().getStandardType(), null);
     }
@@ -388,61 +414,87 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
           || elementTypeName == StandardSQLTypeName.BIGNUMERIC) {
         JsonStringArrayList<BigDecimal> newList = new JsonStringArrayList<>();
         for (Object item : originalList) {
-          if (item != null) {
-            newList.add(((BigDecimal) item).stripTrailingZeros());
-          } else {
+          if (item == null) {
             newList.add(null);
+            continue;
           }
+          newList.add(((BigDecimal) item).stripTrailingZeros());
         }
-        return new BigQueryArrowArray(fieldSchema, newList, this.LOG.getArrowArrayLogger());
-      } else if (elementTypeName == StandardSQLTypeName.RANGE) {
+        return new BigQueryArrowArray(
+            fieldSchema, newList, this.LOG.getArrowArrayLogger(), this.enableTimestampPicos);
+      }
+      if (elementTypeName == StandardSQLTypeName.RANGE) {
         JsonStringArrayList<String> newList = new JsonStringArrayList<>();
         for (Object item : originalList) {
-          if (item != null) {
-            JsonStringHashMap<?, ?> rangeMap = (JsonStringHashMap<?, ?>) item;
-            Object start = rangeMap.get("start");
-            Object end = rangeMap.get("end");
-
-            Object representativeElement = (start != null) ? start : end;
-            StandardSQLTypeName rangeElementType = getElementTypeFromValue(representativeElement);
-
-            String formattedStart = formatRangeElement(start, rangeElementType);
-            String formattedEnd = formatRangeElement(end, rangeElementType);
-
-            newList.add(String.format("[%s, %s)", formattedStart, formattedEnd));
-          } else {
+          if (item == null) {
             newList.add(null);
+            continue;
           }
+          JsonStringHashMap<?, ?> rangeMap = (JsonStringHashMap<?, ?>) item;
+          Object start = rangeMap.get("start");
+          Object end = rangeMap.get("end");
+
+          Object representativeElement = (start != null) ? start : end;
+          StandardSQLTypeName rangeElementType =
+              getRangeElementType(fieldSchema, representativeElement);
+
+          String formattedStart = formatRangeElement(start, rangeElementType);
+          String formattedEnd = formatRangeElement(end, rangeElementType);
+
+          newList.add(String.format("[%s, %s)", formattedStart, formattedEnd));
         }
-        return new BigQueryArrowArray(fieldSchema, newList, this.LOG.getArrowArrayLogger());
+        return new BigQueryArrowArray(
+            fieldSchema, newList, this.LOG.getArrowArrayLogger(), this.enableTimestampPicos);
       }
-      return new BigQueryArrowArray(fieldSchema, originalList, this.LOG.getArrowArrayLogger());
-    } else if (isStruct(fieldSchema)) {
+      return new BigQueryArrowArray(
+          fieldSchema, originalList, this.LOG.getArrowArrayLogger(), this.enableTimestampPicos);
+    }
+
+    if (isStruct(fieldSchema)) {
       return new BigQueryArrowStruct(
           fieldSchema.getSubFields(),
           (JsonStringHashMap<?, ?>) value,
-          this.LOG.getArrowStructLogger());
-    } else if (fieldSchema.getType().getStandardType() == StandardSQLTypeName.RANGE) {
+          this.LOG.getArrowStructLogger(),
+          this.enableTimestampPicos);
+    }
+
+    if (fieldSchema.getType().getStandardType() == StandardSQLTypeName.RANGE) {
       JsonStringHashMap<?, ?> rangeMap = (JsonStringHashMap<?, ?>) value;
       Object start = rangeMap.get("start");
       Object end = rangeMap.get("end");
 
       Object representativeElement = (start != null) ? start : end;
-      StandardSQLTypeName elementType = getElementTypeFromValue(representativeElement);
+      StandardSQLTypeName elementType = getRangeElementType(fieldSchema, representativeElement);
 
       String formattedStart = formatRangeElement(start, elementType);
       String formattedEnd = formatRangeElement(end, elementType);
 
       return String.format("[%s, %s)", formattedStart, formattedEnd);
-    } else {
-      if ((fieldSchema.getType().getStandardType() == StandardSQLTypeName.NUMERIC
-              || fieldSchema.getType().getStandardType() == StandardSQLTypeName.BIGNUMERIC)
-          && value instanceof BigDecimal) {
-        // The Arrow DecimalVector may return a BigDecimal with a larger scale than necessary.
-        // Strip trailing zeros to match JSON API and CLI output
-        return ((BigDecimal) value).stripTrailingZeros();
-      }
-      return BigQueryTypeRegistry.convert(value, fieldSchema.getType().getStandardType(), null);
+    }
+
+    if ((fieldSchema.getType().getStandardType() == StandardSQLTypeName.NUMERIC
+            || fieldSchema.getType().getStandardType() == StandardSQLTypeName.BIGNUMERIC)
+        && value instanceof BigDecimal) {
+      // The Arrow DecimalVector may return a BigDecimal with a larger scale than necessary.
+      // Strip trailing zeros to match JSON API and CLI output
+      return ((BigDecimal) value).stripTrailingZeros();
+    }
+    if (this.enableTimestampPicos && isPicosecondTimestamp(fieldSchema)) {
+      return BigQueryTemporalUtility.formatTimestampValue(value, true);
+    }
+    return BigQueryTypeRegistry.convert(value, fieldSchema.getType().getStandardType(), null);
+  }
+
+  private StandardSQLTypeName getRangeElementType(Field field, Object representativeElement) {
+    if (field == null
+        || field.getRangeElementType() == null
+        || field.getRangeElementType().getType() == null) {
+      return getElementTypeFromValue(representativeElement);
+    }
+    try {
+      return StandardSQLTypeName.valueOf(field.getRangeElementType().getType());
+    } catch (IllegalArgumentException ignored) {
+      return getElementTypeFromValue(representativeElement);
     }
   }
 
@@ -467,6 +519,9 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
     if (element == null) {
       return "UNBOUNDED";
     }
+    if (element instanceof Text) {
+      element = element.toString();
+    }
     switch (elementType) {
       case DATE:
         // Arrow gives DATE as an Integer (days since epoch)
@@ -476,9 +531,7 @@ class BigQueryArrowResultSet extends BigQueryBaseResultSet {
         Timestamp dtTs = Timestamp.valueOf((LocalDateTime) element);
         return BigQueryTypeRegistry.convert(dtTs, String.class);
       case TIMESTAMP:
-        // Arrow gives TIMESTAMP as a Long (microseconds since epoch)
-        Timestamp ts = BigQueryTypeRegistry.convert((Long) element, Timestamp.class);
-        return BigQueryTypeRegistry.convert(ts, String.class);
+        return BigQueryTemporalUtility.formatTimestampValue(element, this.enableTimestampPicos);
       default:
         // Fallback for any other unexpected type
         return element.toString();

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
+import org.apache.arrow.vector.util.Text;
 
 /**
  * An implementation of {@link BigQueryBaseStruct} used to represent Struct values from Arrow data.
@@ -38,15 +39,21 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
 
   private final JsonStringHashMap<?, ?> values;
 
+  private final boolean enableTimestampPicos;
+
   BigQueryArrowStruct(FieldList schema, JsonStringHashMap<?, ?> values) {
-    this(schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class));
+    this(schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class), false);
   }
 
   BigQueryArrowStruct(
-      FieldList schema, JsonStringHashMap<?, ?> values, BigQueryJdbcResultSetLogger log) {
+      FieldList schema,
+      JsonStringHashMap<?, ?> values,
+      BigQueryJdbcResultSetLogger log,
+      boolean enableTimestampPicos) {
     super(log);
     this.schema = schema;
     this.values = values;
+    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   @Override
@@ -76,21 +83,31 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
 
   private Object getValue(Field currentSchema, Object currentValue) throws SQLException {
     LOG.finestTrace("getValue");
+    if (currentValue instanceof Text) {
+      currentValue = currentValue.toString();
+    }
     if (isArray(currentSchema)) {
       return new BigQueryArrowArray(
-          currentSchema, (JsonStringArrayList<?>) currentValue, this.LOG.getArrowArrayLogger());
-    } else if (isStruct(currentSchema)) {
+          currentSchema,
+          (JsonStringArrayList<?>) currentValue,
+          this.LOG.getArrowArrayLogger(),
+          this.enableTimestampPicos);
+    }
+    if (isStruct(currentSchema)) {
       return new BigQueryArrowStruct(
           currentSchema.getSubFields(),
           (JsonStringHashMap<?, ?>) currentValue,
-          this.LOG.getArrowStructLogger());
-    } else {
-      if (currentValue instanceof Integer
-          && currentSchema.getType().getStandardType() == StandardSQLTypeName.DATE) {
-        currentValue = LocalDate.ofEpochDay(((Integer) currentValue).longValue());
-      }
-      return BigQueryTypeRegistry.convert(
-          currentValue, currentSchema.getType().getStandardType(), null);
+          this.LOG.getArrowStructLogger(),
+          this.enableTimestampPicos);
     }
+    if (currentValue instanceof Integer
+        && currentSchema.getType().getStandardType() == StandardSQLTypeName.DATE) {
+      currentValue = LocalDate.ofEpochDay(((Integer) currentValue).longValue());
+    }
+    if (this.enableTimestampPicos && BigQueryArrowResultSet.isPicosecondTimestamp(currentSchema)) {
+      return BigQueryTemporalUtility.formatTimestampValue(currentValue, true);
+    }
+    return BigQueryTypeRegistry.convert(
+        currentValue, currentSchema.getType().getStandardType(), null);
   }
 }

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
@@ -39,21 +39,18 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
 
   private final JsonStringHashMap<?, ?> values;
 
-  private final boolean enableTimestampPicos;
-
   BigQueryArrowStruct(FieldList schema, JsonStringHashMap<?, ?> values) {
-    this(schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class), false);
+    this(schema, values, false, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class));
   }
 
   BigQueryArrowStruct(
       FieldList schema,
       JsonStringHashMap<?, ?> values,
-      BigQueryJdbcResultSetLogger log,
-      boolean enableTimestampPicos) {
-    super(log);
+      boolean enableTimestampPicos,
+      BigQueryJdbcResultSetLogger log) {
+    super(enableTimestampPicos, log);
     this.schema = schema;
     this.values = values;
-    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   @Override
@@ -90,21 +87,21 @@ class BigQueryArrowStruct extends BigQueryBaseStruct {
       return new BigQueryArrowArray(
           currentSchema,
           (JsonStringArrayList<?>) currentValue,
-          this.LOG.getArrowArrayLogger(),
-          this.enableTimestampPicos);
+          this.enableTimestampPicos,
+          this.LOG.getArrowArrayLogger());
     }
     if (isStruct(currentSchema)) {
       return new BigQueryArrowStruct(
           currentSchema.getSubFields(),
           (JsonStringHashMap<?, ?>) currentValue,
-          this.LOG.getArrowStructLogger(),
-          this.enableTimestampPicos);
+          this.enableTimestampPicos,
+          this.LOG.getArrowStructLogger());
     }
     if (currentValue instanceof Integer
         && currentSchema.getType().getStandardType() == StandardSQLTypeName.DATE) {
       currentValue = LocalDate.ofEpochDay(((Integer) currentValue).longValue());
     }
-    if (this.enableTimestampPicos && BigQueryArrowResultSet.isPicosecondTimestamp(currentSchema)) {
+    if (this.enableTimestampPicos && BigQueryTemporalUtility.isPicosecondTimestamp(currentSchema)) {
       return BigQueryTemporalUtility.formatTimestampValue(currentValue, true);
     }
     return BigQueryTypeRegistry.convert(

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
@@ -46,12 +46,18 @@ abstract class BigQueryBaseArray implements java.sql.Array {
   protected final boolean arrayOfStruct;
   private boolean valid;
   protected Field schema;
+  protected final boolean enableTimestampPicos;
 
   BigQueryBaseArray(Field schema, BigQueryJdbcResultSetLogger log) {
+    this(schema, false, log);
+  }
+
+  BigQueryBaseArray(Field schema, boolean enableTimestampPicos, BigQueryJdbcResultSetLogger log) {
     this.LOG = log;
     this.schema = schema;
     this.arrayOfStruct = isStruct(schema);
     this.valid = true;
+    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   @Override
@@ -142,6 +148,9 @@ abstract class BigQueryBaseArray implements java.sql.Array {
 
   protected Class<?> getTargetClass() {
     LOG.finestTrace("getTargetClass");
+    if (this.enableTimestampPicos && BigQueryTemporalUtility.isPicosecondTimestamp(this.schema)) {
+      return String.class;
+    }
     return this.arrayOfStruct
         ? Struct.class
         : BigQueryTypeRegistry.toJavaClass(this.schema.getType().getStandardType());

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
@@ -37,9 +37,15 @@ import java.util.Map;
  */
 abstract class BigQueryBaseStruct implements java.sql.Struct {
   protected final BigQueryJdbcResultSetLogger LOG;
+  protected final boolean enableTimestampPicos;
 
   BigQueryBaseStruct(BigQueryJdbcResultSetLogger log) {
+    this(false, log);
+  }
+
+  BigQueryBaseStruct(boolean enableTimestampPicos, BigQueryJdbcResultSetLogger log) {
     this.LOG = log;
+    this.enableTimestampPicos = enableTimestampPicos;
   }
 
   abstract FieldList getSchema();

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
@@ -50,12 +50,14 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcSqlFeatureNotSupportedExc
 import com.google.cloud.bigquery.exception.BigQueryJdbcSqlSyntaxErrorException;
 import com.google.cloud.bigquery.storage.v1.ArrowRecordBatch;
 import com.google.cloud.bigquery.storage.v1.ArrowSchema;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.grpc.Status;
@@ -883,6 +885,10 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       // format
       ReadSession.Builder sessionBuilder =
           ReadSession.newBuilder().setTable(srcTable).setDataFormat(DataFormat.ARROW);
+      TableReadOptions readOptions = buildTableReadOptions();
+      if (readOptions != null) {
+        sessionBuilder.setReadOptions(readOptions);
+      }
 
       CreateReadSessionRequest.Builder builder =
           CreateReadSessionRequest.newBuilder()
@@ -935,6 +941,19 @@ public class BigQueryStatement extends BigQueryNoOpsStatement {
       }
       throw new BigQueryJdbcException(ex.getMessage(), ex);
     }
+  }
+
+  private TableReadOptions buildTableReadOptions() {
+    if (!isEnableTimestampPicos()) {
+      return null;
+    }
+    return TableReadOptions.newBuilder()
+        .setArrowSerializationOptions(
+            ArrowSerializationOptions.newBuilder()
+                .setPicosTimestampPrecision(
+                    ArrowSerializationOptions.PicosTimestampPrecision.TIMESTAMP_PRECISION_PICOS)
+                .build())
+        .build();
   }
 
   /** Asynchronously reads results and populates an arrow record queue */

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtility.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtility.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.bigquery.jdbc;
 
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -324,6 +326,14 @@ final class BigQueryTemporalUtility {
       return formatTimestampStringFromIso(str, enableTimestampPicos);
     }
     return formatTimestampStringFromEpochDecimal(str, enableTimestampPicos);
+  }
+
+  static boolean isPicosecondTimestamp(Field field) {
+    return field != null
+        && field.getType() != null
+        && field.getType().getStandardType() == StandardSQLTypeName.TIMESTAMP
+        && field.getTimestampPrecision() != null
+        && field.getTimestampPrecision() > 6;
   }
 
   private static StringBuilder formatDateTimeBase(LocalDateTime dt, int scale) {

--- a/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtility.java
+++ b/java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtility.java
@@ -306,6 +306,26 @@ final class BigQueryTemporalUtility {
     return sb.toString();
   }
 
+  /**
+   * Formats a timestamp value (which may be a {@link Long} epoch microsecond, an ISO-8601 string, a
+   * {@link java.sql.Timestamp}, or an epoch decimal string) into a standard UTC JDBC timestamp
+   * string with 6 or 12 fractional digits according to {@code enableTimestampPicos}.
+   */
+  static String formatTimestampValue(Object value, boolean enableTimestampPicos)
+      throws BigQueryJdbcException {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Long) {
+      return formatTimestampStringFromMicroseconds((Long) value, enableTimestampPicos);
+    }
+    String str = value.toString();
+    if (str.indexOf(':') >= 0) {
+      return formatTimestampStringFromIso(str, enableTimestampPicos);
+    }
+    return formatTimestampStringFromEpochDecimal(str, enableTimestampPicos);
+  }
+
   private static StringBuilder formatDateTimeBase(LocalDateTime dt, int scale) {
     StringBuilder sb = new StringBuilder(scale == 12 ? 32 : 26);
     BASE_FORMATTER.formatTo(dt, sb);

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
@@ -424,7 +424,7 @@ public class BigQueryArrowArrayOfPrimitivesTest {
 
     BigQueryArrowArray array =
         new BigQueryArrowArray(
-            field, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class), true);
+            field, values, true, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class));
 
     assertThat(array.getBaseTypeName()).isEqualTo("TIMESTAMP");
     assertThat(array.getBaseType()).isEqualTo(Types.TIMESTAMP);
@@ -460,7 +460,7 @@ public class BigQueryArrowArrayOfPrimitivesTest {
 
     BigQueryArrowArray array =
         new BigQueryArrowArray(
-            field, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class), false);
+            field, values, false, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class));
 
     Object result = array.getArray();
     assertThat(result).isInstanceOf(Timestamp[].class);

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
@@ -63,6 +63,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.Text;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -408,5 +409,67 @@ public class BigQueryArrowArrayOfPrimitivesTest {
   private void ensureArrayIsInvalid(Executable block) {
     Exception exception = assertThrows(IllegalStateException.class, block);
     assertThat(exception.getMessage()).isEqualTo(INVALID_ARRAY);
+  }
+
+  @Test
+  public void testArrowArrayTimestampPicosEnabled() throws SQLException {
+    Field field =
+        Field.newBuilder("picosArray", StandardSQLTypeName.TIMESTAMP)
+            .setMode(Field.Mode.REPEATED)
+            .setTimestampPrecision(12L)
+            .build();
+    JsonStringArrayList<Text> values = new JsonStringArrayList<>();
+    values.add(new Text("2026-04-08T10:00:00.123456789123Z"));
+    values.add(new Text("2026-04-08T11:00:00.987654321012Z"));
+
+    BigQueryArrowArray array =
+        new BigQueryArrowArray(
+            field, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class), true);
+
+    assertThat(array.getBaseTypeName()).isEqualTo("TIMESTAMP");
+    assertThat(array.getBaseType()).isEqualTo(Types.TIMESTAMP);
+
+    Object result = array.getArray();
+    assertThat(result).isInstanceOf(String[].class);
+    assertThat((String[]) result)
+        .asList()
+        .containsExactly("2026-04-08 10:00:00.123456789123", "2026-04-08 11:00:00.987654321012")
+        .inOrder();
+
+    ResultSet rs = array.getResultSet();
+    assertThat(rs.next()).isTrue();
+    assertThat(rs.getInt(1)).isEqualTo(1);
+    assertThat(rs.getString(2)).isEqualTo("2026-04-08 10:00:00.123456789123");
+    assertThat(rs.getObject(2)).isEqualTo("2026-04-08 10:00:00.123456789123");
+
+    assertThat(rs.next()).isTrue();
+    assertThat(rs.getInt(1)).isEqualTo(2);
+    assertThat(rs.getString(2)).isEqualTo("2026-04-08 11:00:00.987654321012");
+    assertThat(rs.getObject(2)).isEqualTo("2026-04-08 11:00:00.987654321012");
+  }
+
+  @Test
+  public void testArrowArrayTimestampPicosDisabled() throws SQLException {
+    Field field =
+        Field.newBuilder("picosArray", StandardSQLTypeName.TIMESTAMP)
+            .setMode(Field.Mode.REPEATED)
+            .setTimestampPrecision(12L)
+            .build();
+    JsonStringArrayList<Text> values = new JsonStringArrayList<>();
+    values.add(new Text("2026-04-08T10:00:00.123456789123Z"));
+
+    BigQueryArrowArray array =
+        new BigQueryArrowArray(
+            field, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowArray.class), false);
+
+    Object result = array.getArray();
+    assertThat(result).isInstanceOf(Timestamp[].class);
+    Timestamp expectedTs = Timestamp.valueOf("2026-04-08 10:00:00.123456789");
+    assertThat((Timestamp[]) result).asList().containsExactly(expectedTs);
+
+    ResultSet rs = array.getResultSet();
+    assertThat(rs.next()).isTrue();
+    assertThat(rs.getString(2)).isEqualTo("2026-04-08 10:00:00.123456");
+    assertThat(rs.getObject(2)).isEqualTo(expectedTs);
   }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSetTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSetTest.java
@@ -22,6 +22,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.apache.arrow.vector.types.Types.MinorType.INT;
 import static org.apache.arrow.vector.types.Types.MinorType.VARCHAR;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import com.google.cloud.bigquery.Field;
@@ -255,7 +256,8 @@ public class BigQueryArrowResultSetTest {
             arraySchema,
             BigQueryArrowBatchWrapper.getNestedFieldValueListWrapper(jsonStringArrayList),
             0,
-            jsonStringArrayList.size());
+            jsonStringArrayList.size(),
+            false);
   }
 
   @Test
@@ -437,5 +439,111 @@ public class BigQueryArrowResultSetTest {
     return rowCount;
   }
 
-  // TODO: Unit Test for iteration and getters
+  private VectorSchemaRoot getPicosVectorSchemaRoot() {
+    RootAllocator allocator = new RootAllocator();
+    VarCharVector picosCol = new VarCharVector("picosTimestamp", allocator);
+    picosCol.allocateNew(1);
+    picosCol.set(0, new Text("2026-04-08T10:00:00.123456789123Z"));
+    picosCol.setValueCount(1);
+    return new VectorSchemaRoot(ImmutableList.of(picosCol));
+  }
+
+  @Test
+  public void testTimestampPicosEnabled() throws SQLException, IOException {
+    VectorSchemaRoot root = getPicosVectorSchemaRoot();
+    ArrowRecordBatch batch =
+        ArrowRecordBatch.newBuilder()
+            .setSerializedRecordBatch(serializeVectorSchemaRoot(root))
+            .build();
+    BlockingQueue<BigQueryArrowBatchWrapper> picosBuffer = new LinkedBlockingDeque<>();
+    picosBuffer.add(BigQueryArrowBatchWrapper.of(batch));
+    picosBuffer.add(BigQueryArrowBatchWrapper.of(null, true));
+
+    BigQueryStatement picosStmt = mock(BigQueryStatement.class);
+    doReturn(true).when(picosStmt).isEnableTimestampPicos();
+
+    Schema schema =
+        Schema.of(
+            Field.newBuilder("picosTimestamp", StandardSQLTypeName.TIMESTAMP)
+                .setTimestampPrecision(12L)
+                .build());
+    ArrowSchema arrowSchema =
+        ArrowSchema.newBuilder().setSerializedSchema(serializeSchema(root.getSchema())).build();
+
+    BigQueryArrowResultSet rs =
+        BigQueryArrowResultSet.of(
+            schema, arrowSchema, 1, picosStmt, picosBuffer, mock(Future.class), null);
+
+    assertThat(rs.next()).isTrue();
+    assertThat(rs.getString("picosTimestamp")).isEqualTo("2026-04-08 10:00:00.123456789123");
+    assertThat(rs.getString(1)).isEqualTo("2026-04-08 10:00:00.123456789123");
+    assertThat(rs.getObject("picosTimestamp")).isEqualTo("2026-04-08 10:00:00.123456789123");
+    assertThat(rs.getObject(1)).isEqualTo("2026-04-08 10:00:00.123456789123");
+    assertThat(rs.getObject("picosTimestamp", String.class))
+        .isEqualTo("2026-04-08 10:00:00.123456789123");
+
+    Timestamp expectedTs = Timestamp.valueOf("2026-04-08 10:00:00.123456789");
+    assertThat(rs.getTimestamp("picosTimestamp")).isEqualTo(expectedTs);
+    assertThat(rs.getObject("picosTimestamp", Timestamp.class)).isEqualTo(expectedTs);
+  }
+
+  @Test
+  public void testTimestampPicosDisabled() throws SQLException, IOException {
+    VectorSchemaRoot root = getPicosVectorSchemaRoot();
+    ArrowRecordBatch batch =
+        ArrowRecordBatch.newBuilder()
+            .setSerializedRecordBatch(serializeVectorSchemaRoot(root))
+            .build();
+    BlockingQueue<BigQueryArrowBatchWrapper> picosBuffer = new LinkedBlockingDeque<>();
+    picosBuffer.add(BigQueryArrowBatchWrapper.of(batch));
+    picosBuffer.add(BigQueryArrowBatchWrapper.of(null, true));
+
+    BigQueryStatement disabledStmt = mock(BigQueryStatement.class);
+    doReturn(false).when(disabledStmt).isEnableTimestampPicos();
+
+    Schema schema =
+        Schema.of(
+            Field.newBuilder("picosTimestamp", StandardSQLTypeName.TIMESTAMP)
+                .setTimestampPrecision(12L)
+                .build());
+    ArrowSchema arrowSchema =
+        ArrowSchema.newBuilder().setSerializedSchema(serializeSchema(root.getSchema())).build();
+
+    BigQueryArrowResultSet rs =
+        BigQueryArrowResultSet.of(
+            schema, arrowSchema, 1, disabledStmt, picosBuffer, mock(Future.class), null);
+
+    assertThat(rs.next()).isTrue();
+    assertThat(rs.getString("picosTimestamp")).isEqualTo("2026-04-08 10:00:00.123456");
+    assertThat(rs.getString(1)).isEqualTo("2026-04-08 10:00:00.123456");
+    Timestamp expectedTs = Timestamp.valueOf("2026-04-08 10:00:00.123456789");
+    assertThat(rs.getObject("picosTimestamp")).isEqualTo(expectedTs);
+    assertThat(rs.getTimestamp("picosTimestamp")).isEqualTo(expectedTs);
+  }
+
+  @Test
+  public void testStandardMicrosecondTimestampWithPicosEnabled() throws SQLException, IOException {
+    VectorSchemaRoot root = getTestVectorSchemaRoot();
+    ArrowRecordBatch batch =
+        ArrowRecordBatch.newBuilder()
+            .setSerializedRecordBatch(serializeVectorSchemaRoot(root))
+            .build();
+    BlockingQueue<BigQueryArrowBatchWrapper> picosBuffer = new LinkedBlockingDeque<>();
+    picosBuffer.add(BigQueryArrowBatchWrapper.of(batch));
+    picosBuffer.add(BigQueryArrowBatchWrapper.of(null, true));
+
+    BigQueryStatement picosStmt = mock(BigQueryStatement.class);
+    doReturn(true).when(picosStmt).isEnableTimestampPicos();
+
+    ArrowSchema arrowSchema =
+        ArrowSchema.newBuilder().setSerializedSchema(serializeSchema(root.getSchema())).build();
+
+    BigQueryArrowResultSet rs =
+        BigQueryArrowResultSet.of(
+            QUERY_SCHEMA, arrowSchema, 1, picosStmt, picosBuffer, mock(Future.class), null);
+
+    assertThat(rs.next()).isTrue();
+    assertThat(rs.getString("timeStampField")).isEqualTo("1970-01-01 00:00:00.010000");
+    assertThat(rs.getObject("timeStampField")).isEqualTo(new Timestamp(10L));
+  }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
@@ -244,4 +244,38 @@ public class BigQueryArrowStructTest {
             () -> structWithPrimitiveValues.getAttributes(emptyMap()));
     assertThat(exception.getMessage()).isEqualTo(CUSTOMER_TYPE_MAPPING_NOT_SUPPORTED);
   }
+
+  @Test
+  public void testArrowStructTimestampPicosEnabled() throws SQLException {
+    Field picosField = Field.newBuilder("picosTs", TIMESTAMP).setTimestampPrecision(12L).build();
+    FieldList schema = FieldList.of(picosField);
+    JsonStringHashMap<String, Object> values = new JsonStringHashMap<>();
+    values.put("picosTs", new Text("2026-04-08T10:00:00.123456789123Z"));
+
+    BigQueryArrowStruct struct =
+        new BigQueryArrowStruct(
+            schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class), true);
+
+    Object[] attributes = struct.getAttributes();
+    assertThat(attributes).isEqualTo(new Object[] {"2026-04-08 10:00:00.123456789123"});
+  }
+
+  @Test
+  public void testArrowStructTimestampPicosDisabled() throws SQLException {
+    Field picosField = Field.newBuilder("picosTs", TIMESTAMP).setTimestampPrecision(12L).build();
+    FieldList schema = FieldList.of(picosField);
+    JsonStringHashMap<String, Object> values = new JsonStringHashMap<>();
+    values.put("picosTs", new Text("2026-04-08T10:00:00.123456789123Z"));
+
+    BigQueryArrowStruct struct =
+        new BigQueryArrowStruct(
+            schema,
+            values,
+            BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class),
+            false);
+
+    Object[] attributes = struct.getAttributes();
+    Timestamp expectedTs = Timestamp.valueOf("2026-04-08 10:00:00.123456789");
+    assertThat(attributes).isEqualTo(new Object[] {expectedTs});
+  }
 }

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
@@ -254,7 +254,7 @@ public class BigQueryArrowStructTest {
 
     BigQueryArrowStruct struct =
         new BigQueryArrowStruct(
-            schema, values, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class), true);
+            schema, values, true, BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class));
 
     Object[] attributes = struct.getAttributes();
     assertThat(attributes).isEqualTo(new Object[] {"2026-04-08 10:00:00.123456789123"});
@@ -271,8 +271,8 @@ public class BigQueryArrowStructTest {
         new BigQueryArrowStruct(
             schema,
             values,
-            BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class),
-            false);
+            false,
+            BigQueryJdbcResultSetLogger.getLogger(BigQueryArrowStruct.class));
 
     Object[] attributes = struct.getAttributes();
     Timestamp expectedTs = Timestamp.valueOf("2026-04-08 10:00:00.123456789");

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
@@ -389,7 +389,7 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     Field arraySchema = Field.of("name", LegacySQLTypeName.INTEGER);
     JsonStringArrayList<Object> arrayValues = new JsonStringArrayList<>();
     arrayValues.add(123L);
-    BigQueryArrowArray array = new BigQueryArrowArray(arraySchema, arrayValues, logger, false);
+    BigQueryArrowArray array = new BigQueryArrowArray(arraySchema, arrayValues, false, logger);
 
     assertConnectionIdPropagated(
         logger, connectionId, "Log from Arrow Array", () -> array.LOG.fine("Log from Arrow Array"));
@@ -405,7 +405,7 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     JsonStringHashMap<String, Object> structValues = new JsonStringHashMap<>();
     structValues.put("col", 456L);
     BigQueryArrowStruct struct =
-        new BigQueryArrowStruct(structSchema, structValues, structLogger, false);
+        new BigQueryArrowStruct(structSchema, structValues, false, structLogger);
 
     assertConnectionIdPropagated(
         structLogger,
@@ -430,7 +430,7 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     JsonStringArrayList<Object> nestedValues = new JsonStringArrayList<>();
     nestedValues.add(map);
     BigQueryArrowArray arrayWithNested =
-        new BigQueryArrowArray(arrayNestedSchema, nestedValues, logger, false);
+        new BigQueryArrowArray(arrayNestedSchema, nestedValues, false, logger);
 
     Object[] result = (Object[]) arrayWithNested.getArray();
     BigQueryArrowStruct nestedStruct = (BigQueryArrowStruct) result[0];
@@ -461,7 +461,7 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     values.put("array_col", arrayVal);
 
     BigQueryArrowStruct structWithNestedArray =
-        new BigQueryArrowStruct(nestedSchema, values, structLogger, false);
+        new BigQueryArrowStruct(nestedSchema, values, false, structLogger);
     Object[] attributes = structWithNestedArray.getAttributes();
     BigQueryArrowArray nestedArray = (BigQueryArrowArray) attributes[0];
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
@@ -389,7 +389,7 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     Field arraySchema = Field.of("name", LegacySQLTypeName.INTEGER);
     JsonStringArrayList<Object> arrayValues = new JsonStringArrayList<>();
     arrayValues.add(123L);
-    BigQueryArrowArray array = new BigQueryArrowArray(arraySchema, arrayValues, logger);
+    BigQueryArrowArray array = new BigQueryArrowArray(arraySchema, arrayValues, logger, false);
 
     assertConnectionIdPropagated(
         logger, connectionId, "Log from Arrow Array", () -> array.LOG.fine("Log from Arrow Array"));
@@ -404,7 +404,8 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     FieldList structSchema = FieldList.of(Field.of("col", LegacySQLTypeName.INTEGER));
     JsonStringHashMap<String, Object> structValues = new JsonStringHashMap<>();
     structValues.put("col", 456L);
-    BigQueryArrowStruct struct = new BigQueryArrowStruct(structSchema, structValues, structLogger);
+    BigQueryArrowStruct struct =
+        new BigQueryArrowStruct(structSchema, structValues, structLogger, false);
 
     assertConnectionIdPropagated(
         structLogger,
@@ -429,7 +430,7 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     JsonStringArrayList<Object> nestedValues = new JsonStringArrayList<>();
     nestedValues.add(map);
     BigQueryArrowArray arrayWithNested =
-        new BigQueryArrowArray(arrayNestedSchema, nestedValues, logger);
+        new BigQueryArrowArray(arrayNestedSchema, nestedValues, logger, false);
 
     Object[] result = (Object[]) arrayWithNested.getArray();
     BigQueryArrowStruct nestedStruct = (BigQueryArrowStruct) result[0];
@@ -460,7 +461,7 @@ public class BigQueryJdbcCustomLoggerTest extends BigQueryJdbcLoggingBaseTest {
     values.put("array_col", arrayVal);
 
     BigQueryArrowStruct structWithNestedArray =
-        new BigQueryArrowStruct(nestedSchema, values, structLogger);
+        new BigQueryArrowStruct(nestedSchema, values, structLogger, false);
     Object[] attributes = structWithNestedArray.getAttributes();
     BigQueryArrowArray nestedArray = (BigQueryArrowArray) attributes[0];
 

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
@@ -62,6 +62,7 @@ import com.google.cloud.bigquery.exception.BigQueryJdbcException;
 import com.google.cloud.bigquery.jdbc.BigQueryStatement.JobIdWrapper;
 import com.google.cloud.bigquery.spi.BigQueryRpcFactory;
 import com.google.cloud.bigquery.storage.v1.ArrowSchema;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
@@ -353,6 +354,63 @@ public class BigQueryStatementTest {
     assertThat(resultSet).isNotNull();
     assertThat(resultSet).isInstanceOf(BigQueryArrowResultSet.class);
     assertThat(resultSet.isLast()).isFalse(); // as we have 10 rows
+
+    ArgumentCaptor<CreateReadSessionRequest> requestCaptor =
+        ArgumentCaptor.forClass(CreateReadSessionRequest.class);
+    verify(bigQueryStatementSpy).getReadSession(requestCaptor.capture());
+    assertThat(
+            requestCaptor
+                .getValue()
+                .getReadSession()
+                .getReadOptions()
+                .hasArrowSerializationOptions())
+        .isFalse();
+  }
+
+  @Test
+  public void testProcessArrowResultSetWithTimestampPicos() throws SQLException {
+    doReturn(true).when(bigQueryConnection).isEnableTimestampPicos();
+    BigQueryStatement stmt = new BigQueryStatement(bigQueryConnection);
+    BigQueryStatement bigQueryStatementSpy = Mockito.spy(stmt);
+    BigQueryReadClient bigQueryReadClient = Mockito.spy(mock(BigQueryReadClient.class));
+    Schema schema = Schema.of(fieldList);
+    ReadSession readSession = ReadSession.getDefaultInstance();
+    doReturn(bigQueryReadClient).when(bigQueryStatementSpy).getBigQueryReadClient();
+    doReturn(readSession)
+        .when(bigQueryStatementSpy)
+        .getReadSession(any(CreateReadSessionRequest.class));
+    Future<?> mockWorker = mock(Future.class);
+    doReturn(mockWorker)
+        .when(bigQueryStatementSpy)
+        .populateArrowBufferedQueue(
+            any(ReadSession.class), any(BlockingQueue.class), any(BigQueryReadClient.class));
+
+    doReturn(arrowSchema).when(bigQueryStatementSpy).getArrowSchema(any(ReadSession.class));
+
+    JobId jobId = JobId.of("123");
+    TableResult result = Mockito.mock(TableResult.class);
+    doReturn(schema).when(result).getSchema();
+    doReturn(10L).when(result).getTotalRows();
+    doReturn(TABLE_ID).when(bigQueryStatementSpy).getDestinationTable(any());
+    doReturn(jobId).when(result).getJobId();
+    Job job = mock(Job.class);
+    doReturn(mock(QueryStatistics.class)).when(job).getStatistics();
+    doReturn(job).when(bigquery).getJob(jobId);
+
+    ResultSet resultSet = bigQueryStatementSpy.processArrowResultSet(result, null);
+    assertThat(resultSet).isNotNull();
+
+    ArgumentCaptor<CreateReadSessionRequest> requestCaptor =
+        ArgumentCaptor.forClass(CreateReadSessionRequest.class);
+    verify(bigQueryStatementSpy).getReadSession(requestCaptor.capture());
+    assertThat(
+            requestCaptor
+                .getValue()
+                .getReadSession()
+                .getReadOptions()
+                .getArrowSerializationOptions()
+                .getPicosTimestampPrecision())
+        .isEqualTo(ArrowSerializationOptions.PicosTimestampPrecision.TIMESTAMP_PRECISION_PICOS);
   }
 
   @Test

--- a/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtilityTest.java
+++ b/java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtilityTest.java
@@ -392,4 +392,29 @@ public class BigQueryTemporalUtilityTest {
     String negOne = BigQueryTemporalUtility.formatTimestampStringFromMicroseconds(-1L, false);
     assertThat(negOne).isEqualTo("1969-12-31 23:59:59.999999");
   }
+
+  @Test
+  public void testFormatTimestampValue() throws BigQueryJdbcException {
+    // Null handling
+    assertThat(BigQueryTemporalUtility.formatTimestampValue(null, true)).isNull();
+
+    // Long (epoch microseconds)
+    assertThat(BigQueryTemporalUtility.formatTimestampValue(1680174859820226L, false))
+        .isEqualTo("2023-03-30 11:14:19.820226");
+    assertThat(BigQueryTemporalUtility.formatTimestampValue(1680174859820226L, true))
+        .isEqualTo("2023-03-30 11:14:19.820226000000");
+
+    // ISO string with picoseconds
+    assertThat(
+            BigQueryTemporalUtility.formatTimestampValue(
+                "2026-04-08T10:00:00.123456789123Z", false))
+        .isEqualTo("2026-04-08 10:00:00.123456");
+    assertThat(
+            BigQueryTemporalUtility.formatTimestampValue("2026-04-08T10:00:00.123456789123Z", true))
+        .isEqualTo("2026-04-08 10:00:00.123456789123");
+
+    // Epoch decimal string
+    assertThat(BigQueryTemporalUtility.formatTimestampValue("1680174859.123456789123", true))
+        .isEqualTo("2023-03-30 11:14:19.123456789123");
+  }
 }


### PR DESCRIPTION
b/544839155

This PR enables picosecond precision (`TIMESTAMP(12)`) support across the BigQuery Storage Read API (Arrow stream) and nested data structures (`ARRAY`, `STRUCT`, and `RANGE`) when `EnableTimestampPicos=true`.

### Key Changes
- **Storage Read API Session Configuration**: Configured `TableReadOptions.arrowSerializationOptions` with `TIMESTAMP_PRECISION_PICOS` in `BigQueryStatement` when `EnableTimestampPicos` is active.
- **Arrow Deserialization & Formatting**:
  - Wired `enableTimestampPicos` into `BigQueryArrowResultSet`, formatting picosecond timestamps directly to 12 fractional digits for column retrieval.
  - Normalized Arrow `Text` instances to `String` across hot paths to prevent downstream `BigQueryTypeRegistry` conversion failures.
  - Formatted `RANGE` and nested `RANGE` bounds using schema-derived element types and precision flags.
- **Nested Types Propagation**:
  - Propagated precision flags to `BigQueryArrowArray` and `BigQueryArrowStruct`.
  - Overrode `getTargetClass()` in `BigQueryArrowArray` to return `String.class` when picoseconds are enabled, preventing `Array.newInstance` mismatch exceptions.
- **Unit Tests**:
  - Added unit test suites verifying picosecond vs. microsecond behavior across `BigQueryArrowResultSet`, `BigQueryArrowArrayOfPrimitives`, `BigQueryArrowStruct`, and `BigQueryStatement`.
