### PR TITLE
test(bigtable): speed up the integration test suite

### DIFF
--- a/java-bigtable/google-cloud-bigtable/pom.xml
+++ b/java-bigtable/google-cloud-bigtable/pom.xml
@@ -40,10 +40,6 @@
     <bigtable.directpath-jwt-audience/>
     <bigtable.directpath-admin-endpoint/>
 
-    <!-- This is used by bigtable-prod-batch-it profile to ensure that tests work on the batch endpoint.
-     Also, this property will be augmented by `internal-bigtable-prod-batch-it-prop-helper` profile -->
-    <bigtable.cfe-data-batch-endpoint>batch-bigtable.googleapis.com:443</bigtable.cfe-data-batch-endpoint>
-
     <!-- Number of JVMs used to run the integration tests concurrently. The ITs are almost entirely
      RPC bound, so this can be raised well above the core count. Override on the commandline via
      `-Dbigtable.it.fork-count=8`. -->
@@ -574,57 +570,6 @@
                   </includes>
                   <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-prod-it.xml</summaryFile>
                   <reportsDirectory>${project.build.directory}/failsafe-reports/prod-it</reportsDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
-    <!-- internal profile to provide a sensible default for bigtable.cfe-data-batch-endpoint based on
-    bigtable.cfe-data-endpoint -->
-    <profile>
-      <id>internal-bigtable-prod-batch-it-prop-helper</id>
-      <activation>
-        <property>
-          <name>bigtable.cfe-data-endpoint</name>
-        </property>
-      </activation>
-      <properties>
-        <bigtable.cfe-data-batch-endpoint>batch-${bigtable.cfe-data-endpoint}</bigtable.cfe-data-batch-endpoint>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>bigtable-prod-batch-it</id>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>prod-batch-it</id>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-                <configuration>
-                  <skip>false</skip>
-
-                  <systemPropertyVariables>
-                    <bigtable.env>cloud</bigtable.env>
-                    <bigtable.data-endpoint>${bigtable.cfe-data-batch-endpoint}</bigtable.data-endpoint>
-                    <bigtable.admin-endpoint>${bigtable.cfe-admin-endpoint}</bigtable.admin-endpoint>
-                    <bigtable.data-jwt-audience>${bigtable.cfe-jwt-audience}</bigtable.data-jwt-audience>
-                    <bigtable.enable-grpc-logs>${bigtable.enable-grpc-logs}</bigtable.enable-grpc-logs>
-                    <bigtable.grpc-log-dir>${project.build.directory}/test-grpc-logs/prod-batch-it</bigtable.grpc-log-dir>
-                  </systemPropertyVariables>
-                  <includes>
-                    <include>com.google.cloud.bigtable.data.v2.it.*IT</include>
-                  </includes>
-                  <summaryFile>${project.build.directory}/failsafe-reports/failsafe-summary-prod-batch-it.xml</summaryFile>
-                  <reportsDirectory>${project.build.directory}/failsafe-reports/prod-batch-it</reportsDirectory>
                 </configuration>
               </execution>
             </executions>

--- a/java-bigtable/google-cloud-bigtable/pom.xml
+++ b/java-bigtable/google-cloud-bigtable/pom.xml
@@ -44,6 +44,11 @@
      Also, this property will be augmented by `internal-bigtable-prod-batch-it-prop-helper` profile -->
     <bigtable.cfe-data-batch-endpoint>batch-bigtable.googleapis.com:443</bigtable.cfe-data-batch-endpoint>
 
+    <!-- Number of JVMs used to run the integration tests concurrently. The ITs are almost entirely
+     RPC bound, so this can be raised well above the core count. Override on the commandline via
+     `-Dbigtable.it.fork-count=8`. -->
+    <bigtable.it.fork-count>4</bigtable.it.fork-count>
+
     <!-- These are needed to compile the protobuf used by Changestream merging acceptance test. -->
     <test-protoc-grpc.version>1.76.3</test-protoc-grpc.version>
     <test-protoc.version>4.33.2</test-protoc.version>
@@ -491,7 +496,10 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <forkCount>1</forkCount>
+              <!-- Keep in-JVM parallelism off so that the verbose logs of a single fork stay
+               attributable to one test class. Forking across processes is still fine: each fork
+               gets its own JUL config and its own `-output.txt`, so it must not be disabled here
+               (doing so serializes the entire IT suite). -->
               <parallel>none</parallel>
               <redirectTestOutputToFile>true</redirectTestOutputToFile>
             </configuration>
@@ -823,7 +831,7 @@
            enabling metrics collection. It only works with cloud environment and will fail with permission
            denied when running against emulators. Running in different processes make sure the state is
            only set on the process for BuiltinMetricsIT test. -->
-          <forkCount>4</forkCount>
+          <forkCount>${bigtable.it.fork-count}</forkCount>
           <reuseForks>false</reuseForks>
 
           <!-- print full stacktraces by default -->

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableAuthorizedViewIT.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableAuthorizedViewIT.java
@@ -58,7 +58,11 @@ public class BigtableAuthorizedViewIT {
   @ClassRule public static final TestEnvRule testEnvRule = new TestEnvRule();
   @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
   private static final Logger LOGGER = Logger.getLogger(BigtableAuthorizedViewIT.class.getName());
-  private static final long[] BACKOFF_DURATION = {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024};
+  // Poll for the delete to propagate. A fixed short interval rather than a doubling backoff:
+  // the resource normally disappears within seconds, and a doubling backoff would keep
+  // sleeping for minutes past that point.
+  private static final long DELETE_POLL_INTERVAL_SECONDS = 2;
+  private static final int DELETE_POLL_ATTEMPTS = 60;
 
   private static BigtableTableAdminClient tableAdmin;
   private static BigtableDataClient dataClient;
@@ -198,15 +202,11 @@ public class BigtableAuthorizedViewIT {
     // Now we should be able to successfully delete the AuthorizedView.
     tableAdmin.deleteAuthorizedView(testTable.getId(), authorizedViewId);
     try {
-      for (int i = 0; i < BACKOFF_DURATION.length; i++) {
+      for (int i = 0; i < DELETE_POLL_ATTEMPTS; i++) {
         tableAdmin.getAuthorizedView(testTable.getId(), authorizedViewId);
 
-        LOGGER.info(
-            "Wait for "
-                + BACKOFF_DURATION[i]
-                + " seconds for deleting authorized view "
-                + authorizedViewId);
-        Thread.sleep(BACKOFF_DURATION[i] * 1000);
+        LOGGER.info("Waiting for authorized view " + authorizedViewId + " to be deleted");
+        Thread.sleep(DELETE_POLL_INTERVAL_SECONDS * 1000);
       }
       fail("AuthorizedView was not deleted.");
     } catch (NotFoundException e) {

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableBackupIT.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableBackupIT.java
@@ -76,11 +76,23 @@ public class BigtableBackupIT {
   private static BigtableInstanceAdminClient instanceAdmin;
   private static BigtableDataClient dataClient;
 
+  /**
+   * The RestoreTable API only kicks off an optimize-restored-table operation once the backup is a
+   * couple of minutes old. Rather than have every restore test block for the full duration, the
+   * backups they restore from are created up front in {@link #setUpClass()} and the tests only wait
+   * for whatever is left of the window once the rest of the class has run.
+   */
+  private static final Duration RESTORE_BACKUP_MIN_AGE = Duration.ofMinutes(2);
+
   private static String targetCluster;
   private static String targetClusterHot;
   private static Table testTable;
   private static Table testTableHot;
   private static Instance testInstance;
+
+  private static String restoreBackupId;
+  private static String crossInstanceRestoreBackupId;
+  private static Stopwatch restoreBackupAge;
 
   @BeforeClass
   public static void setUpClass() throws InterruptedException, IOException {
@@ -115,10 +127,36 @@ public class BigtableBackupIT {
     testTableHot =
         tableAdminHot.createTable(
             CreateTableRequest.of(PrefixGenerator.newPrefix("hot-table")).addFamily("cf"));
+
+    // Start the RESTORE_BACKUP_MIN_AGE clock now so the restore tests can overlap it with the rest
+    // of the class instead of each sleeping through it.
+    restoreBackupId = PrefixGenerator.newPrefix("restore");
+    crossInstanceRestoreBackupId = PrefixGenerator.newPrefix("cross-instance-restore");
+    tableAdmin.createBackup(createBackupRequest(restoreBackupId));
+    tableAdmin.createBackup(createBackupRequest(crossInstanceRestoreBackupId));
+    restoreBackupAge = Stopwatch.createStarted();
+  }
+
+  /** Blocks until the backups created by {@link #setUpClass()} are old enough to restore from. */
+  private static void awaitRestorableBackups() throws InterruptedException {
+    long remainingMillis =
+        RESTORE_BACKUP_MIN_AGE.toMillis() - restoreBackupAge.elapsed(TimeUnit.MILLISECONDS);
+    if (remainingMillis > 0) {
+      Thread.sleep(remainingMillis);
+    }
   }
 
   @AfterClass
   public static void tearDownClass() {
+    for (String backupId : new String[] {restoreBackupId, crossInstanceRestoreBackupId}) {
+      if (backupId != null) {
+        try {
+          tableAdmin.deleteBackup(targetCluster, backupId);
+        } catch (Exception e) {
+          // Ignore, the owning test deletes it on the happy path.
+        }
+      }
+    }
     if (testTable != null) {
       try {
         tableAdmin.deleteTable(testTable.getId());
@@ -314,13 +352,12 @@ public class BigtableBackupIT {
 
   @Test
   public void restoreTableTest() throws InterruptedException, ExecutionException {
-    String backupId = prefixGenerator.newPrefix();
+    String backupId = restoreBackupId;
     String restoredTableId = prefixGenerator.newPrefix();
-    tableAdmin.createBackup(createBackupRequest(backupId));
 
-    // Wait 2 minutes so that the RestoreTable API will trigger an optimize restored
+    // Wait until the backup is old enough for the RestoreTable API to trigger an optimize restored
     // table operation.
-    Thread.sleep(120 * 1000);
+    awaitRestorableBackups();
 
     try {
       RestoreTableRequest req =
@@ -348,16 +385,8 @@ public class BigtableBackupIT {
   @Test
   public void crossInstanceRestoreTest()
       throws InterruptedException, IOException, ExecutionException, TimeoutException {
-    String backupId = prefixGenerator.newPrefix();
+    String backupId = crossInstanceRestoreBackupId;
     String restoredTableId = prefixGenerator.newPrefix();
-
-    // Create the backup
-    tableAdmin.createBackup(
-        CreateBackupRequest.of(targetCluster, backupId)
-            .setSourceTableId(testTable.getId())
-            .setExpireTime(Instant.now().plus(Duration.ofHours(6))));
-
-    Stopwatch stopwatch = Stopwatch.createStarted();
 
     // Set up a new instance to test cross-instance restore. The backup will be restored here
     String targetInstance = prefixGenerator.newPrefix();
@@ -371,12 +400,9 @@ public class BigtableBackupIT {
     try (BigtableTableAdminClient destTableAdmin =
         testEnvRule.env().getTableAdminClientForInstance(targetInstance)) {
 
-      // Wait 2 minutes so that the RestoreTable API will trigger an optimize restored
-      // table operation.
-      Thread.sleep(
-          Duration.ofMinutes(2)
-              .minus(Duration.ofMillis(stopwatch.elapsed(TimeUnit.MILLISECONDS)))
-              .toMillis());
+      // Wait until the backup is old enough for the RestoreTable API to trigger an optimize
+      // restored table operation.
+      awaitRestorableBackups();
 
       try {
         RestoreTableRequest req =
@@ -534,7 +560,7 @@ public class BigtableBackupIT {
     }
   }
 
-  private CreateBackupRequest createBackupRequest(String backupId) {
+  private static CreateBackupRequest createBackupRequest(String backupId) {
     return CreateBackupRequest.of(targetCluster, backupId)
         .setSourceTableId(testTable.getId())
         .setExpireTime(Instant.now().plus(Duration.ofDays(15)));

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableCmekIT.java
@@ -37,11 +37,13 @@ import com.google.cloud.bigtable.common.Status.Code;
 import com.google.cloud.bigtable.test_helpers.env.EmulatorEnv;
 import com.google.cloud.bigtable.test_helpers.env.PrefixGenerator;
 import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -62,7 +64,8 @@ import org.threeten.bp.temporal.ChronoUnit;
 @RunWith(JUnit4.class)
 public class BigtableCmekIT {
 
-  private static final long[] BACKOFF_DURATION = {5, 10, 50, 100, 150, 200, 250, 300};
+  private static final long KEY_STATUS_TIMEOUT_SECONDS = 360;
+  private static final long KEY_STATUS_POLL_INTERVAL_SECONDS = 10;
   private static final Logger LOGGER = Logger.getLogger(BigtableCmekIT.class.getName());
   private static final String TEST_TABLE_ID = "test-table-for-cmek-it";
   private static final String BACKUP_ID = "test-table-for-cmek-it-backup";
@@ -226,7 +229,10 @@ public class BigtableCmekIT {
   }
 
   private void waitForCmekStatus(String tableId, String clusterId) throws InterruptedException {
-    for (int i = 0; i < BACKOFF_DURATION.length; i++) {
+    // Poll at a fine granularity: the key status usually settles well before the deadline and a
+    // coarse backoff would spend minutes asleep after the status was already OK.
+    Stopwatch stopwatch = Stopwatch.createStarted();
+    while (stopwatch.elapsed(TimeUnit.SECONDS) < KEY_STATUS_TIMEOUT_SECONDS) {
       try {
         EncryptionInfo encryptionInfo = tableAdmin.getEncryptionInfo(tableId).get(clusterId).get(0);
         if (encryptionInfo.getStatus().getCode() == Code.OK) {
@@ -234,14 +240,14 @@ public class BigtableCmekIT {
         }
       } catch (ApiException ex) {
         LOGGER.info(
-            "Wait for "
-                + BACKOFF_DURATION[i]
-                + " seconds for key status for table "
+            "Waiting for key status for table "
                 + tableId
                 + " and cluster "
-                + clusterId);
+                + clusterId
+                + ": "
+                + ex);
       }
-      Thread.sleep(BACKOFF_DURATION[i] * 1000);
+      Thread.sleep(KEY_STATUS_POLL_INTERVAL_SECONDS * 1000);
     }
     fail("CMEK key status failed to return");
   }

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableLogicalViewIT.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableLogicalViewIT.java
@@ -49,7 +49,11 @@ public class BigtableLogicalViewIT {
   @ClassRule public static final TestEnvRule testEnvRule = new TestEnvRule();
   @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
   private static final Logger LOGGER = Logger.getLogger(BigtableLogicalViewIT.class.getName());
-  private static final long[] BACKOFF_DURATION = {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024};
+  // Poll for the delete to propagate. A fixed short interval rather than a doubling backoff:
+  // the resource normally disappears within seconds, and a doubling backoff would keep
+  // sleeping for minutes past that point.
+  private static final long DELETE_POLL_INTERVAL_SECONDS = 2;
+  private static final int DELETE_POLL_ATTEMPTS = 60;
 
   private static BigtableInstanceAdminClient client;
   private static Table testTable;
@@ -168,15 +172,11 @@ public class BigtableLogicalViewIT {
     // Now we should be able to successfully delete the LogicalView.
     client.deleteLogicalView(instanceId, logicalViewId);
     try {
-      for (int i = 0; i < BACKOFF_DURATION.length; i++) {
+      for (int i = 0; i < DELETE_POLL_ATTEMPTS; i++) {
         client.getLogicalView(instanceId, logicalViewId);
 
-        LOGGER.info(
-            "Wait for "
-                + BACKOFF_DURATION[i]
-                + " seconds for deleting logical view "
-                + logicalViewId);
-        Thread.sleep(BACKOFF_DURATION[i] * 1000);
+        LOGGER.info("Waiting for logical view " + logicalViewId + " to be deleted");
+        Thread.sleep(DELETE_POLL_INTERVAL_SECONDS * 1000);
       }
       fail("LogicalView was not deleted.");
     } catch (NotFoundException e) {

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableMaterializedViewIT.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableMaterializedViewIT.java
@@ -51,7 +51,11 @@ public class BigtableMaterializedViewIT {
   @ClassRule public static final TestEnvRule testEnvRule = new TestEnvRule();
   @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
   private static final Logger LOGGER = Logger.getLogger(BigtableMaterializedViewIT.class.getName());
-  private static final long[] BACKOFF_DURATION = {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024};
+  // Poll for the delete to propagate. A fixed short interval rather than a doubling backoff:
+  // the resource normally disappears within seconds, and a doubling backoff would keep
+  // sleeping for minutes past that point.
+  private static final long DELETE_POLL_INTERVAL_SECONDS = 2;
+  private static final int DELETE_POLL_ATTEMPTS = 60;
 
   private BigtableInstanceAdminClient client;
   private Table testTable;
@@ -166,15 +170,11 @@ public class BigtableMaterializedViewIT {
     // Now we should be able to successfully delete the MaterializedView.
     client.deleteMaterializedView(instanceId, materializedViewId);
     try {
-      for (int i = 0; i < BACKOFF_DURATION.length; i++) {
+      for (int i = 0; i < DELETE_POLL_ATTEMPTS; i++) {
         client.getMaterializedView(instanceId, materializedViewId);
 
-        LOGGER.info(
-            "Wait for "
-                + BACKOFF_DURATION[i]
-                + " seconds for deleting materialized view "
-                + materializedViewId);
-        Thread.sleep(BACKOFF_DURATION[i] * 1000);
+        LOGGER.info("Waiting for materialized view " + materializedViewId + " to be deleted");
+        Thread.sleep(DELETE_POLL_INTERVAL_SECONDS * 1000);
       }
       fail("MaterializedView was not deleted.");
     } catch (NotFoundException e) {

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableSchemaBundleIT.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/admin/v2/it/BigtableSchemaBundleIT.java
@@ -59,7 +59,11 @@ public class BigtableSchemaBundleIT {
   @ClassRule public static final TestEnvRule testEnvRule = new TestEnvRule();
   @Rule public final PrefixGenerator prefixGenerator = new PrefixGenerator();
   private static final Logger LOGGER = Logger.getLogger(BigtableSchemaBundleIT.class.getName());
-  private static final long[] BACKOFF_DURATION = {2, 4, 8, 16, 32, 64, 128, 256, 512, 1024};
+  // Poll for the delete to propagate. A fixed short interval rather than a doubling backoff:
+  // the resource normally disappears within seconds, and a doubling backoff would keep
+  // sleeping for minutes past that point.
+  private static final long DELETE_POLL_INTERVAL_SECONDS = 2;
+  private static final int DELETE_POLL_ATTEMPTS = 60;
   // Location: `google-cloud-bigtable/src/test/resources/proto_schema_bundle.pb`
   private static final String TEST_PROTO_SCHEMA_BUNDLE = "proto_schema_bundle.pb";
   // Location:
@@ -170,15 +174,11 @@ public class BigtableSchemaBundleIT {
     // Now we should be able to successfully delete the SchemaBundle.
     tableAdmin.deleteSchemaBundle(testTable.getId(), SchemaBundleId);
     try {
-      for (int i = 0; i < BACKOFF_DURATION.length; i++) {
+      for (int i = 0; i < DELETE_POLL_ATTEMPTS; i++) {
         tableAdmin.getSchemaBundle(testTable.getId(), SchemaBundleId);
 
-        LOGGER.info(
-            "Wait for "
-                + BACKOFF_DURATION[i]
-                + " seconds for deleting schema bundle "
-                + SchemaBundleId);
-        Thread.sleep(BACKOFF_DURATION[i] * 1000);
+        LOGGER.info("Waiting for schema bundle " + SchemaBundleId + " to be deleted");
+        Thread.sleep(DELETE_POLL_INTERVAL_SECONDS * 1000);
       }
       fail("SchemaBundle was not deleted.");
     } catch (NotFoundException e) {

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/LargeRowIT.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/it/LargeRowIT.java
@@ -18,6 +18,8 @@ package com.google.cloud.bigtable.data.v2.it;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.TruthJUnit.assume;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.rpc.ResponseObserver;
 import com.google.api.gax.rpc.StreamController;
@@ -39,6 +41,7 @@ import com.google.cloud.bigtable.test_helpers.env.TestEnvRule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -192,11 +195,27 @@ public class LargeRowIT {
     byte[] largeValueBytes = new byte[3 * 1024 * 1024];
     ByteString largeValue = ByteString.copyFrom(largeValueBytes);
 
+    // Each cell is written with its own qualifier, so the writes are independent of each other and
+    // can be sent concurrently. Doing them one at a time means 200 sequential round trips carrying
+    // 600 MiB in total, which dominated the runtime of this test. Keep a bounded window in flight
+    // so we don't buffer the whole payload in the channel.
+    int inFlightLimit = 16;
+    List<ApiFuture<Void>> pending = new ArrayList<>(inFlightLimit);
     for (int i = 0; i < 100; i++) {
       ByteString qualifier = ByteString.copyFromUtf8("qualifier1_" + "_" + i);
-      client.mutateRow(RowMutation.create(tableId, "r2").setCell(familyId, qualifier, largeValue));
-      client.mutateRow(RowMutation.create(tableId, "r3").setCell(familyId, qualifier, largeValue));
+      pending.add(
+          client.mutateRowAsync(
+              RowMutation.create(tableId, "r2").setCell(familyId, qualifier, largeValue)));
+      pending.add(
+          client.mutateRowAsync(
+              RowMutation.create(tableId, "r3").setCell(familyId, qualifier, largeValue)));
+
+      if (pending.size() >= inFlightLimit) {
+        ApiFutures.allAsList(pending).get(10, TimeUnit.MINUTES);
+        pending.clear();
+      }
     }
+    ApiFutures.allAsList(pending).get(10, TimeUnit.MINUTES);
 
     // sync
     assertThat(


### PR DESCRIPTION
The bigtable integration suite was taking > 1 hour to run with the presubmit's
profile list (`.kokoro/presubmit/bigtable-integration.cfg`). Measured from a full run:
emulator-it 66s + prod-it 2414s + prod-batch-it 905s ≈ 56 min wall clock.

Three separate problems, all fixed here.

### 1. The suite was running single threaded

`google-cloud-bigtable/pom.xml` sets `forkCount=4` on failsafe, but the
`enable-verbose-grpc-logs` profile overrode it back to `forkCount=1`. Profile
plugin config wins, so every run with that profile serialized the entire IT
suite into one JVM. The forked-JVM banner in the logs only ever mentions
"forked JVM 1", confirming it.

The override dates back to #1004 / #2295, when `TestEnvRule` installed a JUL
appender that wrote grpc logs to the console and interleaved output across
forks. That appender is gone — `TestEnvRule.grpcLogHandler` is declared and
read in `teardownLogging()` but never assigned — and
`redirectTestOutputToFile=true` now gives each fork its own `-output.txt`.
So cross-process forking is safe; only in-JVM `parallel` needs to stay off
for log attributability.

The profile now keeps `<parallel>none</parallel>` and
`<redirectTestOutputToFile>true</redirectTestOutputToFile>` but no longer
pins `forkCount`. Fork count is also now a property
(`-Dbigtable.it.fork-count=8`) since the ITs are RPC bound and can go well
above the core count.

### 2. The prod-batch pass was redundant

`bigtable-prod-batch-it` re-ran the entire `data.v2.it` package against
`batch-bigtable.googleapis.com` — 905s, ~27% of the presubmit's wall clock.

It was added in 484b62a4ca8 (#892, "fix: jwt authentication on
batch-bigtable.googleapis.com") to prove end to end that self-signed JWT auth
worked against an endpoint whose service host and JWT audience diverge. That
rationale no longer holds:

- `EnhancedBigtableStubSettings.Builder.setJwtAudienceMapping` — the
  endpoint-to-audience table the profile guarded — is now `@Deprecated` and a
  no-op that just returns `this`.
- `batch-bigtable.googleapis.com` appears nowhere in main source.
- The profile passed `bigtable.data-jwt-audience=${bigtable.cfe-jwt-audience}`,
  the same value as `prod-it`, and that property defaults to empty. So the only
  difference between the two passes was the data endpoint hostname.

The auth behaviour for that endpoint is still covered hermetically by
`EnhancedBigtableStubTest`, which points the stub at
`batch-bigtable.googleapis.com:443` with JWT credentials against an in-process
server and asserts the emitted authorization header.

Removes the `bigtable-prod-batch-it` profile, the
`internal-bigtable-prod-batch-it-prop-helper` helper profile and the
`bigtable.cfe-data-batch-endpoint` property.

> **Note:** `.kokoro/presubmit/bigtable-integration.cfg` still lists
> `bigtable-prod-batch-it` in `INTEGRATION_TEST_ARGS` and needs the profile
> dropped from that list. It is the only CI config referencing it
> (`bigtable-integration-dp.cfg` uses `bigtable-directpath-it` and is
> unaffected).

### 3. Slow tests

- **`LargeRowIT.testSkipLargeRow`** (242s prod / 79s batch) sent 200
  sequential 3 MiB `mutateRow` calls — 600 MiB of serial round trips. The
  writes target distinct qualifiers and are independent, so they now go out
  with a bounded 16-deep in-flight window.
- **`BigtableBackupIT`** (485s) had two flat 2-minute sleeps. `RestoreTable`
  only kicks off the optimize-restored-table operation once the backup is a
  couple of minutes old, and each restore test slept through that window
  itself. The backups are now created in `setUpClass()` and the tests only
  wait for whatever is left of the window after the rest of the class has run.
- **`BigtableCmekIT`** (422s) polled key status on a `{5, 10, 50, 100, 150,
  200, 250, 300}` second backoff, so it could oversleep 95s+ past the point
  where the status was already OK. Now a 10s fixed interval against a 360s
  deadline.
- **`BigtableMaterializedViewIT`, `BigtableLogicalViewIT`,
  `BigtableSchemaBundleIT`, `BigtableAuthorizedViewIT`** each waited for a
  delete to propagate on a doubling `{2, 4, ... 1024}` backoff (2046s worst
  case). The resource normally disappears within seconds, so these are now a
  2s interval with a 60 attempt cap.

### Follow-ups not done here

- `reuseForks=false` costs ~20s of JVM boot per test class (~763s across 36
  cloud forks). The pom comment says `BuiltinMetricsIT` mutates process-global
  metrics state, so enabling reuse means first splitting that test into its
  own isolated execution.
- `TestEnvRule.cleanUpStale()` runs after every test class (36+ times per run)
  and does a project-wide `listInstances` + `listClusters` + `listTables` +
  `listAppProfiles` scan, but only deletes resources older than a day. It is
  logically a once-per-run job.
- The admin view ITs (`BigtableMaterializedViewIT`, `BigtableLogicalViewIT`,
  `BigtableSchemaBundleIT`) create and delete a fresh table in `@Before`/
  `@After` for every test method. No test mutates that table — it is only
  referenced by name in the view query — so one table per class would do.
