### PR TITLE
ci: use three-dot diff to isolate PR branch changes in lint check

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -238,7 +238,7 @@ case ${JOB_TYPE} in
         # Format those specific modules instead of the entire codebase, reducing format check time.
         # The --relative flag is when building in the submodule as only files modified in the module
         # should be accounted for.
-        changed_file_list=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" --relative)
+        changed_file_list=$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" --relative)
         echo "${changed_file_list}"
 
         has_code_change="false"


### PR DESCRIPTION
In .kokoro/build.sh, changed_file_list used a two-dot git diff (${BASE_SHA} ${HEAD_SHA}), which compares BASE_SHA directly to HEAD_SHA. When BASE_SHA moves ahead on main after the PR branch diverges, files merged into main on other modules were erroneously included in the diff.

Switch to a three-dot git diff (${BASE_SHA}...${HEAD_SHA}) to diff against the merge base between BASE_SHA and HEAD_SHA, matching .kokoro/common.sh get_modified_files() behavior.

Logs from lint job in https://github.com/googleapis/google-cloud-java/pull/14354 which only touched a spanner file:
```
java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSet.java
java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStruct.java
java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseArray.java
java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryBaseStruct.java
java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryStatement.java
java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtility.java
java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArrayOfPrimitivesTest.java
java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowResultSetTest.java
java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryArrowStructTest.java
java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryJdbcCustomLoggerTest.java
java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryStatementTest.java
java-bigquery-jdbc/src/test/java/com/google/cloud/bigquery/jdbc/BigQueryTemporalUtilityTest.java
java-spanner/samples/snippets/src/main/java/com/example/spanner/QueueSample.java
Matched: java-bigquery-jdbc/src/main/java/com/google/cloud/bigquery/jdbc/BigQueryArrowArray.java
Changed Modules: java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc java-bigquery-jdbc
Formatting only changed modules: java-bigquery-jdbc
```