### PR TITLE
feat(bigtable): append java-bigtable-batcher token to x-goog-api-client for batcher RPCs

### DIFF
--- a/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
+++ b/java-bigtable/google-cloud-bigtable/src/main/java/com/google/cloud/bigtable/data/v2/stub/EnhancedBigtableStub.java
@@ -58,6 +58,7 @@ import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.ReadRowsResponse;
 import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.cloud.bigtable.Version;
 import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.internal.PrepareQueryRequest;
 import com.google.cloud.bigtable.data.v2.internal.PrepareResponse;
@@ -116,6 +117,7 @@ import com.google.cloud.bigtable.gaxx.retrying.RetryInfoRetryAlgorithm;
 import com.google.common.base.Functions;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import io.grpc.MethodDescriptor;
@@ -146,6 +148,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
 
   private static final String CLIENT_NAME = "Bigtable";
   private static final long FLOW_CONTROL_ADJUSTING_INTERVAL_MS = TimeUnit.SECONDS.toMillis(20);
+  private static final String BATCHER_API_CLIENT_TOKEN = "java-bigtable-batcher/" + Version.VERSION;
   private final ClientOperationSettings perOpSettings;
   private final BigtableClientContext bigtableClientContext;
 
@@ -803,8 +806,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
         perOpSettings.bulkMutateRowsSettings.getBatchingSettings(),
         bigtableClientContext.getClientContext().getExecutor(),
         bulkMutationFlowController,
-        MoreObjects.firstNonNull(
-            ctx, bigtableClientContext.getClientContext().getDefaultCallContext()));
+        batcherCallContext(ctx));
   }
 
   /**
@@ -835,8 +837,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
         perOpSettings.bulkMutateRowsSettings.getBatchingSettings(),
         bigtableClientContext.getClientContext().getExecutor(),
         bulkMutationFlowController,
-        MoreObjects.firstNonNull(
-            ctx, bigtableClientContext.getClientContext().getDefaultCallContext()));
+        batcherCallContext(ctx));
   }
 
   /**
@@ -864,8 +865,7 @@ public class EnhancedBigtableStub implements AutoCloseable {
         perOpSettings.bulkReadRowsSettings.getBatchingSettings(),
         bigtableClientContext.getClientContext().getExecutor(),
         null,
-        MoreObjects.firstNonNull(
-            ctx, bigtableClientContext.getClientContext().getDefaultCallContext()));
+        batcherCallContext(ctx));
   }
 
   /**
@@ -1185,6 +1185,13 @@ public class EnhancedBigtableStub implements AutoCloseable {
 
     return traced.withDefaultCallContext(
         bigtableClientContext.getClientContext().getDefaultCallContext());
+  }
+
+  private ApiCallContext batcherCallContext(@Nullable GrpcCallContext userCtx) {
+    return MoreObjects.firstNonNull(
+            userCtx, bigtableClientContext.getClientContext().getDefaultCallContext())
+        .withExtraHeaders(
+            ImmutableMap.of("x-goog-api-client", ImmutableList.of(BATCHER_API_CLIENT_TOKEN)));
   }
 
   private Map<String, String> composeRequestParams(

--- a/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/HeadersTest.java
+++ b/java-bigtable/google-cloud-bigtable/src/test/java/com/google/cloud/bigtable/data/v2/stub/HeadersTest.java
@@ -54,6 +54,7 @@ import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.data.v2.models.TableId;
 import com.google.cloud.bigtable.data.v2.models.sql.PreparedStatement;
+import com.google.protobuf.ByteString;
 import com.google.rpc.Status;
 import io.grpc.Metadata;
 import io.grpc.Server;
@@ -111,13 +112,20 @@ public class HeadersTest {
     HeaderProvider headerProvider =
         FixedHeaderProvider.create(TEST_FIXED_HEADER_STRING, "test_header_value");
 
-    // Force immediate flush
+    // Force immediate flush for both batcher types
     settings
         .stubSettings()
         .setHeaderProvider(headerProvider)
         .bulkMutateRowsSettings()
         .setBatchingSettings(
             settings.stubSettings().bulkMutateRowsSettings().getBatchingSettings().toBuilder()
+                .setElementCountThreshold(1L)
+                .build());
+    settings
+        .stubSettings()
+        .bulkReadRowsSettings()
+        .setBatchingSettings(
+            settings.stubSettings().bulkReadRowsSettings().getBatchingSettings().toBuilder()
                 .setElementCountThreshold(1L)
                 .build());
 
@@ -205,6 +213,40 @@ public class HeadersTest {
   public void prepareQueryTest() {
     client.prepareStatement("SELECT * FROM table", new HashMap<>());
     verifyHeaderSent(true);
+  }
+
+  @Test
+  public void bulkMutationBatcherHasBatcherToken() throws Exception {
+    try (Batcher<RowMutationEntry, Void> batcher = client.newBulkMutationBatcher(TABLE_ID)) {
+      batcher.add(RowMutationEntry.create("fake-key").deleteRow());
+    }
+    Metadata metadata = sentMetadata.take();
+    assertThat(hasApiClientToken(metadata, "java-bigtable-batcher")).isTrue();
+  }
+
+  @Test
+  public void bulkReadRowsBatcherHasBatcherToken() throws Exception {
+    try (Batcher<ByteString, Row> batcher = client.newBulkReadRowsBatcher(TABLE_ID)) {
+      batcher.add(ByteString.copyFromUtf8("fake-key"));
+    }
+    Metadata metadata = sentMetadata.take();
+    assertThat(hasApiClientToken(metadata, "java-bigtable-batcher")).isTrue();
+  }
+
+  @Test
+  public void regularRpcDoesNotHaveBatcherToken() throws Exception {
+    client.mutateRowAsync(RowMutation.create(TABLE_ID, "fake-key").deleteRow()).get();
+    Metadata metadata = sentMetadata.take();
+    assertThat(hasApiClientToken(metadata, "java-bigtable-batcher")).isFalse();
+  }
+
+  private static boolean hasApiClientToken(Metadata metadata, String token) {
+    Iterable<String> values = metadata.getAll(API_CLIENT_HEADER_KEY);
+    if (values == null) return false;
+    for (String value : values) {
+      if (value.contains(token)) return true;
+    }
+    return false;
   }
 
   private void verifyHeaderSent() {


### PR DESCRIPTION
## Summary

- Stamps a `java-bigtable-batcher/<version>` token into the `x-goog-api-client` header for all RPCs originating from `BulkMutateRows` and `BulkReadRows` batchers.
- The token is added once to the `ApiCallContext` stored in `BatcherImpl` at batcher creation time (via `withExtraHeaders`), so there is zero per-RPC overhead.
- Regular (non-batcher) RPCs are unaffected; the extra entry only appears on batcher flush RPCs.
- Adds three new tests in `HeadersTest` verifying the token is present on batcher RPCs and absent on regular RPCs.

## Test plan

- [ ] `bulkMutationBatcherHasBatcherToken` — verifies `java-bigtable-batcher` token appears in `x-goog-api-client` on BulkMutateRows flush RPCs
- [ ] `bulkReadRowsBatcherHasBatcherToken` — verifies `java-bigtable-batcher` token appears in `x-goog-api-client` on BulkReadRows flush RPCs
- [ ] `regularRpcDoesNotHaveBatcherToken` — verifies `java-bigtable-batcher` token is absent on regular MutateRow RPCs
- [ ] Existing `HeadersTest` tests continue to pass