### PR TITLE
chore: bump retail and BOMs back to SNAPSHOT

### DIFF
--- a/gapic-libraries-bom/pom.xml
+++ b/gapic-libraries-bom/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>gapic-libraries-bom</artifactId>
   <packaging>pom</packaging>
-  <version>1.91.1</version><!-- {x-version-update:google-cloud-java:current} -->
+  <version>1.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
   <name>Google Cloud Java BOM</name>
   <description>
     BOM for the libraries in google-cloud-java repository. Users should not
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>google-cloud-pom-parent</artifactId>
     <groupId>com.google.cloud</groupId>
-    <version>1.91.0</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
+    <version>1.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 
@@ -25,1569 +25,1569 @@
       <dependency>
         <groupId>com.google.analytics</groupId>
         <artifactId>google-analytics-admin-bom</artifactId>
-        <version>0.107.0</version><!-- {x-version-update:google-analytics-admin:current} -->
+        <version>0.108.0-SNAPSHOT</version><!-- {x-version-update:google-analytics-admin:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.analytics</groupId>
         <artifactId>google-analytics-data-bom</artifactId>
-        <version>0.108.0</version><!-- {x-version-update:google-analytics-data:current} -->
+        <version>0.109.0-SNAPSHOT</version><!-- {x-version-update:google-analytics-data:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.area120</groupId>
         <artifactId>google-area120-tables-bom</artifactId>
-        <version>0.101.0</version><!-- {x-version-update:google-area120-tables:current} -->
+        <version>0.102.0-SNAPSHOT</version><!-- {x-version-update:google-area120-tables:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-accessapproval-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-accessapproval:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-accessapproval:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-advisorynotifications-bom</artifactId>
-        <version>0.86.0</version><!-- {x-version-update:google-cloud-advisorynotifications:current} -->
+        <version>0.87.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-advisorynotifications:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-agentidentity-bom</artifactId>
-        <version>0.3.0</version><!-- {x-version-update:google-cloud-agentidentity:current} -->
+        <version>0.4.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-agentidentity:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-agentregistry-bom</artifactId>
-        <version>0.4.0</version><!-- {x-version-update:google-cloud-agentregistry:current} -->
+        <version>0.5.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-agentregistry:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-aiplatform-bom</artifactId>
-        <version>3.98.0</version><!-- {x-version-update:google-cloud-aiplatform:current} -->
+        <version>3.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-aiplatform:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-alloydb-bom</artifactId>
-        <version>0.86.0</version><!-- {x-version-update:google-cloud-alloydb:current} -->
+        <version>0.87.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-alloydb:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-alloydb-connectors-bom</artifactId>
-        <version>0.75.0</version><!-- {x-version-update:google-cloud-alloydb-connectors:current} -->
+        <version>0.76.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-alloydb-connectors:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-analyticshub-bom</artifactId>
-        <version>0.94.0</version><!-- {x-version-update:google-cloud-analyticshub:current} -->
+        <version>0.95.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-analyticshub:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-api-gateway-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-api-gateway:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-api-gateway:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-apigee-connect-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-apigee-connect:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-apigee-connect:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-apihub-bom</artifactId>
-        <version>0.50.0</version><!-- {x-version-update:google-cloud-apihub:current} -->
+        <version>0.51.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-apihub:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-apikeys-bom</artifactId>
-        <version>0.95.0</version><!-- {x-version-update:google-cloud-apikeys:current} -->
+        <version>0.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-apikeys:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-appengine-admin-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-appengine-admin:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-appengine-admin:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-apphub-bom</artifactId>
-        <version>0.61.0</version><!-- {x-version-update:google-cloud-apphub:current} -->
+        <version>0.62.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-apphub:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-appoptimize-bom</artifactId>
-        <version>0.7.0</version><!-- {x-version-update:google-cloud-appoptimize:current} -->
+        <version>0.8.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-appoptimize:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-apptopology-bom</artifactId>
-        <version>0.1.0</version><!-- {x-version-update:google-cloud-apptopology:current} -->
+        <version>0.2.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-apptopology:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-artifact-registry-bom</artifactId>
-        <version>1.96.0</version><!-- {x-version-update:google-cloud-artifact-registry:current} -->
+        <version>1.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-artifact-registry:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-asset-bom</artifactId>
-        <version>3.101.0</version><!-- {x-version-update:google-cloud-asset:current} -->
+        <version>3.102.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-asset:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-assured-workloads-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-assured-workloads:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-assured-workloads:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-auditmanager-bom</artifactId>
-        <version>0.15.0</version><!-- {x-version-update:google-cloud-auditmanager:current} -->
+        <version>0.16.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-auditmanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-automl-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-automl:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-automl:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-backstory-bom</artifactId>
-        <version>0.5.0</version><!-- {x-version-update:google-cloud-backstory:current} -->
+        <version>0.6.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-backstory:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-backupdr-bom</artifactId>
-        <version>0.56.0</version><!-- {x-version-update:google-cloud-backupdr:current} -->
+        <version>0.57.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-backupdr:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bare-metal-solution-bom</artifactId>
-        <version>0.97.0</version><!-- {x-version-update:google-cloud-bare-metal-solution:current} -->
+        <version>0.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bare-metal-solution:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-batch-bom</artifactId>
-        <version>0.97.0</version><!-- {x-version-update:google-cloud-batch:current} -->
+        <version>0.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-batch:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-beyondcorp-appconnections-bom</artifactId>
-        <version>0.95.0</version><!-- {x-version-update:google-cloud-beyondcorp-appconnections:current} -->
+        <version>0.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-beyondcorp-appconnections:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-beyondcorp-appconnectors-bom</artifactId>
-        <version>0.95.0</version><!-- {x-version-update:google-cloud-beyondcorp-appconnectors:current} -->
+        <version>0.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-beyondcorp-appconnectors:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-beyondcorp-appgateways-bom</artifactId>
-        <version>0.95.0</version><!-- {x-version-update:google-cloud-beyondcorp-appgateways:current} -->
+        <version>0.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-beyondcorp-appgateways:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-beyondcorp-clientconnectorservices-bom</artifactId>
-        <version>0.95.0</version><!-- {x-version-update:google-cloud-beyondcorp-clientconnectorservices:current} -->
+        <version>0.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-beyondcorp-clientconnectorservices:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-beyondcorp-clientgateways-bom</artifactId>
-        <version>0.95.0</version><!-- {x-version-update:google-cloud-beyondcorp-clientgateways:current} -->
+        <version>0.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-beyondcorp-clientgateways:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-biglake-bom</artifactId>
-        <version>0.85.0</version><!-- {x-version-update:google-cloud-biglake:current} -->
+        <version>0.86.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-biglake:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-biglake-hive-bom</artifactId>
-        <version>0.2.0</version><!-- {x-version-update:google-cloud-biglake-hive:current} -->
+        <version>0.3.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-biglake-hive:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery-bom</artifactId>
-        <version>2.71.0</version><!-- {x-version-update:google-cloud-bigquery:current} -->
+        <version>2.72.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery-data-exchange-bom</artifactId>
-        <version>2.92.0</version><!-- {x-version-update:google-cloud-bigquery-data-exchange:current} -->
+        <version>2.93.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquery-data-exchange:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigqueryconnection-bom</artifactId>
-        <version>2.99.0</version><!-- {x-version-update:google-cloud-bigqueryconnection:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigqueryconnection:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquerydatapolicy-bom</artifactId>
-        <version>0.94.0</version><!-- {x-version-update:google-cloud-bigquerydatapolicy:current} -->
+        <version>0.95.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquerydatapolicy:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquerydatatransfer-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-bigquerydatatransfer:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquerydatatransfer:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquerymigration-bom</artifactId>
-        <version>0.100.0</version><!-- {x-version-update:google-cloud-bigquerymigration:current} -->
+        <version>0.101.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquerymigration:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigqueryreservation-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-bigqueryreservation:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigqueryreservation:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquerystorage-bom</artifactId>
-        <version>3.33.0</version><!-- {x-version-update:google-cloud-bigquerystorage:current} -->
+        <version>3.34.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigquerystorage:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigtable-bom</artifactId>
-        <version>2.83.0</version><!-- {x-version-update:google-cloud-bigtable:current} -->
+        <version>2.84.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bigtable:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-billing-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-billing:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-billing:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-billingbudgets-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-billingbudgets:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-billingbudgets:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-binary-authorization-bom</artifactId>
-        <version>1.96.0</version><!-- {x-version-update:google-cloud-binary-authorization:current} -->
+        <version>1.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-binary-authorization:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-build-bom</artifactId>
-        <version>3.99.0</version><!-- {x-version-update:google-cloud-build:current} -->
+        <version>3.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-build:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-capacityplanner-bom</artifactId>
-        <version>0.20.0</version><!-- {x-version-update:google-cloud-capacityplanner:current} -->
+        <version>0.21.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-capacityplanner:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-certificate-manager-bom</artifactId>
-        <version>0.100.0</version><!-- {x-version-update:google-cloud-certificate-manager:current} -->
+        <version>0.101.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-certificate-manager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-ces-bom</artifactId>
-        <version>0.13.0</version><!-- {x-version-update:google-cloud-ces:current} -->
+        <version>0.14.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-ces:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-channel-bom</artifactId>
-        <version>3.101.0</version><!-- {x-version-update:google-cloud-channel:current} -->
+        <version>3.102.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-channel:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-chat-bom</artifactId>
-        <version>0.61.0</version><!-- {x-version-update:google-cloud-chat:current} -->
+        <version>0.62.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-chat:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-chronicle-bom</artifactId>
-        <version>0.35.0</version><!-- {x-version-update:google-cloud-chronicle:current} -->
+        <version>0.36.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-chronicle:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-cloudapiregistry-bom</artifactId>
-        <version>0.16.0</version><!-- {x-version-update:google-cloud-cloudapiregistry:current} -->
+        <version>0.17.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-cloudapiregistry:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-cloudcommerceconsumerprocurement-bom</artifactId>
-        <version>0.95.0</version><!-- {x-version-update:google-cloud-cloudcommerceconsumerprocurement:current} -->
+        <version>0.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-cloudcommerceconsumerprocurement:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-cloudcontrolspartner-bom</artifactId>
-        <version>0.61.0</version><!-- {x-version-update:google-cloud-cloudcontrolspartner:current} -->
+        <version>0.62.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-cloudcontrolspartner:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-cloudquotas-bom</artifactId>
-        <version>0.65.0</version><!-- {x-version-update:google-cloud-cloudquotas:current} -->
+        <version>0.66.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-cloudquotas:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-cloudsecuritycompliance-bom</artifactId>
-        <version>0.24.0</version><!-- {x-version-update:google-cloud-cloudsecuritycompliance:current} -->
+        <version>0.25.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-cloudsecuritycompliance:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-cloudsupport-bom</artifactId>
-        <version>0.81.0</version><!-- {x-version-update:google-cloud-cloudsupport:current} -->
+        <version>0.82.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-cloudsupport:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-commerceproducer-bom</artifactId>
-        <version>0.3.0</version><!-- {x-version-update:google-cloud-commerceproducer:current} -->
+        <version>0.4.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-commerceproducer:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-compute-bom</artifactId>
-        <version>1.107.0</version><!-- {x-version-update:google-cloud-compute:current} -->
+        <version>1.108.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-confidentialcomputing-bom</artifactId>
-        <version>0.83.0</version><!-- {x-version-update:google-cloud-confidentialcomputing:current} -->
+        <version>0.84.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-confidentialcomputing:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-configdelivery-bom</artifactId>
-        <version>0.31.0</version><!-- {x-version-update:google-cloud-configdelivery:current} -->
+        <version>0.32.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-configdelivery:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-connectgateway-bom</artifactId>
-        <version>0.49.0</version><!-- {x-version-update:google-cloud-connectgateway:current} -->
+        <version>0.50.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-connectgateway:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-contact-center-insights-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-contact-center-insights:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-contact-center-insights:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-container-bom</artifactId>
-        <version>2.100.0</version><!-- {x-version-update:google-cloud-container:current} -->
+        <version>2.101.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-container:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-containeranalysis-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-containeranalysis:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-containeranalysis:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-contentwarehouse-bom</artifactId>
-        <version>0.93.0</version><!-- {x-version-update:google-cloud-contentwarehouse:current} -->
+        <version>0.94.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-contentwarehouse:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-data-fusion-bom</artifactId>
-        <version>1.97.0</version><!-- {x-version-update:google-cloud-data-fusion:current} -->
+        <version>1.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-data-fusion:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-databasecenter-bom</artifactId>
-        <version>0.18.0</version><!-- {x-version-update:google-cloud-databasecenter:current} -->
+        <version>0.19.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-databasecenter:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dataflow-bom</artifactId>
-        <version>0.101.0</version><!-- {x-version-update:google-cloud-dataflow:current} -->
+        <version>0.102.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dataflow:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dataform-bom</artifactId>
-        <version>0.96.0</version><!-- {x-version-update:google-cloud-dataform:current} -->
+        <version>0.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dataform:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-datalineage-bom</artifactId>
-        <version>0.89.0</version><!-- {x-version-update:google-cloud-datalineage:current} -->
+        <version>0.90.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-datalineage:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dataplex-bom</artifactId>
-        <version>1.95.0</version><!-- {x-version-update:google-cloud-dataplex:current} -->
+        <version>1.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dataplex:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dataproc-bom</artifactId>
-        <version>4.94.0</version><!-- {x-version-update:google-cloud-dataproc:current} -->
+        <version>4.95.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dataproc:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dataproc-metastore-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-dataproc-metastore:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dataproc-metastore:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-datastore-bom</artifactId>
-        <version>3.5.0</version><!-- {x-version-update:google-cloud-datastore:current} -->
+        <version>3.6.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-datastore:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-datastream-bom</artifactId>
-        <version>1.96.0</version><!-- {x-version-update:google-cloud-datastream:current} -->
+        <version>1.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-datastream:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-deploy-bom</artifactId>
-        <version>1.95.0</version><!-- {x-version-update:google-cloud-deploy:current} -->
+        <version>1.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-deploy:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-developer-knowledge-bom</artifactId>
-        <version>0.5.0</version><!-- {x-version-update:google-cloud-developer-knowledge:current} -->
+        <version>0.6.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-developer-knowledge:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-developerconnect-bom</artifactId>
-        <version>0.54.0</version><!-- {x-version-update:google-cloud-developerconnect:current} -->
+        <version>0.55.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-developerconnect:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-devicestreaming-bom</artifactId>
-        <version>0.37.0</version><!-- {x-version-update:google-cloud-devicestreaming:current} -->
+        <version>0.38.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-devicestreaming:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dialogflow-bom</artifactId>
-        <version>4.103.0</version><!-- {x-version-update:google-cloud-dialogflow:current} -->
+        <version>4.104.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dialogflow:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dialogflow-cx-bom</artifactId>
-        <version>0.108.0</version><!-- {x-version-update:google-cloud-dialogflow-cx:current} -->
+        <version>0.109.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dialogflow-cx:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-discoveryengine-bom</artifactId>
-        <version>0.93.0</version><!-- {x-version-update:google-cloud-discoveryengine:current} -->
+        <version>0.94.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-discoveryengine:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-distributedcloudedge-bom</artifactId>
-        <version>0.94.0</version><!-- {x-version-update:google-cloud-distributedcloudedge:current} -->
+        <version>0.95.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-distributedcloudedge:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dlp-bom</artifactId>
-        <version>3.101.0</version><!-- {x-version-update:google-cloud-dlp:current} -->
+        <version>3.102.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dlp:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dms-bom</artifactId>
-        <version>2.96.0</version><!-- {x-version-update:google-cloud-dms:current} -->
+        <version>2.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dms:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-dns</artifactId>
-        <version>2.95.0</version><!-- {x-version-update:google-cloud-dns:current} -->
+        <version>2.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-dns:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-document-ai-bom</artifactId>
-        <version>2.101.0</version><!-- {x-version-update:google-cloud-document-ai:current} -->
+        <version>2.102.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-document-ai:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-domains-bom</artifactId>
-        <version>1.94.0</version><!-- {x-version-update:google-cloud-domains:current} -->
+        <version>1.95.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-domains:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-edgenetwork-bom</artifactId>
-        <version>0.65.0</version><!-- {x-version-update:google-cloud-edgenetwork:current} -->
+        <version>0.66.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-edgenetwork:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-enterpriseknowledgegraph-bom</artifactId>
-        <version>0.93.0</version><!-- {x-version-update:google-cloud-enterpriseknowledgegraph:current} -->
+        <version>0.94.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-enterpriseknowledgegraph:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-errorreporting-bom</artifactId>
-        <version>0.218.0-beta</version><!-- {x-version-update:google-cloud-errorreporting:current} -->
+        <version>0.219.0-beta-SNAPSHOT</version><!-- {x-version-update:google-cloud-errorreporting:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-essential-contacts-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-essential-contacts:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-essential-contacts:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-eventarc-bom</artifactId>
-        <version>1.97.0</version><!-- {x-version-update:google-cloud-eventarc:current} -->
+        <version>1.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-eventarc:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-eventarc-publishing-bom</artifactId>
-        <version>0.97.0</version><!-- {x-version-update:google-cloud-eventarc-publishing:current} -->
+        <version>0.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-eventarc-publishing:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-filestore-bom</artifactId>
-        <version>1.98.0</version><!-- {x-version-update:google-cloud-filestore:current} -->
+        <version>1.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-filestore:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-financialservices-bom</artifactId>
-        <version>0.38.0</version><!-- {x-version-update:google-cloud-financialservices:current} -->
+        <version>0.39.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-financialservices:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-firestore-bom</artifactId>
-        <version>3.47.0</version><!-- {x-version-update:google-cloud-firestore:current} -->
+        <version>3.48.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-firestore:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-ftp-bom</artifactId>
-        <version>0.2.0</version><!-- {x-version-update:google-cloud-ftp:current} -->
+        <version>0.3.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-ftp:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-functions-bom</artifactId>
-        <version>2.99.0</version><!-- {x-version-update:google-cloud-functions:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-functions:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gdchardwaremanagement-bom</artifactId>
-        <version>0.52.0</version><!-- {x-version-update:google-cloud-gdchardwaremanagement:current} -->
+        <version>0.53.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-gdchardwaremanagement:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-geminidataanalytics-bom</artifactId>
-        <version>0.25.0</version><!-- {x-version-update:google-cloud-geminidataanalytics:current} -->
+        <version>0.26.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-geminidataanalytics:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gke-backup-bom</artifactId>
-        <version>0.96.0</version><!-- {x-version-update:google-cloud-gke-backup:current} -->
+        <version>0.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-gke-backup:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gke-connect-gateway-bom</artifactId>
-        <version>0.98.0</version><!-- {x-version-update:google-cloud-gke-connect-gateway:current} -->
+        <version>0.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-gke-connect-gateway:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gke-multi-cloud-bom</artifactId>
-        <version>0.96.0</version><!-- {x-version-update:google-cloud-gke-multi-cloud:current} -->
+        <version>0.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-gke-multi-cloud:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gkehub-bom</artifactId>
-        <version>1.97.0</version><!-- {x-version-update:google-cloud-gkehub:current} -->
+        <version>1.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-gkehub:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gkerecommender-bom</artifactId>
-        <version>0.17.0</version><!-- {x-version-update:google-cloud-gkerecommender:current} -->
+        <version>0.18.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-gkerecommender:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-gsuite-addons-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-gsuite-addons:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-gsuite-addons:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-health-bom</artifactId>
-        <version>0.6.0</version><!-- {x-version-update:google-cloud-health:current} -->
+        <version>0.7.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-health:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-hypercomputecluster-bom</artifactId>
-        <version>0.17.0</version><!-- {x-version-update:google-cloud-hypercomputecluster:current} -->
+        <version>0.18.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-hypercomputecluster:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-iamcredentials-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-iamcredentials:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-iamcredentials:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-iap-bom</artifactId>
-        <version>0.53.0</version><!-- {x-version-update:google-cloud-iap:current} -->
+        <version>0.54.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-iap:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-ids-bom</artifactId>
-        <version>1.96.0</version><!-- {x-version-update:google-cloud-ids:current} -->
+        <version>1.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-ids:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-infra-manager-bom</artifactId>
-        <version>0.74.0</version><!-- {x-version-update:google-cloud-infra-manager:current} -->
+        <version>0.75.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-infra-manager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-iot-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-iot:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-iot:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-kms-bom</artifactId>
-        <version>2.100.0</version><!-- {x-version-update:google-cloud-kms:current} -->
+        <version>2.101.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-kms:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-kmsinventory-bom</artifactId>
-        <version>0.86.0</version><!-- {x-version-update:google-cloud-kmsinventory:current} -->
+        <version>0.87.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-kmsinventory:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-language-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-language:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-language:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-licensemanager-bom</artifactId>
-        <version>0.30.0</version><!-- {x-version-update:google-cloud-licensemanager:current} -->
+        <version>0.31.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-licensemanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-life-sciences-bom</artifactId>
-        <version>0.99.0</version><!-- {x-version-update:google-cloud-life-sciences:current} -->
+        <version>0.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-life-sciences:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-live-stream-bom</artifactId>
-        <version>0.99.0</version><!-- {x-version-update:google-cloud-live-stream:current} -->
+        <version>0.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-live-stream:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-locationfinder-bom</artifactId>
-        <version>0.22.0</version><!-- {x-version-update:google-cloud-locationfinder:current} -->
+        <version>0.23.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-locationfinder:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging-bom</artifactId>
-        <version>3.38.0</version><!-- {x-version-update:google-cloud-logging:current} -->
+        <version>3.39.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-logging-logback</artifactId>
-        <version>0.146.0-alpha</version><!-- {x-version-update:google-cloud-logging-logback:current} -->
+        <version>0.147.0-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-logging-logback:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-lustre-bom</artifactId>
-        <version>0.37.0</version><!-- {x-version-update:google-cloud-lustre:current} -->
+        <version>0.38.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-lustre:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-maintenance-bom</artifactId>
-        <version>0.31.0</version><!-- {x-version-update:google-cloud-maintenance:current} -->
+        <version>0.32.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-maintenance:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-managed-identities-bom</artifactId>
-        <version>1.95.0</version><!-- {x-version-update:google-cloud-managed-identities:current} -->
+        <version>1.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-managed-identities:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-managedkafka-bom</artifactId>
-        <version>0.53.0</version><!-- {x-version-update:google-cloud-managedkafka:current} -->
+        <version>0.54.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-managedkafka:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-mediatranslation-bom</artifactId>
-        <version>0.103.0</version><!-- {x-version-update:google-cloud-mediatranslation:current} -->
+        <version>0.104.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-mediatranslation:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-meet-bom</artifactId>
-        <version>0.64.0</version><!-- {x-version-update:google-cloud-meet:current} -->
+        <version>0.65.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-meet:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-memcache-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-memcache:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-memcache:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-migrationcenter-bom</artifactId>
-        <version>0.79.0</version><!-- {x-version-update:google-cloud-migrationcenter:current} -->
+        <version>0.80.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-migrationcenter:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-modelarmor-bom</artifactId>
-        <version>0.38.0</version><!-- {x-version-update:google-cloud-modelarmor:current} -->
+        <version>0.39.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-modelarmor:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-monitoring-bom</artifactId>
-        <version>3.98.0</version><!-- {x-version-update:google-cloud-monitoring:current} -->
+        <version>3.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-monitoring:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-monitoring-dashboard-bom</artifactId>
-        <version>2.99.0</version><!-- {x-version-update:google-cloud-monitoring-dashboard:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-monitoring-dashboard:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-monitoring-metricsscope-bom</artifactId>
-        <version>0.91.0</version><!-- {x-version-update:google-cloud-monitoring-metricsscope:current} -->
+        <version>0.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-monitoring-metricsscope:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-netapp-bom</artifactId>
-        <version>0.76.0</version><!-- {x-version-update:google-cloud-netapp:current} -->
+        <version>0.77.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-netapp:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-network-management-bom</artifactId>
-        <version>1.98.0</version><!-- {x-version-update:google-cloud-network-management:current} -->
+        <version>1.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-network-management:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-network-security-bom</artifactId>
-        <version>0.100.0</version><!-- {x-version-update:google-cloud-network-security:current} -->
+        <version>0.101.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-network-security:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-networkconnectivity-bom</artifactId>
-        <version>1.96.0</version><!-- {x-version-update:google-cloud-networkconnectivity:current} -->
+        <version>1.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-networkconnectivity:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-networkservices-bom</artifactId>
-        <version>0.53.0</version><!-- {x-version-update:google-cloud-networkservices:current} -->
+        <version>0.54.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-networkservices:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-nio-bom</artifactId>
-        <version>0.137.0</version><!-- {x-version-update:google-cloud-nio:current} -->
+        <version>0.138.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-nio:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-notebooks-bom</artifactId>
-        <version>1.95.0</version><!-- {x-version-update:google-cloud-notebooks:current} -->
+        <version>1.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-notebooks:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-notification</artifactId>
-        <version>0.215.0-beta</version><!-- {x-version-update:google-cloud-notification:current} -->
+        <version>0.216.0-beta-SNAPSHOT</version><!-- {x-version-update:google-cloud-notification:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-optimization-bom</artifactId>
-        <version>1.95.0</version><!-- {x-version-update:google-cloud-optimization:current} -->
+        <version>1.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-optimization:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-oracledatabase-bom</artifactId>
-        <version>0.46.0</version><!-- {x-version-update:google-cloud-oracledatabase:current} -->
+        <version>0.47.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-oracledatabase:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-orchestration-airflow-bom</artifactId>
-        <version>1.97.0</version><!-- {x-version-update:google-cloud-orchestration-airflow:current} -->
+        <version>1.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-orchestration-airflow:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-orgpolicy-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-orgpolicy:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-orgpolicy:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-os-config-bom</artifactId>
-        <version>2.99.0</version><!-- {x-version-update:google-cloud-os-config:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-os-config:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-os-login-bom</artifactId>
-        <version>2.96.0</version><!-- {x-version-update:google-cloud-os-login:current} -->
+        <version>2.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-os-login:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-parallelstore-bom</artifactId>
-        <version>0.60.0</version><!-- {x-version-update:google-cloud-parallelstore:current} -->
+        <version>0.61.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-parallelstore:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-parametermanager-bom</artifactId>
-        <version>0.41.0</version><!-- {x-version-update:google-cloud-parametermanager:current} -->
+        <version>0.42.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-parametermanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-phishingprotection-bom</artifactId>
-        <version>0.128.0</version><!-- {x-version-update:google-cloud-phishingprotection:current} -->
+        <version>0.129.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-phishingprotection:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-policy-troubleshooter-bom</artifactId>
-        <version>1.96.0</version><!-- {x-version-update:google-cloud-policy-troubleshooter:current} -->
+        <version>1.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-policy-troubleshooter:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-policysimulator-bom</artifactId>
-        <version>0.76.0</version><!-- {x-version-update:google-cloud-policysimulator:current} -->
+        <version>0.77.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-policysimulator:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-private-catalog-bom</artifactId>
-        <version>0.99.0</version><!-- {x-version-update:google-cloud-private-catalog:current} -->
+        <version>0.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-private-catalog:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-privilegedaccessmanager-bom</artifactId>
-        <version>0.51.0</version><!-- {x-version-update:google-cloud-privilegedaccessmanager:current} -->
+        <version>0.52.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-privilegedaccessmanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-productregistry-bom</artifactId>
-        <version>0.3.0</version><!-- {x-version-update:google-cloud-productregistry:current} -->
+        <version>0.4.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-productregistry:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-profiler-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-profiler:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-profiler:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-publicca-bom</artifactId>
-        <version>0.94.0</version><!-- {x-version-update:google-cloud-publicca:current} -->
+        <version>0.95.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-publicca:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-pubsub-bom</artifactId>
-        <version>1.155.0</version><!-- {x-version-update:google-cloud-pubsub:current} -->
+        <version>1.156.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsub:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-rapidmigrationassessment-bom</artifactId>
-        <version>0.80.0</version><!-- {x-version-update:google-cloud-rapidmigrationassessment:current} -->
+        <version>0.81.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-rapidmigrationassessment:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-recaptchaenterprise-bom</artifactId>
-        <version>3.94.0</version><!-- {x-version-update:google-cloud-recaptchaenterprise:current} -->
+        <version>3.95.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-recaptchaenterprise:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-recommendations-ai-bom</artifactId>
-        <version>0.104.0</version><!-- {x-version-update:google-cloud-recommendations-ai:current} -->
+        <version>0.105.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-recommendations-ai:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-recommender-bom</artifactId>
-        <version>2.99.0</version><!-- {x-version-update:google-cloud-recommender:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-recommender:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-redis-bom</artifactId>
-        <version>2.100.0</version><!-- {x-version-update:google-cloud-redis:current} -->
+        <version>2.101.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-redis:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-redis-cluster-bom</artifactId>
-        <version>0.69.0</version><!-- {x-version-update:google-cloud-redis-cluster:current} -->
+        <version>0.70.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-redis-cluster:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-resourcemanager-bom</artifactId>
-        <version>1.99.0</version><!-- {x-version-update:google-cloud-resourcemanager:current} -->
+        <version>1.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-resourcemanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-retail-bom</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-run-bom</artifactId>
-        <version>0.97.0</version><!-- {x-version-update:google-cloud-run:current} -->
+        <version>0.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-run:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-saasservicemgmt-bom</artifactId>
-        <version>0.27.0</version><!-- {x-version-update:google-cloud-saasservicemgmt:current} -->
+        <version>0.28.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-saasservicemgmt:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-scheduler-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-scheduler:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-scheduler:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-secretmanager-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-secretmanager:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-secretmanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-securesourcemanager-bom</artifactId>
-        <version>0.67.0</version><!-- {x-version-update:google-cloud-securesourcemanager:current} -->
+        <version>0.68.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-securesourcemanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-security-private-ca-bom</artifactId>
-        <version>2.99.0</version><!-- {x-version-update:google-cloud-security-private-ca:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-security-private-ca:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-securitycenter-bom</artifactId>
-        <version>2.105.0</version><!-- {x-version-update:google-cloud-securitycenter:current} -->
+        <version>2.106.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-securitycenter:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-securitycenter-settings-bom</artifactId>
-        <version>0.100.0</version><!-- {x-version-update:google-cloud-securitycenter-settings:current} -->
+        <version>0.101.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-securitycenter-settings:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-securitycentermanagement-bom</artifactId>
-        <version>0.65.0</version><!-- {x-version-update:google-cloud-securitycentermanagement:current} -->
+        <version>0.66.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-securitycentermanagement:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-securityposture-bom</artifactId>
-        <version>0.62.0</version><!-- {x-version-update:google-cloud-securityposture:current} -->
+        <version>0.63.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-securityposture:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-service-control-bom</artifactId>
-        <version>1.97.0</version><!-- {x-version-update:google-cloud-service-control:current} -->
+        <version>1.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-service-control:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-service-management-bom</artifactId>
-        <version>3.95.0</version><!-- {x-version-update:google-cloud-service-management:current} -->
+        <version>3.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-service-management:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-service-usage-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-service-usage:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-service-usage:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-servicedirectory-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-servicedirectory:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-servicedirectory:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-servicehealth-bom</artifactId>
-        <version>0.64.0</version><!-- {x-version-update:google-cloud-servicehealth:current} -->
+        <version>0.65.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-servicehealth:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shell-bom</artifactId>
-        <version>2.96.0</version><!-- {x-version-update:google-cloud-shell:current} -->
+        <version>2.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-shell:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanner-bom</artifactId>
-        <version>6.122.0</version><!-- {x-version-update:google-cloud-spanner:current} -->
+        <version>6.123.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanner:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-spanneradapter-bom</artifactId>
-        <version>0.33.0</version><!-- {x-version-update:google-cloud-spanneradapter:current} -->
+        <version>0.34.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-spanneradapter:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-speech-bom</artifactId>
-        <version>4.92.0</version><!-- {x-version-update:google-cloud-speech:current} -->
+        <version>4.93.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-speech:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-sql-bom</artifactId>
-        <version>0.3.0</version><!-- {x-version-update:google-cloud-sql:current} -->
+        <version>0.4.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-sql:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage-bom</artifactId>
-        <version>2.73.0</version><!-- {x-version-update:google-cloud-storage:current} -->
+        <version>2.74.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-storage:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storage-transfer-bom</artifactId>
-        <version>1.97.0</version><!-- {x-version-update:google-cloud-storage-transfer:current} -->
+        <version>1.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-storage-transfer:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storagebatchoperations-bom</artifactId>
-        <version>0.37.0</version><!-- {x-version-update:google-cloud-storagebatchoperations:current} -->
+        <version>0.38.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-storagebatchoperations:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-storageinsights-bom</artifactId>
-        <version>0.82.0</version><!-- {x-version-update:google-cloud-storageinsights:current} -->
+        <version>0.83.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-storageinsights:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-talent-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-talent:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-talent:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-tasks-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-tasks:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-tasks:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-telcoautomation-bom</artifactId>
-        <version>0.67.0</version><!-- {x-version-update:google-cloud-telcoautomation:current} -->
+        <version>0.68.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-telcoautomation:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-texttospeech-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-texttospeech:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-texttospeech:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-tpu-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-tpu:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-tpu:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-trace-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-trace:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-trace:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-translate-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-translate:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-translate:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-valkey-bom</artifactId>
-        <version>0.43.0</version><!-- {x-version-update:google-cloud-valkey:current} -->
+        <version>0.44.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-valkey:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-vectorsearch-bom</artifactId>
-        <version>0.19.0</version><!-- {x-version-update:google-cloud-vectorsearch:current} -->
+        <version>0.20.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-vectorsearch:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-video-intelligence-bom</artifactId>
-        <version>2.96.0</version><!-- {x-version-update:google-cloud-video-intelligence:current} -->
+        <version>2.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-video-intelligence:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-video-stitcher-bom</artifactId>
-        <version>0.97.0</version><!-- {x-version-update:google-cloud-video-stitcher:current} -->
+        <version>0.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-video-stitcher:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-video-transcoder-bom</artifactId>
-        <version>1.96.0</version><!-- {x-version-update:google-cloud-video-transcoder:current} -->
+        <version>1.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-video-transcoder:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-vision-bom</artifactId>
-        <version>3.95.0</version><!-- {x-version-update:google-cloud-vision:current} -->
+        <version>3.96.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-vision:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-visionai-bom</artifactId>
-        <version>0.54.0</version><!-- {x-version-update:google-cloud-visionai:current} -->
+        <version>0.55.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-visionai:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-vmmigration-bom</artifactId>
-        <version>1.97.0</version><!-- {x-version-update:google-cloud-vmmigration:current} -->
+        <version>1.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-vmmigration:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-vmwareengine-bom</artifactId>
-        <version>0.91.0</version><!-- {x-version-update:google-cloud-vmwareengine:current} -->
+        <version>0.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-vmwareengine:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-vpcaccess-bom</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:google-cloud-vpcaccess:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-vpcaccess:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-webrisk-bom</artifactId>
-        <version>2.96.0</version><!-- {x-version-update:google-cloud-webrisk:current} -->
+        <version>2.97.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-webrisk:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-websecurityscanner-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-websecurityscanner:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-websecurityscanner:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-workflow-executions-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-workflow-executions:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-workflow-executions:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-workflows-bom</artifactId>
-        <version>2.97.0</version><!-- {x-version-update:google-cloud-workflows:current} -->
+        <version>2.98.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-workflows:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-workloadidentity-bom</artifactId>
-        <version>0.2.0</version><!-- {x-version-update:google-cloud-workloadidentity:current} -->
+        <version>0.3.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-workloadidentity:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-workloadmanager-bom</artifactId>
-        <version>0.13.0</version><!-- {x-version-update:google-cloud-workloadmanager:current} -->
+        <version>0.14.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-workloadmanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-workspaceevents-bom</artifactId>
-        <version>0.61.0</version><!-- {x-version-update:google-cloud-workspaceevents:current} -->
+        <version>0.62.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-workspaceevents:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-workstations-bom</artifactId>
-        <version>0.85.0</version><!-- {x-version-update:google-cloud-workstations:current} -->
+        <version>0.86.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-workstations:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-iam-admin-bom</artifactId>
-        <version>3.92.0</version><!-- {x-version-update:google-iam-admin:current} -->
+        <version>3.93.0-SNAPSHOT</version><!-- {x-version-update:google-iam-admin:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-iam-policy-bom</artifactId>
-        <version>1.94.0</version><!-- {x-version-update:google-iam-policy:current} -->
+        <version>1.95.0-SNAPSHOT</version><!-- {x-version-update:google-iam-policy:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-identity-accesscontextmanager-bom</artifactId>
-        <version>1.98.0</version><!-- {x-version-update:google-identity-accesscontextmanager:current} -->
+        <version>1.99.0-SNAPSHOT</version><!-- {x-version-update:google-identity-accesscontextmanager:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.grafeas</groupId>
         <artifactId>grafeas</artifactId>
-        <version>2.98.0</version><!-- {x-version-update:grafeas:current} -->
+        <version>2.99.0-SNAPSHOT</version><!-- {x-version-update:grafeas:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java-cloud-bom/google-cloud-bom/pom.xml
+++ b/java-cloud-bom/google-cloud-bom/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-bom</artifactId>
   <packaging>pom</packaging>
-  <version>0.269.1</version><!-- {x-version-update:google-cloud-bom:current} -->
+  <version>0.270.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
   <name>Google Cloud Java BOM</name>
   <url>https://github.com/googleapis/google-cloud-java</url>
   <description>
@@ -172,7 +172,7 @@
         <!-- Artifacts from google-cloud-java monorepo -->
         <groupId>com.google.cloud</groupId>
         <artifactId>gapic-libraries-bom</artifactId>
-        <version>1.91.1</version><!-- {x-version-update:google-cloud-java:current} -->
+        <version>1.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/java-cloud-bom/libraries-bom/pom.xml
+++ b/java-cloud-bom/libraries-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>libraries-bom</artifactId>
-  <version>26.88.1</version><!-- {x-version-update:libraries-bom:current} -->
+  <version>26.89.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom:current} -->
   <packaging>pom</packaging>
 
   <name>Google Cloud Platform Supported Libraries</name>
@@ -43,7 +43,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <first-party-dependencies.version>3.67.0</first-party-dependencies.version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
+    <first-party-dependencies.version>3.68.0-SNAPSHOT</first-party-dependencies.version><!-- {x-version-update:google-cloud-shared-dependencies:current} -->
     <enforcer.skip>true</enforcer.skip>
   </properties>
 
@@ -74,7 +74,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bom</artifactId>
-        <version>0.269.1</version><!-- {x-version-update:google-cloud-bom:current} -->
+        <version>0.270.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/java-cloud-bom/tests/dependency-convergence/pom.xml
+++ b/java-cloud-bom/tests/dependency-convergence/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>full-convergence-check</artifactId>
   <packaging>pom</packaging>
   <!-- We do not publish this module to Maven Central -->
-  <version>0.87.0</version><!-- {x-version-update:full-convergence-check:current} -->
+  <version>0.88.0-SNAPSHOT</version><!-- {x-version-update:full-convergence-check:current} -->
   <name>Full convergence check for all library dependencies in Google Cloud Java BOM</name>
   <description>
     BOM for Full convergence check on google-cloud-java
@@ -28,7 +28,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>26.88.1</version><!-- {x-version-update:libraries-bom:current} -->
+        <version>26.89.0-SNAPSHOT</version><!-- {x-version-update:libraries-bom:current} -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/java-cloud-bom/tests/pom.xml
+++ b/java-cloud-bom/tests/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>java-cloud-bom-tests</artifactId>
-  <version>0.84.0</version><!-- {x-version-update:java-cloud-bom-tests:current} -->
+  <version>0.85.0-SNAPSHOT</version><!-- {x-version-update:java-cloud-bom-tests:current} -->
   <name>A module to test Google Cloud Java BOMs</name>
   <url>https://github.com/googleapis/java-cloud-bom</url>
   <description>

--- a/java-cloud-bom/tests/validate-bom/pom.xml
+++ b/java-cloud-bom/tests/validate-bom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pom-parent</artifactId>
-    <version>1.91.0</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
+    <version>1.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../../../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/java-retail/google-cloud-retail-bom/pom.xml
+++ b/java-retail/google-cloud-retail-bom/pom.xml
@@ -3,13 +3,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-retail-bom</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   <packaging>pom</packaging>
 
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pom-parent</artifactId>
-    <version>1.91.0</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
+    <version>1.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-pom-parent:current} -->
     <relativePath>../../google-cloud-pom-parent/pom.xml</relativePath>
   </parent>
 
@@ -28,37 +28,37 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-retail</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-retail-v2</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-retail-v2alpha</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2alpha:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2alpha:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-retail-v2beta</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2beta:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2beta:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-retail-v2</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-retail-v2alpha</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2alpha:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2alpha:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-retail-v2beta</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2beta:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2beta:current} -->
       </dependency>
       <!-- {x-generated-dependencies-end} -->
     </dependencies>

--- a/java-retail/google-cloud-retail/pom.xml
+++ b/java-retail/google-cloud-retail/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-retail</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   <packaging>jar</packaging>
   <name>Google Cloud Retail</name>
   <description>Retail solutions API.</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-retail-parent</artifactId>
-    <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+    <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-retail</site.installationModule>

--- a/java-retail/grpc-google-cloud-retail-v2/pom.xml
+++ b/java-retail/grpc-google-cloud-retail-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-retail-v2</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2:current} -->
   <name>grpc-google-cloud-retail-v2</name>
   <description>GRPC library for google-cloud-retail</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-retail-parent</artifactId>
-    <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+    <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/java-retail/grpc-google-cloud-retail-v2alpha/pom.xml
+++ b/java-retail/grpc-google-cloud-retail-v2alpha/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-retail-v2alpha</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2alpha:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2alpha:current} -->
   <name>grpc-google-cloud-retail-v2alpha</name>
   <description>GRPC library for google-cloud-retail</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-retail-parent</artifactId>
-    <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+    <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/java-retail/grpc-google-cloud-retail-v2beta/pom.xml
+++ b/java-retail/grpc-google-cloud-retail-v2beta/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>grpc-google-cloud-retail-v2beta</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2beta:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2beta:current} -->
   <name>grpc-google-cloud-retail-v2beta</name>
   <description>GRPC library for google-cloud-retail</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-retail-parent</artifactId>
-    <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+    <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/java-retail/pom.xml
+++ b/java-retail/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-retail-parent</artifactId>
   <packaging>pom</packaging>
-  <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   <name>Google Cloud Retail Parent</name>
   <description>
     Java idiomatic client for Google Cloud Platform services.
@@ -13,7 +13,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-jar-parent</artifactId>
-    <version>1.91.0</version><!-- {x-version-update:google-cloud-java:current} -->
+    <version>1.92.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-java:current} -->
     <relativePath>../google-cloud-jar-parent/pom.xml</relativePath>
   </parent>
 
@@ -30,37 +30,37 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-retail</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-retail-v2beta</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2beta:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2beta:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-retail-v2alpha</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2alpha:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2alpha:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-retail-v2beta</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2beta:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2beta:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-retail-v2alpha</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2alpha:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2alpha:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-retail-v2</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>grpc-google-cloud-retail-v2</artifactId>
-        <version>2.99.1</version><!-- {x-version-update:grpc-google-cloud-retail-v2:current} -->
+        <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:grpc-google-cloud-retail-v2:current} -->
       </dependency>
       <!-- {x-generated-dependencies-end} -->
     </dependencies>

--- a/java-retail/proto-google-cloud-retail-v2/pom.xml
+++ b/java-retail/proto-google-cloud-retail-v2/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-retail-v2</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2:current} -->
   <name>proto-google-cloud-retail-v2</name>
   <description>Proto library for google-cloud-retail</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-retail-parent</artifactId>
-    <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+    <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/java-retail/proto-google-cloud-retail-v2alpha/pom.xml
+++ b/java-retail/proto-google-cloud-retail-v2alpha/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-retail-v2alpha</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2alpha:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2alpha:current} -->
   <name>proto-google-cloud-retail-v2alpha</name>
   <description>Proto library for google-cloud-retail</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-retail-parent</artifactId>
-    <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+    <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/java-retail/proto-google-cloud-retail-v2beta/pom.xml
+++ b/java-retail/proto-google-cloud-retail-v2beta/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-retail-v2beta</artifactId>
-  <version>2.99.1</version><!-- {x-version-update:proto-google-cloud-retail-v2beta:current} -->
+  <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-retail-v2beta:current} -->
   <name>proto-google-cloud-retail-v2beta</name>
   <description>Proto library for google-cloud-retail</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-retail-parent</artifactId>
-    <version>2.99.1</version><!-- {x-version-update:google-cloud-retail:current} -->
+    <version>2.100.0-SNAPSHOT</version><!-- {x-version-update:google-cloud-retail:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2183,10 +2183,10 @@ libraries:
       name_pretty_override: GKE Recommender API
       product_documentation_override: https://cloud.google.com/kubernetes-engine/docs/how-to/machine-learning/inference-quickstart
   - name: google-cloud-java
-    version: 1.91.1
+    version: 1.92.0-SNAPSHOT
     skip_generate: true
     java:
-      released_version: 1.91.0
+      released_version: 1.91.1
   - name: google-cloud-pom-parent
     version: 1.92.0-SNAPSHOT
     skip_generate: true
@@ -5209,7 +5209,7 @@ libraries:
       product_documentation_override: https://cloud.google.com/resource-manager
       billing_not_required: true
   - name: retail
-    version: 2.99.1
+    version: 2.100.0-SNAPSHOT
     apis:
       - path: google/cloud/retail/v2
         java:
@@ -5225,7 +5225,7 @@ libraries:
             - path: google/cloud/location/locations.proto
     java:
       api_description_override: Retail solutions API.
-      released_version: 2.99.0
+      released_version: 2.99.1
       name_pretty_override: Cloud Retail
       product_documentation_override: https://cloud.google.com/solutions/retail
   - name: run

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,7 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-java:1.91.0:1.91.1
+google-cloud-java:1.91.1:1.92.0-SNAPSHOT
 google-cloud-pom-parent:1.91.0:1.92.0-SNAPSHOT
 google-cloud-accessapproval:2.98.0:2.99.0-SNAPSHOT
 grpc-google-cloud-accessapproval-v1:2.98.0:2.99.0-SNAPSHOT
@@ -402,13 +402,13 @@ proto-google-cloud-redis-v1beta1:2.100.0:2.101.0-SNAPSHOT
 google-cloud-resourcemanager:1.99.0:1.100.0-SNAPSHOT
 grpc-google-cloud-resourcemanager-v3:1.99.0:1.100.0-SNAPSHOT
 proto-google-cloud-resourcemanager-v3:1.99.0:1.100.0-SNAPSHOT
-google-cloud-retail:2.99.1:2.99.1
-grpc-google-cloud-retail-v2:2.99.1:2.99.1
-proto-google-cloud-retail-v2:2.99.1:2.99.1
-proto-google-cloud-retail-v2alpha:2.99.1:2.99.1
-proto-google-cloud-retail-v2beta:2.99.1:2.99.1
-grpc-google-cloud-retail-v2alpha:2.99.1:2.99.1
-grpc-google-cloud-retail-v2beta:2.99.1:2.99.1
+google-cloud-retail:2.99.1:2.100.0-SNAPSHOT
+grpc-google-cloud-retail-v2:2.99.1:2.100.0-SNAPSHOT
+proto-google-cloud-retail-v2:2.99.1:2.100.0-SNAPSHOT
+proto-google-cloud-retail-v2alpha:2.99.1:2.100.0-SNAPSHOT
+proto-google-cloud-retail-v2beta:2.99.1:2.100.0-SNAPSHOT
+grpc-google-cloud-retail-v2alpha:2.99.1:2.100.0-SNAPSHOT
+grpc-google-cloud-retail-v2beta:2.99.1:2.100.0-SNAPSHOT
 google-cloud-run:0.97.0:0.98.0-SNAPSHOT
 proto-google-cloud-run-v2:0.97.0:0.98.0-SNAPSHOT
 grpc-google-cloud-run-v2:0.97.0:0.98.0-SNAPSHOT
@@ -1049,8 +1049,8 @@ google-cloud-developer-knowledge:0.5.0:0.6.0-SNAPSHOT
 proto-google-cloud-developer-knowledge-v1:0.5.0:0.6.0-SNAPSHOT
 grpc-google-cloud-developer-knowledge-v1:0.5.0:0.6.0-SNAPSHOT
 google-cloud-backstory:0.5.0:0.6.0-SNAPSHOT
-google-cloud-bom:0.269.1:0.269.1
-libraries-bom:26.88.1:26.88.1
+google-cloud-bom:0.269.1:0.270.0-SNAPSHOT
+libraries-bom:26.88.1:26.89.0-SNAPSHOT
 java-cloud-bom-tests:0.84.0:0.85.0-SNAPSHOT
 full-convergence-check:0.87.0:0.88.0-SNAPSHOT
 google-cloud-shared-config:1.21.0:1.22.0-SNAPSHOT


### PR DESCRIPTION
Bumps versions of google-cloud-retail to 2.100.0-SNAPSHOT, google-cloud-java to 1.92.0-SNAPSHOT, google-cloud-bom to 0.270.0-SNAPSHOT, and libraries-bom to 26.89.0-SNAPSHOT after partial release (#14342).