### PR TITLE
fix(bom): restore google-cloud-spanner-jdbc to libraries-bom

### DIFF
--- a/java-cloud-bom/google-cloud-bom/pom.xml
+++ b/java-cloud-bom/google-cloud-bom/pom.xml
@@ -185,6 +185,11 @@
       </dependency>
       <dependency>
         <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner-jdbc</artifactId>
+        <version>2.44.0</version><!-- {x-version-update:google-cloud-spanner-jdbc:current} -->
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-vertexai-bom</artifactId>
         <!-- This version is for backward compatibility only, it is fixed and should not be updated -->
         <version>1.48.0</version>

--- a/java-cloud-bom/tests/dependency-convergence/pom.xml
+++ b/java-cloud-bom/tests/dependency-convergence/pom.xml
@@ -385,6 +385,10 @@
       <groupId>com.google.cloud</groupId>
     </dependency>
     <dependency>
+      <artifactId>google-cloud-spanner-jdbc</artifactId>
+      <groupId>com.google.cloud</groupId>
+    </dependency>
+    <dependency>
       <artifactId>google-cloud-speech</artifactId>
       <groupId>com.google.cloud</groupId>
     </dependency>


### PR DESCRIPTION
Restores `google-cloud-spanner-jdbc` to `google-cloud-bom` and dependency convergence checks. It was erroneously removed in #13777 during a partial release.

Fixes #14347