### PR TITLE
fix(spanner): only set snapshot isolation read timestamp for SI or optimistic txns in CloudClientExecutor

### DIFF
--- a/java-spanner/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/CloudClientExecutor.java
+++ b/java-spanner/google-cloud-spanner-executor/src/main/java/com/google/cloud/executor/spanner/CloudClientExecutor.java
@@ -788,7 +788,8 @@ public class CloudClientExecutor extends CloudExecutor {
               if (finishMode == Mode.COMMIT && rwTxn.runner.getCommitResponse() != null) {
                 com.google.cloud.spanner.CommitResponse commitResponse =
                     rwTxn.runner.getCommitResponse();
-                if (commitResponse.getSnapshotTimestamp() != null) {
+                if ((rwTxn.repeatableRead || rwTxn.optimistic)
+                    && commitResponse.getSnapshotTimestamp() != null) {
                   outcomeBuilder.setSnapshotIsolationTxnReadTimestamp(
                       Timestamps.toMicros(commitResponse.getSnapshotTimestamp().toProto()));
                 }


### PR DESCRIPTION
In `CloudClientExecutor`, `CommitResponse.getSnapshotTimestamp()` was unconditionally populated into `SpannerActionOutcome`'s `snapshot_isolation_txn_read_timestamp` for all committing read-write transactions.

When a standard Serializable Pessimistic transaction executes over a multiplexed session with reads, Cloud Spanner SpanFE records an internal snapshot timestamp and includes it in CommitResponse. Setting snapshot_isolation_txn_read_timestamp for non-SI/non-optimistic transactions violates systest SpotValidator invariants, causing validation failures with: `"Snapshot read timestamp set in a txn that's not a snapshot isolation or optimistic txn."`

This change gates setting `snapshot_isolation_txn_read_timestamp` on (`rwTxn.repeatableRead || rwTxn.optimistic`), ensuring the field is only populated when the transaction actually ran with snapshot isolation or optimistic concurrency control.